### PR TITLE
Restore animations when markers come back into view (fixed version)

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -760,10 +760,18 @@ function showInBoundsMarkers(markers) {
       }
     }
 
-    if (show && !markers[key].marker.getMap()) {
-      markers[key].marker.setMap(map);
-    } else if (!show && markers[key].marker.getMap()) {
-      markers[key].marker.setMap(null);
+    if (show && !marker.getMap()) {
+      marker.setMap(map);
+      // Not all markers can be animated (ex: scan locations)
+      if ( marker.setAnimation && marker.oldAnimation ) {
+        marker.setAnimation(marker.oldAnimation);
+      }
+    } else if (!show && marker.getMap()) {
+      // Not all markers can be animated (ex: scan locations)
+      if ( marker.getAnimation ) {
+        marker.oldAnimation = marker.getAnimation();
+      }
+      marker.setMap(null);
     }
   });
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Marker animations are lost when they go off screen. This makes sure animations work correctly when they come back on screen.

This is a fixed version of the fix reverted in https://github.com/PokemonGoMap/PokemonGo-Map/commit/f632c023e905a70c775cdc3fc3e7d0b8ce95b5c1 . That version generated errors if scan location markers were enabled. Those can not be animated, and therefore do not have getAnimation/setAnimation functions

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Chrome on both Windows and Android with various markers enabled/disabled

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

