### PR TITLE
Make the altitude grabber a bit more robust against API overuse

### DIFF
--- a/runserver.py
+++ b/runserver.py
@@ -105,7 +105,7 @@ if __name__ == '__main__':
         altitude = requests.get(url).json()[u'results'][0][u'elevation']
         log.debug('Local altitude is: %sm', altitude)
         position = (position[0], position[1], altitude)
-    except requests.exceptions.RequestException:
+    except (requests.exceptions.RequestException, IndexError, KeyError):
         log.error('Unable to retrieve altitude from Google APIs; setting to 0')
 
     if not any(position):


### PR DESCRIPTION
Very minor tweak.  I don't know how this is possible -- you'd have to be really abusing the elevation API with constant restarts or something -- but some people might possible be running into Map API throttling.  This minor tweak should prevent that.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

