### PR TITLE
Add cache busting to flask url_for entries to prevent bad js/css

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ sphinx-autobuild==0.6.0
 recommonmark==0.4.0
 sphinx_rtd_theme==0.1.9
 requests==2.10.0
+git+https://github.com/ChrisTM/Flask-CacheBust.git@aa09ad861f104f987928fe9f5107ccfe0e4473c3#egg=flask_cache_bust

--- a/runserver.py
+++ b/runserver.py
@@ -41,6 +41,7 @@ if not hasattr(pgoapi, "__version__") or StrictVersion(pgoapi.__version__) < Str
 from threading import Thread, Event
 from queue import Queue
 from flask_cors import CORS
+from flask.ext import cache_bust
 
 from pogom import config
 from pogom.app import Pogom
@@ -161,6 +162,9 @@ if __name__ == '__main__':
 
     if args.cors:
         CORS(app);
+
+    # No more stale JS
+    cache_bust.init_cache_busting(app)
 
     app.set_search_control(pause_bit)
     app.set_location_queue(new_location_queue)

--- a/templates/map.html
+++ b/templates/map.html
@@ -11,26 +11,26 @@
     <meta name="theme-color" content="#3b3b3b">
     <!-- Fav- & Apple-Touch-Icons -->
     <!-- Favicon -->
-    <link rel="shortcut icon" href="static/appicons/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="{{ url_for('static', filename='appicons/favicon.ico').lstrip('/') }}" type="image/x-icon">
     <!-- non-retina iPhone pre iOS 7 -->
-    <link rel="apple-touch-icon" href="static/appicons/114x114.png" sizes="57x57">
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='appicons/114x114.png').lstrip('/') }}" sizes="57x57">
     <!-- non-retina iPad pre iOS 7 -->
-    <link rel="apple-touch-icon" href="static/appicons/144x144.png" sizes="72x72">
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='appicons/144x144.png').lstrip('/') }}" sizes="72x72">
     <!-- non-retina iPad iOS 7 -->
-    <link rel="apple-touch-icon" href="static/appicons/152x152.png" sizes="76x76">
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='appicons/152x152.png').lstrip('/') }}" sizes="76x76">
     <!-- retina iPhone pre iOS 7 -->
-    <link rel="apple-touch-icon" href="static/appicons/114x114.png" sizes="114x114">
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='appicons/114x114.png').lstrip('/') }}" sizes="114x114">
     <!-- retina iPhone iOS 7 -->
-    <link rel="apple-touch-icon" href="static/appicons/120x120.png" sizes="120x120">
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='appicons/120x120.png').lstrip('/') }}" sizes="120x120">
     <!-- retina iPad pre iOS 7 -->
-    <link rel="apple-touch-icon" href="static/appicons/144x144.png" sizes="144x144">
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='appicons/144x144.png').lstrip('/') }}" sizes="144x144">
     <!-- retina iPad iOS 7 -->
-    <link rel="apple-touch-icon" href="static/appicons/152x152.png" sizes="152x152">
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='appicons/152x152.png').lstrip('/') }}" sizes="152x152">
     <!-- retina iPhone 6 iOS 7 -->
-    <link rel="apple-touch-icon" href="static/appicons/180x180.png" sizes="180x180">
-    <link rel="stylesheet" href="static/dist/css/app.min.css">
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='appicons/180x180.png').lstrip('/') }}" sizes="180x180">
+    <link rel="stylesheet" href="{{ url_for('static', filename='dist/css/app.min.css').lstrip('/') }}">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.0/jquery-ui.min.css">
-    <script src="static/js/vendor/modernizr.custom.js"></script>
+    <script src="{{ url_for('static', filename='js/vendor/modernizr.custom.js').lstrip('/') }}"></script>
   </head>
   <body id="top">
     <div class="wrapper">
@@ -210,15 +210,14 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.0/jquery-ui.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/skel/3.0.1/skel.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js"></script>
-    <script src="static/dist/js/app.min.js"></script>
-    <script src="static/js/vendor/classie.js"></script>
+    <script src="{{ url_for('static', filename='dist/js/app.min.js').lstrip('/') }}"></script>
+    <script src="{{ url_for('static', filename='js/vendor/classie.js').lstrip('/') }}"></script>
     <script>
       var centerLat = {{lat}};
       var centerLng = {{lng}};
     </script>
-
-    <script src="static/dist/js/map.min.js"></script>
-    <script src="static/dist/js/stats.min.js"></script>
+    <script src="{{ url_for('static', filename='dist/js/map.min.js').lstrip('/') }}"></script>
+    <script src="{{ url_for('static', filename='dist/js/stats.min.js').lstrip('/') }}"></script>
     <script defer src="https://maps.googleapis.com/maps/api/js?key={{ gmaps_key }}&amp;callback=initMap&amp;libraries=places,geometry"></script>
   </body>
 </html>

--- a/templates/mobile_list.html
+++ b/templates/mobile_list.html
@@ -3,14 +3,15 @@
 	<title>Nearby Pokémon</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<script>var pageLoaded = new Date().getTime();</script>
-	<link rel="stylesheet" href="static/dist/css/mobile.min.css" type="text/css" />
+	<link rel="stylesheet" href="{{ url_for('static', filename='dist/css/mobile.min.css').lstrip('/') }}" type="text/css" />
 </head>
 <body>
 	<h1>Nearby Pokémon</h1>
 
 	<ol>
 {% for pokemon in pokemon_list[:20] %}
