### PR TITLE
Make infoWindow disappear when clicking icon while infoWindow is shown

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1263,10 +1263,15 @@ function clearSelection () {
 
 function addListeners (marker) {
   marker.addListener('click', function () {
-    marker.infoWindow.open(map, marker)
-    clearSelection()
-    updateLabelDiffTime()
-    marker.persist = true
+    if (marker.persist) {
+      marker.persist = false
+      marker.infoWindow.close()
+    } else {
+      marker.infoWindow.open(map, marker)
+      clearSelection()
+      updateLabelDiffTime()
+      marker.persist = true
+    }
   })
 
   google.maps.event.addListener(marker.infoWindow, 'closeclick', function () {


### PR DESCRIPTION
Adds functionality to make InfoWindows disappear when clicked while open already.

## Description
At the moment when hovering an item on the map, its InfoWindow is shown. When clicking that item the InfoWindow stays open even when moving the mouse elsewhere. These InfoWindows must be closed clicking the "x" on their top right corner.
This PR will make it so that another click on the item will set make the infoWindow disappear again.

## Motivation and Context
Can't be bother moving the mouse to "x". also when clicking on items where the InfoWindow's "x" button is outside of the bounds of the map => can't be bothered panning the map.

## How Has This Been Tested?
Docker & Chome on Linux.
Tested across updateMap calls, with and without changes to gyms (points change) and pokemon (expiration & removal)

## Types of changes
[X] New feature (non-breaking change which adds functionality)

## Checklist:
[X] My code follows the code style of this project.