### PR TITLE
Removes global grunt install/remove step; not required

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,8 @@ COPY package.json Gruntfile.js /usr/src/app/
 COPY static /usr/src/app/static
 
 RUN apk add --no-cache build-base nodejs \
- && npm install -g grunt-cli \
  && npm install \
- && npm run-script build \
- && npm uninstall -g grunt-cli \
+ && npm run build \
  && rm -rf node_modules \
  && apk del build-base nodejs
 


### PR DESCRIPTION
Discovered while investigating #195, these steps aren't needed now.