-		<li style="background-image: url('static/pixel_icons/{{pokemon.id}}.png')"
+{% set img = 'pixel_icons/' ~ pokemon.id ~ '.png' -%}
+		<li style="background-image: url('{{ url_for('static', filename=img).lstrip('/') }}')"
 			href='geo:0,0?q={{pokemon.latitude}},{{pokemon.longitude}}({{pokemon.name}})'>
 			<div class="name">{{pokemon.name}}</div>
 			<div class="dir"> - {{pokemon.distance}}m ({{pokemon.card_dir}}) - </div>
@@ -28,6 +29,6 @@
 
 	<a class="origin" href='geo:0,0?q={{origin_lat}},{{origin_lng}}(origin)'>origin location</a>
 
-	<script src="static/dist/js/mobile.min.js"></script>
+	<script src="{{ url_for('static', filename='dist/js/mobile.min.js').lstrip('/') }}"></script>
 </body>
 </html>

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -6,27 +6,27 @@
 
     <!-- Fav- & Apple-Touch-Icons -->
     <!-- Favicon -->
-    <link rel="shortcut icon" href="static/appicons/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="{{ url_for('static', filename='appicons/favicon.ico').lstrip('/') }}" type="image/x-icon">
     <!-- non-retina iPhone pre iOS 7 -->
-    <link rel="apple-touch-icon" href="static/appicons/114x114.png" sizes="57x57">
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='appicons/114x114.png').lstrip('/') }}" sizes="57x57">
     <!-- non-retina iPad pre iOS 7 -->
-    <link rel="apple-touch-icon" href="static/appicons/144x144.png" sizes="72x72">
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='appicons/144x144.png').lstrip('/') }}" sizes="72x72">
     <!-- non-retina iPad iOS 7 -->
-    <link rel="apple-touch-icon" href="static/appicons/152x152.png" sizes="76x76">
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='appicons/152x152.png').lstrip('/') }}" sizes="76x76">
     <!-- retina iPhone pre iOS 7 -->
-    <link rel="apple-touch-icon" href="static/appicons/114x114.png" sizes="114x114">
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='appicons/114x114.png').lstrip('/') }}" sizes="114x114">
     <!-- retina iPhone iOS 7 -->
-    <link rel="apple-touch-icon" href="static/appicons/120x120.png" sizes="120x120">
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='appicons/120x120.png').lstrip('/') }}" sizes="120x120">
     <!-- retina iPad pre iOS 7 -->
-    <link rel="apple-touch-icon" href="static/appicons/144x144.png" sizes="144x144">
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='appicons/144x144.png').lstrip('/') }}" sizes="144x144">
     <!-- retina iPad iOS 7 -->
-    <link rel="apple-touch-icon" href="static/appicons/152x152.png" sizes="152x152">
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='appicons/152x152.png').lstrip('/') }}" sizes="152x152">
     <!-- retina iPhone 6 iOS 7 -->
-    <link rel="apple-touch-icon" href="static/appicons/180x180.png" sizes="180x180">
+    <link rel="apple-touch-icon" href="{{ url_for('static', filename='appicons/180x180.png').lstrip('/') }}" sizes="180x180">
 
-    <link rel="stylesheet" href="static/dist/css/app.min.css">
-    <link rel="stylesheet" href="static/dist/css/statistics.min.css">
-    <script src="static/js/vendor/modernizr.custom.js"></script>
+    <link rel="stylesheet" href="{{ url_for('static', filename='dist/css/app.min.css').lstrip('/') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='dist/css/statistics.min.css').lstrip('/') }}">
+    <script src="{{ url_for('static', filename='js/vendor/modernizr.custom.js').lstrip('/') }}"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.9.1/polyfill.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/skel/3.0.1/skel.min.js"></script>
@@ -35,7 +35,7 @@
       var centerLat = {{lat}};
       var centerLng = {{lng}};
     </script>
-    <script src="static/dist/js/map.min.js"></script>
+    <script src="{{ url_for('static', filename='dist/js/map.min.js').lstrip('/') }}"></script>
 </head>
 <body>
         <!-- Header -->
@@ -61,11 +61,11 @@
             <h3 id="seen_header"></h3>
             <h1 id="seen_total"></h1>
         </div>
-        <div id="loading"><img src="static/images/loading.gif" alt="Loading"/></div>
+        <div id="loading"><img src="{{ url_for('static', filename='images/loading.gif').lstrip('/') }}" alt="Loading"/></div>
         <div class="container" id="seen_container">
         </div>
         <div id="location_details" class="overlay">
-            <div class="close" onclick="closeOverlay();"><img src="static/images/close.png" alt="Close" /></div>
+            <div class="close" onclick="closeOverlay();"><img src="{{ url_for('static', filename='images/close.png').lstrip('/') }}" alt="Close" /></div>
             <div class="location_header"><h3 id="location_header"></h3></div>
             <div class="content">
                 <div id="times_list" style="display: none;"></div>
@@ -74,7 +74,7 @@
                 </div>
             </div>
         </div>
-    <script src="static/dist/js/app.min.js"></script>
-    <script src="static/dist/js/statistics.min.js"></script>
+    <script src="{{ url_for('static', filename='dist/js/app.min.js').lstrip('/') }}"></script>
+    <script src="{{ url_for('static', filename='dist/js/statistics.min.js').lstrip('/') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes #169

All urls are now using the flask helper `url_for` and with the cache buster, it will calculate the md5 of the file so that, as the file changes, so too does the URL. Also does it as an early part of the URL so your guaranteed to not get a stale cache from GET params busting (which can be problematic).

All the `lstrip` stuff is to keep the URLs relative since, by default, they are absolute which breaks proxies for a few folks who host the app a directory or two deep.