### PR TITLE
Added -ss --step-size option for larger scan point distances

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -59,7 +59,7 @@ def get_new_coords(init_loc, distance, bearing):
 
 def generate_location_steps(initial_loc, step_count):
 
-    # There's another call to this *not* using args.step_count as second argument, this is for step_size only.
+    # Do not use 'args" to replace the "step_count" parameter above, it does not always equal args.step_count!
     args = get_args()
     
     #Bearing (degrees)
@@ -68,9 +68,14 @@ def generate_location_steps(initial_loc, step_count):
     SOUTH = 180
     WEST = 270
 
-    pulse_radius = args.step_size / 1000.0	# dist between scan points (-ss), meters to km, default is 70.
+    if (args.no_pokemon == False): # scan_size requires -np, 70 is default
+        pulse_radius = 0.07
+    else:
+        pulse_radius = args.step_size / 1000.0	# dist between scan points (-ss), meters to km, default is 70.
+        
     xdist = math.sqrt(3)*pulse_radius   # dist between column centers
     ydist = 3*(pulse_radius/2)          # dist between row centers    
+    
     yield (initial_loc[0], initial_loc[1], 0) #insert initial location
 
     ring = 1

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -59,8 +59,9 @@ def get_new_coords(init_loc, distance, bearing):
 
 def generate_location_steps(initial_loc, step_count):
 
+    # There's another call to this *not* using args.step_count as second argument, this is for step_size only.
     args = get_args()
-
+    
     #Bearing (degrees)
     NORTH = 0
     EAST = 90

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -34,6 +34,7 @@ from pgoapi.exceptions import AuthException
 
 from . import config
 from .models import parse_map
+from .utils import get_args
 
 log = logging.getLogger(__name__)
 
@@ -56,17 +57,20 @@ def get_new_coords(init_loc, distance, bearing):
 
     return [math.degrees(new_lat), math.degrees(new_lon)]
 
-def generate_location_steps(initial_loc, step_count, step_size):
+def generate_location_steps(initial_loc, step_count):
+
+    args = get_args()
+
     #Bearing (degrees)
     NORTH = 0
     EAST = 90
     SOUTH = 180
     WEST = 270
 
-    pulse_radius = step_size / 1000	# dist between scan points (-ss), meters to km, default is 70.
+    pulse_radius = args.step_size / 1000.0	# dist between scan points (-ss), meters to km, default is 70.
     xdist = math.sqrt(3)*pulse_radius   # dist between column centers
     ydist = 3*(pulse_radius/2)          # dist between row centers
-
+    
     yield (initial_loc[0], initial_loc[1], 0) #insert initial location
 
     ring = 1
@@ -163,7 +167,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
         # cleared above) -- either way, time to fill it back up
         if search_items_queue.empty():
             log.debug('Search queue empty, restarting loop')
-            for step, step_location in enumerate(generate_location_steps(current_location, args.step_limit, args.step_size), 1):
+            for step, step_location in enumerate(generate_location_steps(current_location, args.step_limit), 1):
                 log.debug('Queueing step %d @ %f/%f/%f', step, step_location[0], step_location[1], step_location[2])
                 search_args = (step, step_location)
                 search_items_queue.put(search_args)

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -68,10 +68,10 @@ def generate_location_steps(initial_loc, step_count):
     SOUTH = 180
     WEST = 270
 
-    if (args.no_pokemon == False): # scan_size requires -np, 70 is default
-        pulse_radius = 0.07
+    if args.no_pokemon: # scan_size requires -np, 70 is default
+        pulse_radius = args.step_size / 1000.0  # dist between scan points (-ss), meters to km, default is 70.
     else:
-        pulse_radius = args.step_size / 1000.0	# dist between scan points (-ss), meters to km, default is 70.
+        pulse_radius = 0.07
         
     xdist = math.sqrt(3)*pulse_radius   # dist between column centers
     ydist = 3*(pulse_radius/2)          # dist between row centers    

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -56,14 +56,14 @@ def get_new_coords(init_loc, distance, bearing):
 
     return [math.degrees(new_lat), math.degrees(new_lon)]
 
