### PR TITLE
Giving Docker container the lint configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apk add --no-cache build-base \
 
 COPY package.json Gruntfile.js /usr/src/app/
 COPY static /usr/src/app/static
+COPY .eslintignore .eslintrc.json /usr/src/app/
 
 RUN apk add --no-cache build-base nodejs \
  && npm install -g grunt-cli \


### PR DESCRIPTION
Docker image was failing to build because it Grunt cannot use eslint (configuration not available).

## Description
This fix adds a layer to the docker build process, which gives the image the appropriate lint files before proceeding with the next step.

## Motivation and Context
This was preventing me from building docker images properly, and that makes me sad.

## How Has This Been Tested?
Built docker image successfully.

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the code style of this project.