### PR TITLE
grunt: do not run linting task in build task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -122,7 +122,7 @@ module.exports = function(grunt) {
   grunt.registerTask('css-build', ['sass', 'cssmin']);
   grunt.registerTask('js-lint', ['eslint']);
 
-  grunt.registerTask('build', ['lint', 'clean', 'js-build', 'css-build']);
+  grunt.registerTask('build', ['clean', 'js-build', 'css-build']);
   grunt.registerTask('lint', ['js-lint']);
   grunt.registerTask('default', ['build', 'watch']);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

`grunt build` now runs the `lint` task as well as building the `.min.x` files. This is not needed for most usages to run the linter. Travis runs `lint` separately already and during development it is easier if `lint` isn't run until you submit a PR. When linting fails during development, the rest of the `build` task isn't being executed.

Also solves issues in Docker (#80).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Running `grunt build`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

