### PR TITLE
Adds webhook field required by Pokelyzer

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -339,7 +339,8 @@ def parse_map(map_dict, step_location):
                         'longitude': f['longitude'],
                         'disappear_time': calendar.timegm(lure_expiration.timetuple()),
                         'is_lured': True
-                    }
+                    },
+                    last_modified_time: f['last_modified_timestamp_ms'],
                     send_to_webhook('pokemon', webhook_data)
                 else:
                     lure_expiration, active_pokemon_id = None, None

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -338,9 +338,9 @@ def parse_map(map_dict, step_location):
                         'latitude': f['latitude'],
                         'longitude': f['longitude'],
                         'disappear_time': calendar.timegm(lure_expiration.timetuple()),
+                        'last_modified_time': f['last_modified_timestamp_ms'],
                         'is_lured': True
-                    },
-                    last_modified_time: f['last_modified_timestamp_ms'],
+                    }
                     send_to_webhook('pokemon', webhook_data)
                 else:
                     lure_expiration, active_pokemon_id = None, None


### PR DESCRIPTION
## Description
Pokelyzer has a webhook listener for receiving data from PokemonGo-Map, but with the new event for 'lured' Pokemon, this missing field for that data causes the integration to break. This addition fixes it.

## How Has This Been Tested?
This is a relatively small change so I simply tested it up making the specified change and then confirming that it worked with a local installation of Pokelyzer.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

