### PR TITLE
use specific version of pgoapi in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ PyMySQL==0.7.5
 flask-cors==2.1.2
 flask-compress==1.3.0
 LatLon==1.0.1
-git+https://github.com/keyphact/pgoapi.git#egg=pgoapi
+git+https://github.com/keyphact/pgoapi.git@691aff2543c39ba929e4aa0e325dc43d24cb24df#egg=pgoapi
 xxhash
 sphinx==1.4.5
 sphinx-autobuild==0.6.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use a specific version of pgoapi in requirements.txt. Currently it is using the master branch of pgoapi, which means that anytime pgoapi pushes a commit, random people will use a different version. API changes of pgoapi will silently result in errors, but only for people who have recently updated using pip.

It seems better to keep everyone on one version and upgrade to a next version once that is compatible and tested.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`pip install -r requirements.txt`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