-def generate_location_steps(initial_loc, step_count):
+def generate_location_steps(initial_loc, step_count, step_size):
     #Bearing (degrees)
     NORTH = 0
     EAST = 90
     SOUTH = 180
     WEST = 270
 
-    pulse_radius = 0.07                 # km - radius of players heartbeat is 70m
+    pulse_radius = step_size / 1000	# dist between scan points (-ss), meters to km, default is 70.
     xdist = math.sqrt(3)*pulse_radius   # dist between column centers
     ydist = 3*(pulse_radius/2)          # dist between row centers
 
@@ -163,7 +163,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
         # cleared above) -- either way, time to fill it back up
         if search_items_queue.empty():
             log.debug('Search queue empty, restarting loop')
-            for step, step_location in enumerate(generate_location_steps(current_location, args.step_limit), 1):
+            for step, step_location in enumerate(generate_location_steps(current_location, args.step_limit, args.step_size), 1):
                 log.debug('Queueing step %d @ %f/%f/%f', step, step_location[0], step_location[1], step_location[2])
                 search_args = (step, step_location)
                 search_items_queue.put(search_args)

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -70,8 +70,7 @@ def generate_location_steps(initial_loc, step_count):
 
     pulse_radius = args.step_size / 1000.0	# dist between scan points (-ss), meters to km, default is 70.
     xdist = math.sqrt(3)*pulse_radius   # dist between column centers
-    ydist = 3*(pulse_radius/2)          # dist between row centers
-    
+    ydist = 3*(pulse_radius/2)          # dist between row centers    
     yield (initial_loc[0], initial_loc[1], 0) #insert initial location
 
     ring = 1

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -49,7 +49,7 @@ def get_args():
     parser.add_argument('-st', '--step-limit', help='Steps', type=int,
                         default=12)
     parser.add_argument('-ss', '--step-size',
-                        help='Distance between scan points, 70 is default and max for pokemons, use with -np.',
+                        help='Distance between scan points. Default and optimal Pokemon scanning value is 70. Useful for gym/pokestop only scans with a value of 1000. REQUIRES -np.',
                         type=float, default=70)
     parser.add_argument('-sd', '--scan-delay',
                         help='Time delay between requests in scan threads',
@@ -148,7 +148,7 @@ def get_args():
 
         if args.auth_service is None:
             args.auth_service = ['ptc']
-
+            
         num_auths = len(args.auth_service)
         num_usernames = len(args.username)
         num_passwords = len(args.password)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -48,6 +48,9 @@ def get_args():
                         help='Location, can be an address or coordinates')
     parser.add_argument('-st', '--step-limit', help='Steps', type=int,
                         default=12)
+    parser.add_argument('-ss', '--step-size',
+                        help='Distance between scan points, 70 is default and max for pokemons, use with -np.',
+                        type=float, default=70)
     parser.add_argument('-sd', '--scan-delay',
                         help='Time delay between requests in scan threads',
                         type=float, default=10)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -49,7 +49,8 @@ def get_args():
     parser.add_argument('-st', '--step-limit', help='Steps', type=int,
                         default=12)
     parser.add_argument('-ss', '--step-size',
-                        help='Distance between scan points. Default and optimal Pokemon scanning value is 70. Useful for gym/pokestop only scans with a value of 1000. REQUIRES -np.',
+                        help='Distance between scan points. Default and optimal Pokemon scanning value is 70. '+
+                             'Useful for gym/pokestop only scans with a value of 1000. REQUIRES -np.',
                         type=float, default=70)
     parser.add_argument('-sd', '--scan-delay',
                         help='Time delay between requests in scan threads',


### PR DESCRIPTION
See https://github.com/PokemonGoMap/PokemonGo-Map/issues/72

 -ss STEP_SIZE, --step-size STEP_SIZE
                        Distance between scan points, 70 is default and max
                        for pokemons, use with -np.
