### PR TITLE
Add bounding polygon option for location_generator.py

### DIFF
--- a/Tools/Hex-Beehive-Generator/Instructions_for_location_generator.txt
+++ b/Tools/Hex-Beehive-Generator/Instructions_for_location_generator.txt
@@ -11,9 +11,9 @@ Experimental Windows support!  Use the --windows flag
 
 
 An example (Linux):
-    python location_generator.py -lat -33.9 -lon 151.1 -st 5 -lp 3 --accounts /home/pika/accounts.csv
+    python location_generator.py -lat -33.9 -lon 151.1 -st 5 -lp 3 --polygon '(-33.895, 151.094),(-33.894, 151.107),(-33.913, 151.099)' --accounts /home/pika/accounts.csv
 An example (Windows):
-    python location_generator.py -lat -33.9 -lon 151.1 -st 5 -lp 3 --accounts C:\Documents\accounts.csv --windows --installdir="C:\Downloads\PokemonGo-Map"
+    python location_generator.py -lat -33.9 -lon 151.1 -st 5 -lp 3 --polygon '(-33.895, 151.094),(-33.894, 151.107),(-33.913, 151.099)' --accounts C:\Documents\accounts.csv --windows --installdir="C:\Downloads\PokemonGo-Map"
 
 
 usage: location_generator.py [-h] -lat LAT -lon LON [-st STEPS] [-lp LEAPS]

--- a/Tools/Hex-Beehive-Generator/Instructions_for_location_generator.txt
+++ b/Tools/Hex-Beehive-Generator/Instructions_for_location_generator.txt
@@ -36,6 +36,8 @@ usage: location_generator.py [-h] -lat LAT -lon LON [-st STEPS] [-lp LEAPS]
                         format
 
   --auth AUTH           Auth method (ptc or google)
+  
+  --polygon             Bounding box for workers
 
   -v, --verbose         Print lat/lng to stdout for debugging
 

--- a/Tools/Hex-Beehive-Generator/location_generator.py
+++ b/Tools/Hex-Beehive-Generator/location_generator.py
@@ -103,8 +103,7 @@ turns = 0               # number of turns made in this ring (0 to 6)
 turn_steps = 0          # number of cells required to complete one turn of the ring
 turn_steps_so_far = 0   # current cell number in this side of the current ring
 
-total_workers_polygonized=0
-k=0
+k=1
 
 for i in range(1, total_workers):
     if turns == 6 or turn_steps == 0:
@@ -136,7 +135,6 @@ for i in range(1, total_workers):
         if point_in_polygon(loc, literal_eval(args.polygon)) :
             locations[k] = loc
             k=k+1
-            total_workers_polygonized = total_workers_polygonized+1
     else:
         locations[i] = loc
     d = d_s
@@ -150,7 +148,10 @@ for i in range(1, total_workers):
         turn_steps_so_far = 0
 
 if args.polygon :
-    total_workers=total_workers_polygonized
+    if point_in_polygon(locations[0],  literal_eval(args.polygon)) == False :
+        locations.pop(0)
+        k=k-1
+    total_workers=k
 
 #if threading is desired (-t flag) cycle through all accounts and merge them into an array (do this anyway because otherwise we need an if statement below)
 

--- a/Tools/Hex-Beehive-Generator/location_generator.py
+++ b/Tools/Hex-Beehive-Generator/location_generator.py
@@ -104,7 +104,7 @@ turn_steps = 0          # number of cells required to complete one turn of the r
 turn_steps_so_far = 0   # current cell number in this side of the current ring
 
 total_workers_polygonized=0
-j=0
+k=0
 
 for i in range(1, total_workers):
     if turns == 6 or turn_steps == 0:
@@ -134,9 +134,9 @@ for i in range(1, total_workers):
     #If polygon arg is set, ignore points outside polygon
     if args.polygon :
         if point_in_polygon(loc, literal_eval(args.polygon)) :
-           locations[j] = loc
-           j=j+1
-           total_workers_polygonized = total_workers_polygonized+1
+            locations[k] = loc
+            k=k+1
+            total_workers_polygonized = total_workers_polygonized+1
     else:
         locations[i] = loc
     d = d_s

--- a/Tools/Hex-Beehive-Generator/location_generator.py
+++ b/Tools/Hex-Beehive-Generator/location_generator.py
@@ -3,6 +3,7 @@ import argparse
 import LatLon
 import itertools
 import os
