### PR TITLE
Optimize grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,8 @@
 module.exports = function(grunt) {
 
+  // load plugins as needed instead of up front
+  require('jit-grunt')(grunt);
+
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
 
@@ -104,19 +107,6 @@ module.exports = function(grunt) {
       }
     }
   });
-
-  grunt.loadNpmTasks('grunt-contrib-uglify');
-  grunt.loadNpmTasks('grunt-eslint');
-  grunt.loadNpmTasks('grunt-contrib-watch');
-  grunt.loadNpmTasks('grunt-sass');
-  grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-cssmin');
-  grunt.loadNpmTasks('grunt-usemin');
-  grunt.loadNpmTasks('grunt-contrib-concat');
-  grunt.loadNpmTasks('grunt-html-validation');
-  grunt.loadNpmTasks('grunt-babel');
-  grunt.loadNpmTasks('grunt-minjson');
 
   grunt.registerTask('js-build', ['babel', 'uglify', 'minjson']);
   grunt.registerTask('css-build', ['sass', 'cssmin']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,10 +79,6 @@ module.exports = function(grunt) {
         interval: 1000,
         spawn: true
       },
-      src: {
-        files: ['**/*.html'],
-        options: { livereload: true }
-      },
       js: {
         files: ['**/*.js', '!node_modules/**/*.js', '!static/dist/**/*.js'],
         options: { livereload: true },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -84,9 +84,14 @@ module.exports = function(grunt) {
         options: { livereload: true }
       },
       js: {
-        files: ['**/*.js', '**/*.json', '!node_modules/**/*.js', '!static/dist/**/*.js', '!static/dist/**/*.json'],
+        files: ['**/*.js', '!node_modules/**/*.js', '!static/dist/**/*.js'],
         options: { livereload: true },
         tasks: ['js-lint', 'js-build']
+      },
+      json: {
+        files: ['**/*.json', '!static/dist/**/*.json', '!package.json'],
+        options: { livereload: true },
+        tasks: ['minjson']
       },
       css: {
         files: '**/*.scss',
@@ -108,11 +113,11 @@ module.exports = function(grunt) {
     }
   });
 
-  grunt.registerTask('js-build', ['babel', 'uglify', 'minjson']);
+  grunt.registerTask('js-build', ['babel', 'uglify']);
   grunt.registerTask('css-build', ['sass', 'cssmin']);
   grunt.registerTask('js-lint', ['eslint']);
 
-  grunt.registerTask('build', ['clean', 'js-build', 'css-build']);
+  grunt.registerTask('build', ['clean', 'js-build', 'css-build', 'minjson']);
   grunt.registerTask('lint', ['js-lint']);
   grunt.registerTask('default', ['build', 'watch']);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -87,7 +87,7 @@ module.exports = function(grunt) {
       json: {
         files: ['static/data/*.json', 'static/locales/*.json'],
         options: { livereload: true },
-        tasks: ['minjson']
+        tasks: ['json']
       },
       css: {
         files: '**/*.scss',
@@ -109,11 +109,12 @@ module.exports = function(grunt) {
     }
   });
 
-  grunt.registerTask('js-build', ['babel', 'uglify']);
-  grunt.registerTask('css-build', ['sass', 'cssmin']);
-  grunt.registerTask('js-lint', ['eslint']);
+  grunt.registerTask('js-build', ['newer:babel', 'newer:uglify']);
+  grunt.registerTask('css-build', ['newer:sass', 'newer:cssmin']);
+  grunt.registerTask('js-lint', ['newer:eslint']);
+  grunt.registerTask('json', ['newer:minjson']);
 
-  grunt.registerTask('build', ['clean', 'js-build', 'css-build', 'minjson']);
+  grunt.registerTask('build', ['clean', 'js-build', 'css-build', 'json']);
   grunt.registerTask('lint', ['js-lint']);
   grunt.registerTask('default', ['build', 'watch']);
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -80,12 +80,12 @@ module.exports = function(grunt) {
         spawn: true
       },
       js: {
-        files: ['**/*.js', '!node_modules/**/*.js', '!static/dist/**/*.js'],
+        files: ['static/js/**/*.js'],
         options: { livereload: true },
         tasks: ['js-lint', 'js-build']
       },
       json: {
-        files: ['**/*.json', '!static/dist/**/*.json', '!package.json'],
+        files: ['static/data/*.json', 'static/locales/*.json'],
         options: { livereload: true },
         tasks: ['minjson']
       },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "grunt-sass": "latest",
     "grunt-unused": "latest",
     "grunt-usemin": "latest",
+    "grunt-newer": "^1.2.0",
     "jit-grunt": "^0.10.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "grunt-minjson": "latest",
     "grunt-sass": "latest",
     "grunt-unused": "latest",
-    "grunt-usemin": "latest"
+    "grunt-usemin": "latest",
+    "jit-grunt": "^0.10.0"
   },
   "scripts": {
     "postinstall": "grunt build",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "postinstall": "grunt build",
     "build": "grunt build",
     "watch": "grunt default",
-    "lint": "grunt lint"
+    "lint": "grunt lint",
+    "grunt": "grunt"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Our grunt setup can be PAINFULLY slow. There are a number of reasons:

 - Loading every npm task for _any_ change
 - Watching a TON of files (1500, originally, due to overly zealous use of `**` matchers)
 - Constantly rebuilding files which have not changed

I've addressed all of these issues in a way that should be, effectively, transparent and backwards compatible. You'll only notice that everything is faster now.

Look at each of the commits for a point-by-point speed ups