### PR TITLE
Add support for basic authentication to protect web app

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -6,6 +6,7 @@ import logging
 
 from flask import Flask, jsonify, render_template, request
 from flask.json import JSONEncoder
+from flask_basicauth import BasicAuth
 from flask_compress import Compress
 from datetime import datetime
 from s2sphere import *
@@ -24,6 +25,15 @@ class Pogom(Flask):
     def __init__(self, import_name, **kwargs):
         super(Pogom, self).__init__(import_name, **kwargs)
         compress.init_app(self)
+        
+        # optional basic authentication
+        args = get_args()
+        if args.basic_auth_user:
+            self.config['BASIC_AUTH_USERNAME'] = args.basic_auth_user
+            self.config['BASIC_AUTH_PASSWORD'] = args.basic_auth_pass
+            self.config['BASIC_AUTH_FORCE'] = True
+            basic_auth = BasicAuth(self)
+        
         self.json_encoder = CustomJSONEncoder
         self.route("/", methods=['GET'])(self.fullmap)
         self.route("/raw_data", methods=['GET'])(self.raw_data)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -67,6 +67,10 @@ def get_args():
                         default='127.0.0.1')
     parser.add_argument('-P', '--port', type=int,
                         help='Set web server listening port', default=5000)
+    parser.add_argument('-bu', '--basic-auth_user',
+                        help='Optional basic authentication user to protect web app')
+    parser.add_argument('-bp', '--basic-auth_pass',
+                        help='Optional basic authentication password to protect web app')
     parser.add_argument('-L', '--locale',
                         help='Locale for Pokemon names (default: {},\
                         check {} for more)'.

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -67,9 +67,9 @@ def get_args():
                         default='127.0.0.1')
     parser.add_argument('-P', '--port', type=int,
                         help='Set web server listening port', default=5000)
-    parser.add_argument('-bu', '--basic-auth_user',
+    parser.add_argument('-bu', '--basic-auth-user',
                         help='Optional basic authentication user to protect web app')
-    parser.add_argument('-bp', '--basic-auth_pass',
+    parser.add_argument('-bp', '--basic-auth-pass',
                         help='Optional basic authentication password to protect web app')
     parser.add_argument('-L', '--locale',
                         help='Locale for Pokemon names (default: {},\

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 six==1.10.0
 Flask==0.11.1
+Flask-BasicAuth==0.2.0
 Jinja2==2.8
 MarkupSafe==0.23
 Werkzeug==0.11.10


### PR DESCRIPTION
## Description
This adds support for basic authentication to limit access to the web app to people with the correct credentials. Useful when run on a public server for a single person only or a limited group of people.

Usage parameter:
`--basic-auth-user admin --basic-auth-pass mysecret`
or short:
`-ba admin -bp mysecret`

If parameter -ba is omitted (default), no authentication is requested, thus being compatible with existing installations.

## How Has This Been Tested?
On Heroku with own installation, with and without password

## Types of changes
- [X] New feature (non-breaking change which adds functionality)