### PR TITLE
Fix absolute paths in mobile.js.

### DIFF
--- a/static/js/mobile.js
+++ b/static/js/mobile.js
@@ -9,7 +9,7 @@ var navBtn = document.querySelector('#nav button');
 navBtn.onclick = function() {
   if (localStorage.useLoc !== 'true') {
     navBtn.disabled = true;
-    return (location.href="/mobile");
+    return (location.href="mobile");
   }
   else if ("geolocation" in navigator) {
     // Getting the GPS position can be very slow on some devices
@@ -19,7 +19,7 @@ navBtn.onclick = function() {
     // Get location and use it!
     navigator.geolocation.getCurrentPosition(function(p) {
       navBtn.innerText = 'Reloading...';
-      location.href='/mobile?lat='+p.coords.latitude+'&lon='+p.coords.longitude;
+      location.href='mobile?lat='+p.coords.latitude+'&lon='+p.coords.longitude;
 
     }, function(err) {
       navBtn.innerText = 'Reload';


### PR DESCRIPTION
Similar to AHAAAAAAA/PokemonGo-Map#2770, but for /mobile in static/js/mobile.js.
Would have submitted as one PR if I had noticed earlier.

When running this behind a reverse proxy and not in the document root, the refresh button is broken because javascript is setting document.location.href to /mobile instead of just mobile.

## Description
Removed the leading slash of href in static/js/mobile.js.

## Motivation and Context
Motivation? I'd like it to work on my server, obviously :P
Also most of the ppl running this behind a rev proxy will benefit from this.

## How Has This Been Tested?
Tested on my root server with rev proxy.

## Types of changes
 [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
 [X] My code follows the code style of this project.