+from ast import literal_eval
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-lat", "--lat", help="latitude", type=float, required=True)
@@ -17,11 +18,30 @@ parser.add_argument("--auth", help="Auth method (ptc or google)", default="ptc")
 parser.add_argument("-v", "--verbose", help="Print lat/lng to stdout for debugging", action='store_true', default=False)
 parser.add_argument("--windows", help="Generate a bat file for Windows", action='store_true', default=False)
 parser.add_argument("--installdir", help="Installation directory (only used for Windows)", type=str, default="C:\\PokemonGo-Map")
-
+parser.add_argument("--polygon", help="Only create workers within the bounds of polygon", type=str)
 preamble = "#!/usr/bin/env bash"
 server_template = "nohup python runserver.py -os -l '{lat}, {lon}' &\n" #this is the output template for linux
 worker_template = "sleep 0.5; nohup python runserver.py -ns -l '{lat}, {lon}' -st {steps} {auth}&\n" # so is this
 auth_template = "-a {} -u {} -p '{}' "  # unix people want single-quoted passwords - for threading reasons whitespace after ' before ""
+
+def point_in_polygon(point,poly):
+    x = float(point.lat)
+    y = float(point.lon)
+    n = len(poly)
+    inside = False
+
+    p1x,p1y = poly[0]
+    for i in range(n+1):
+        p2x,p2y = poly[i % n]
+        if y > min(p1y,p2y):
+            if y <= max(p1y,p2y):
+                if x <= max(p1x,p2x):
+                    if p1y != p2y:
+                        xints = (y-p1y)*(p2x-p1x)/(p2y-p1y)+p1x
+                    if p1x == p2x or x <= xints:
+                        inside = not inside
+        p1x,p1y = p2x,p2y
+    return inside
 
 R = 6378137.0
 r_hex = 52.5  # probably not correct
@@ -83,6 +103,8 @@ turns = 0               # number of turns made in this ring (0 to 6)
 turn_steps = 0          # number of cells required to complete one turn of the ring
 turn_steps_so_far = 0   # current cell number in this side of the current ring
 
+total_workers_polygonized=0
+j=0
 
 for i in range(1, total_workers):
     if turns == 6 or turn_steps == 0:
@@ -109,7 +131,14 @@ for i in range(1, total_workers):
         brng = 60 * turns + math.degrees(A)
 
     loc = loc.offset(brng + mod, d)
-    locations[i] = loc
+    #If polygon arg is set, ignore points outside polygon
+    if args.polygon :
+        if point_in_polygon(loc, literal_eval(args.polygon)) :
+           locations[j] = loc
+           j=j+1
+           total_workers_polygonized = total_workers_polygonized+1
+    else:
+        locations[i] = loc
     d = d_s
 
     turn_steps_so_far += 1
@@ -120,14 +149,17 @@ for i in range(1, total_workers):
         turns += 1
         turn_steps_so_far = 0
 
+if args.polygon :
+    total_workers=total_workers_polygonized
+
 #if threading is desired (-t flag) cycle through all accounts and merge them into an array (do this anyway because otherwise we need an if statement below)
 
 #make a list of exactly the right number of accounts
 accountsNeeded = [(j) for i,j in itertools.izip(range(0,int(args.thread)*total_workers),itertools.cycle(accounts))]
 #group those accounts, concatenate the details into a single string per worker
 accountStack=[""]*total_workers
-for i in range(0,total_workers):    
-    for j in range(0,int(args.thread)):
+for i in range(0,total_workers):
+    for j in range(0,int(args.thread)):   
         accountStack[i] = accountStack[i] + accountsNeeded[i*int(args.thread)+j]
 
 # if accounts list was provided, match each location with an account


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added option so that bounding polygon can be specified.  This allows more flexibility that the beehive shape.

## Motivation and Context
This solves the problem of giving the user more flexibility in the shape of the workers created.  Previously I had to export out all the coordinates, because I was working around objects like lakes.. and only wanting specific neighborhoods included as workers.  

## How Has This Been Tested?
I've tested with multiple sets of data on an Ubuntu 16.04 system.  However, I am unable to test on windows.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

Example usage, for Milwaukee near the lake:
python location_generator.py -lat 43.036586 -lon -87.912787 -st 3 -lp 8 -polygon '(43.06452,-87.92514),(43.06427,-87.87329),(43.0442,-87.89149),(43.00692,-87.88428),(42.9744,-87.85201),(42.97089,-87.92033),(43.02362,-87.92788)'

Using the --polygon argument will only generate 80 worker processes, whereas without it would create 169

A [tool like this](https://codepen.io/bgus/full/grBdrr) could be hacked together (if there isn't another one out there) for generating the coordinates