### PR TITLE
Make location marker always be on top

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -314,7 +314,8 @@ function createSearchMarker() {
     },
     map: map,
     animation: google.maps.Animation.DROP,
-    draggable: true
+    draggable: true,
+    zIndex: google.maps.Marker.MAX_ZINDEX + 1
   });
 
   var oldLocation = null;


### PR DESCRIPTION
## Motivation and Context
This makes dragging the location marker easier, as it won't be below pokemon markers

## How Has This Been Tested?
Tested on Chromium on Arch Linux and Chrome on Android

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

