### PR TITLE
Add scan-here button

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -922,6 +922,11 @@ function initMap () { // eslint-disable-line no-unused-vars
 
   addMyLocationButton()
   initSidebar()
+
+  $('#scan-here').on('click', function () {
+    var loc = map.getCenter()
+    changeLocation(loc.lat(), loc.lng())
+  })
 }
 
 function updateSearchMarker (style) {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -926,6 +926,11 @@ function initMap () { // eslint-disable-line no-unused-vars
   $('#scan-here').on('click', function () {
     var loc = map.getCenter()
     changeLocation(loc.lat(), loc.lng())
+
+    if (!$('#search-switch').checked) {
+      $('#search-switch').prop('checked', true)
+      searchControl('on')
+    }
   })
 }
 
@@ -975,10 +980,12 @@ function createSearchMarker () {
 var searchControlURI = 'search_control'
 function searchControl (action) {
   $.post(searchControlURI + '?action=' + encodeURIComponent(action))
+  $('#scan-here').toggleClass('disabled', action === 'off')
 }
 function updateSearchStatus () {
   $.getJSON(searchControlURI).then(function (data) {
     $('#search-switch').prop('checked', data.status)
+    $('#scan-here').toggleClass('disabled', !data.status)
   })
 }
 

--- a/static/sass/layout/_main.scss
+++ b/static/sass/layout/_main.scss
@@ -31,3 +31,26 @@ html, body {
 	bottom: 0px;
   width: 100%;
 }
+
+.fab {
+  background: darken(_palette(accent2, bg), 12);
+  color: _palette(accent2, fg);
+  width:30px;
+  height:30px;
+  border-radius:100%;
+  border:none;
+  outline:none;
+  font-size:19px;
+  box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+  transition:.3s;
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+  text-align: center;
+  @include icon('\f05b');
+}
+
+#scan-here {
+  position: fixed;
+  left: 50%;
+  margin-left: -15px;
+  bottom: 1.5em;
+}

--- a/static/sass/layout/_main.scss
+++ b/static/sass/layout/_main.scss
@@ -53,4 +53,7 @@ html, body {
   left: 50%;
   margin-left: -15px;
   bottom: 1.5em;
+  &.disabled {
+    opacity: 0.5;
+  }
 }

--- a/static/sass/layout/_main.scss
+++ b/static/sass/layout/_main.scss
@@ -40,15 +40,15 @@ html, body {
   border-radius:100%;
   border:none;
   outline:none;
-  font-size:19px;
+  font-size:18px;
   box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
   transition:.3s;
   -webkit-tap-highlight-color: rgba(0,0,0,0);
   text-align: center;
-  @include icon('\f05b');
 }
 
 #scan-here {
+  @include icon('\f002');
   position: fixed;
   left: 50%;
   margin-left: -15px;

--- a/templates/map.html
+++ b/templates/map.html
@@ -235,6 +235,7 @@
         </div>
       </nav>
       <div id="map"></div>
+      <div class="fab" id="scan-here" style="display:{{is_fixed}}"></div>
     </div>
     <!-- Scripts -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.9.1/polyfill.min.js"></script>


### PR DESCRIPTION
## Description
Adds a "scan here" Floating Action Button at bottom center of the map. When clicked/touched, will set the current map center as new search location.

## Motivation and Context
When outside hunting Pokemon you often want to check a few nearby places before deciding which way to go. This is way more convenient when you can just move the map one or two kilometers/miles and tap "scan here" instead of having to type in the name of some location.

## How Has This Been Tested?
Tested using docker.

## Types of changes
[X] New feature (non-breaking change which adds functionality)

## Checklist:
[X] My code follows the code style of this project. (I think?)