### PR TITLE
Implement lured pokemon webhook

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -319,7 +319,8 @@ def parse_map(map_dict, step_location):
                     'longitude': p['longitude'],
                     'disappear_time': calendar.timegm(d_t.timetuple()),
                     'last_modified_time': p['last_modified_timestamp_ms'],
-                    'time_until_hidden_ms': p['time_till_hidden_ms']
+                    'time_until_hidden_ms': p['time_till_hidden_ms'],
+                    'is_lured': False
                 }
 
                 send_to_webhook('pokemon', webhook_data)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -330,6 +330,16 @@ def parse_map(map_dict, step_location):
                     lure_expiration = datetime.utcfromtimestamp(
                         f['lure_info']['lure_expires_timestamp_ms'] / 1000.0)
                     active_pokemon_id = f['lure_info']['active_pokemon_id']
+                    encounter_id = f['lure_info']['encounter_id']
+                    webhook_data = {
+                        'encounter_id': b64encode(str(encounter_id)),
+                        'pokemon_id': active_pokemon_id,
+                        'latitude': f['latitude'],
+                        'longitude': f['longitude'],
+                        'disappear_time': calendar.timegm(lure_expiration.timetuple()),
+                        'is_lured': True
+                    }
+                    send_to_webhook('pokemon', webhook_data)
                 else:
                     lure_expiration, active_pokemon_id = None, None
 


### PR DESCRIPTION
## Description
Implement lured pokemon webhook with same basic structure as that of normal pokemon's

## Motivation and Context
This allows third party apps like PokeAlarm to be notified of lured pokemon as well as normal pokemon.

## How Has This Been Tested?
PokeAlarm notifies of lured pokemon.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

