### PR TITLE
add argument to pause search threads on start

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -115,7 +115,12 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
     parse_lock = Lock()
 
     # Create a search_worker_thread per account
-    log.info('Starting search worker threads')
+
+    if args.stop_search_threads:
+        log.info('Waiting for start command')
+    else:
+        log.info('Starting search worker threads')
+
     for i, account in enumerate(args.accounts):
         log.debug('Starting search worker thread %d for user %s', i, account['username'])
         t = Thread(target=search_worker_thread,

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -91,8 +91,7 @@ def get_args():
                         help='Hides the search bar for use in shared maps.',
                         action='store_true', default=False)
     parser.add_argument('-k', '--gmaps-key',
-                        help='Google Maps Javascript API Key',
-                        required=True)
+                        help='Google Maps Javascript API Key')
     parser.add_argument('-C', '--cors', help='Enable CORS on web server',
                         action='store_true', default=False)
     parser.add_argument('-D', '--db', help='Database filename',

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -109,6 +109,9 @@ def get_args():
     parser.add_argument('-nk', '--no-pokestops',
                         help='Disables PokeStops from the map (including parsing them into local db)',
                         action='store_true', default=False)
+    parser.add_argument('-sst', '--stop-search-threads',
+                        help='Does not start the search threads',
+                        action='store_true', default=False)
     parser.add_argument('--db-type', help='Type of database to be used (default: sqlite)',
                         default='sqlite')
     parser.add_argument('--db-name', help='Name of the database to be used')

--- a/runserver.py
+++ b/runserver.py
@@ -110,6 +110,8 @@ if __name__ == '__main__':
         log.info('Parsing of Pokestops disabled')
     if args.no_gyms:
         log.info('Parsing of Gyms disabled')
+    if not args.gmaps_key:
+        log.info('No Google Maps Javascript API Key set. Set one using the -k argument or you won\'t be able to use the map.')
 
     config['LOCALE'] = args.locale
     config['CHINA'] = args.china

--- a/runserver.py
+++ b/runserver.py
@@ -128,7 +128,11 @@ if __name__ == '__main__':
 
     # Control the search status (running or not) across threads
     pause_bit = Event()
-    pause_bit.clear()
+
+    if args.stop_search_threads:
+        pause_bit.set()
+    else:
+        pause_bit.clear()
 
     # Setup the location tracking queue and push the first location on
     new_location_queue = Queue()

--- a/templates/map.html
+++ b/templates/map.html
@@ -202,7 +202,12 @@
           <div id="pokestopList" style="color: black;"></div>
         </div>
       </nav>
-      <div id="map"></div>
+      <div id="map">
+        <div style="position: absolute; width: 520px; left: calc(50% - 260px); top: 30px; padding: 1.2em" class="ui-state-error ui-widget ui-front ui-widget-content ui-corner-all ui-widget-shadow">
+        <span class="ui-icon ui-icon-alert" style="float: left; margin-right: .3em; margin-top: .3em"></span><strong>Alert</strong><br/>
+        It looks like you don't have a Google Maps Javascript API Key set. Please set one using the -k argument in order to use the maps. If you don't have an API Key please obtain one from <a href="https://console.developers.google.com/">https://console.developers.google.com/</a>. For further instructions and help visit: <a href="https://pgm.readthedocs.io/en/develop/basic-install/google-maps.html">https://pgm.readthedocs.io/en/develop/basic-install/google-maps.html</a>.
+        </div>
+      </div>
     </div>
     <!-- Scripts -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.9.1/polyfill.min.js"></script>
@@ -219,6 +224,13 @@
 
     <script src="static/dist/js/map.min.js"></script>
     <script src="static/dist/js/stats.min.js"></script>
-    <script defer src="https://maps.googleapis.com/maps/api/js?key={{ gmaps_key }}&amp;callback=initMap&amp;libraries=places,geometry"></script>
+    <script>
+      var gmaps_key = "{{ gmaps_key }}";
+
+      if (gmaps_key !== "None") {
+        var src = "https://maps.googleapis.com/maps/api/js?key=" + gmaps_key + "&amp;callback=initMap&amp;libraries=places,geometry";
+        document.write('<' + 'script defer src="' + src + '"><' + '/script>');
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Adds an -sst argument to pause the search threads on start

## Motivation and Context
Even though you set a start location using the -l parameter, I don't want the script to start scanning at that location immediately. Actually i don't want to pass a -l parameter at all, but I left it mandatory at the moment. After running the script, it will wait for a resume command which can be issued by the web-interface or by a post call to the api

## How Has This Been Tested?
implemented the changes, tried running the script, and made sure that the script resumes after switching the toggle in the web-interface

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.