### PR TITLE
Optional altitude for configuration

### DIFF
--- a/runserver.py
+++ b/runserver.py
@@ -92,7 +92,7 @@ if __name__ == '__main__':
     res = prog.match(args.location)
     if res:
         log.debug('Using coords from CLI directly')
-        position = (float(res.group(1)), float(res.group(2)), float(res.group(3))
+        position = (float(res.group(1)), float(res.group(2)), float(res.group(3)))
     else:
         log.debug('Lookig up coords in API')
         position = util.get_pos_by_name(args.location)

--- a/runserver.py
+++ b/runserver.py
@@ -88,7 +88,7 @@ if __name__ == '__main__':
 
 
     # use lat/lng directly if matches such a pattern
-    prog = re.compile("^(\-?\d+\.\d+),?\s?(\-?\d+\.\d+),?(\d+\.?\d+?)?$")
+    prog = re.compile("^(\-?\d+\.\d+),?\s?(\-?\d+\.\d+),?\s?(\-?\d+\.?\d+?)?$")
     res = prog.match(args.location)
     if res:
         log.debug('Using coords from CLI directly')

--- a/runserver.py
+++ b/runserver.py
@@ -92,7 +92,7 @@ if __name__ == '__main__':
     res = prog.match(args.location)
     if res:
         log.debug('Using coords from CLI directly')
-        position = (float(res.group(1)), float(res.group(2)), float(res.group(3)))
+        position = (float(res.group(1)), float(res.group(2)), float(res.group(3) if (res.group(3) != None) else 0.0))
     else:
         log.debug('Lookig up coords in API')
         position = util.get_pos_by_name(args.location)

--- a/runserver.py
+++ b/runserver.py
@@ -88,11 +88,11 @@ if __name__ == '__main__':
 
 
     # use lat/lng directly if matches such a pattern
-    prog = re.compile("^(\-?\d+\.\d+),?\s?(\-?\d+\.\d+)$")
+    prog = re.compile("^(\-?\d+\.\d+),?\s?(\-?\d+\.\d+),?(\d+\.?\d+?)?$")
     res = prog.match(args.location)
     if res:
         log.debug('Using coords from CLI directly')
-        position = (float(res.group(1)), float(res.group(2)), 0)
+        position = (float(res.group(1)), float(res.group(2)), float(res.group(3))
     else:
         log.debug('Lookig up coords in API')
         position = util.get_pos_by_name(args.location)


### PR DESCRIPTION
Because we don't all live underground at altitude 0, we shouldn't be submitting that. This PR enables us to submit altitude as a configuration, while retaining backwards compatibility for old underground people.

## Description
Modified regex to support a optional third set of values for position.
Modified parsed position to accept the optional third set of values.

## Motivation and Context
Makes it more difficult for Niantic to ban all that submits altitude 0.

## How Has This Been Tested?
Built docker image and running for my own production environment now.

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## Checklist:
- [X] My code follows the code style of this project.
