### PR TITLE
Added node-sass dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "grunt-minjson": "latest",
     "grunt-sass": "latest",
     "grunt-unused": "latest",
-    "grunt-usemin": "latest"
+    "grunt-usemin": "latest",
+    "node-sass": "^3.8.0"
   },
   "scripts": {
     "postinstall": "./node_modules/.bin/grunt build",


### PR DESCRIPTION
When running `npm install` I faced the following error:  

```
> pogomap@0.1.0 postinstall /root/PokemonGo-Map
> grunt build

Loading "sass.js" tasks...ERROR
>> Error: ENOENT: no such file or directory, scandir '/root/PokemonGo-Map/node_modules/node-sass/vendor'

Running "clean:build" (clean) task
>> 1 path cleaned.

Running "babel:dist" (babel) task
^C
```
This error states that node-sass was missing, this module is required by `grunt-sass` which is required by the grunt task `grunt.registerTask('css-build', ['sass', 'cssmin']);`  

With this change I was successfully able to build the project.