### PR TITLE
FLASK env value not needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,8 @@ sudo: false
 language: python
 python:
   - 2.7
-env:
-  - FLASK=0.11.1
 install:
   - nvm install 4.4.7
-  - pip install Flask==$FLASK
   - pip install -r requirements.txt
   - npm install grunt-cli -g
   - npm install


### PR DESCRIPTION
We shouldn't need to install flask on its own; and if we do `requirements.txt` should be considered broken.