### PR TITLE
Add The option to jump blocks

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -31,11 +31,12 @@ from pgoapi import PGoApi
 from pgoapi.utilities import f2i
 from pgoapi import utilities as util
 from pgoapi.exceptions import AuthException
-
 from . import config
 from .models import parse_map
-
+from pogom.utils import get_args
+args = get_args()
 log = logging.getLogger(__name__)
+
 
 TIMESTAMP = '\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000'
 
@@ -63,7 +64,7 @@ def generate_location_steps(initial_loc, step_count):
     SOUTH = 180
     WEST = 270
 
-    pulse_radius = 0.07                 # km - radius of players heartbeat is 70m
+    pulse_radius = 0.07*args.jump_block# km - radius of players heartbeat is 70m - jump_block is an multiplicator for less accurate jumps for less accurate scans
     xdist = math.sqrt(3)*pulse_radius   # dist between column centers
     ydist = 3*(pulse_radius/2)          # dist between row centers
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -17,7 +17,6 @@ from s2sphere import LatLng, CellId
 from geopy.geocoders import GoogleV3
 
 from . import config
-
 log = logging.getLogger(__name__)
 
 
@@ -119,6 +118,8 @@ def get_args():
     parser.add_argument('--db-max_connections', help='Max connections for the database', type=int, default=5)
     parser.add_argument('-wh', '--webhook', help='Define URL(s) to POST webhook information to',
                         nargs='*', default=False, dest='webhooks')
+    parser.add_argument('-jb', '--jump-block', required=False, help='Gap measurement of search algorithm (Default is "1")', type=int, default=1)
+
     parser.set_defaults(DEBUG=False)
 
     args = parser.parse_args()


### PR DESCRIPTION
# Description
Issue https://github.com/PokemonGoMap/PokemonGo-Map/issues/219
There was already a push request for the former Pokemongo map but it never got merged  since it got shut down.

# Motivation and Context
I wanted to scan a bigger area for Pokestops and Pokemon in a reasonable time. This option "-jb" allows me to do exactly this.

# How Has This Been Tested?
Ran it locally on my PC.
![githup jumpsearch](https://cloud.githubusercontent.com/assets/15572960/17497909/7971925a-5dc4-11e6-9ccd-815da00c5712.png)

# Types of changes
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:
- [x]  My code follows the code style of this project.
- [x]  My change requires a change to the documentation.
- [ ]  I have updated the documentation accordingly.

