### PR TITLE
Fix ESLint error when building image with Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apk add --no-cache build-base \
  && pip install --no-cache-dir -r requirements.txt \
  && apk del build-base
 
-COPY package.json Gruntfile.js /usr/src/app/
+COPY package.json Gruntfile.js .eslintignore .eslintrc.json /usr/src/app/
 COPY static /usr/src/app/static
 
 RUN apk add --no-cache build-base nodejs \


### PR DESCRIPTION
## Description
Added ESLint files to Dockerfile in order fix error with `npm run-script build`

This PR should fix  #110 and #93 

## Motivation and Context
`docker build -t pokemongo-map .` doesn't succeed because of error `No ESLint configuration found. Use --force to continue`.

This was due to `.eslintignore` and `.eslintrc.json` not being added to the image.

## How Has This Been Tested?
Tested locally and now the build succeeds

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.