### PR TITLE
Fix follow location feature and current-location button

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -113,7 +113,7 @@
     if (event.target.matches('a[href="#nav"]')) {
       return
     }
-    if ($stats && event.target.matches('a[href="#stats]')) {
+    if ($stats && event.target.matches('a[href="#stats"]')) {
       return
     }
     $nav.classList.remove('visible')

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -869,7 +869,7 @@ function initMap () { // eslint-disable-line no-unused-vars
   map.setMapTypeId(Store.get('map_style'))
   google.maps.event.addListener(map, 'idle', updateMap)
 
-  createSearchMarker()
+  marker = createSearchMarker()
 
   addMyLocationButton()
   initSidebar()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Two very small fixes to `app.js` and `map.js`:

When the "follow location" switch was toggled on, the location was not being updated and instead an error would be shown in the console every second.

Clicking the current-location button would also throw an error, caused by a typo in the code responsible for hiding the sidebar when clicking on the map.

## Motivation and Context
Both of these features were not working and throw errors in the browser console.

## How Has This Been Tested?
Only locally on Safari and Chrome

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

