### PR TITLE
Add notification by rarity

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -3,7 +3,8 @@
 //
 
 var $selectExclude
-var $selectNotify
+var $selectPokemonNotify
+var $selectRarityNotify
 var $selectStyle
 var $selectIconResolution
 var $selectIconSize
@@ -17,6 +18,7 @@ var languageLookupThreshold = 3
 
 var excludedPokemon = []
 var notifiedPokemon = []
+var notifiedRarity = []
 
 var map
 var rawDataIsLoading = false
@@ -698,6 +700,10 @@ var StoreOptions = {
     default: [],
     type: StoreTypes.JSON
   },
+  'remember_select_rarity_notify': {
+    default: [],
+    type: StoreTypes.JSON
+  },
   'showGyms': {
     default: false,
     type: StoreTypes.Boolean
@@ -784,8 +790,8 @@ function excludePokemon (id) { // eslint-disable-line no-unused-vars
 }
 
 function notifyAboutPokemon (id) { // eslint-disable-line no-unused-vars
-  $selectNotify.val(
-    $selectNotify.val().concat(id)
+  $selectPokemonNotify.val(
+    $selectPokemonNotify.val().concat(id)
   ).trigger('change')
 }
 
@@ -1162,7 +1168,7 @@ function setupPokemonMarker (item, skipNotification, isBounceDisabled) {
     disableAutoPan: true
   })
 
-  if (notifiedPokemon.indexOf(item['pokemon_id']) > -1) {
+  if (notifiedPokemon.indexOf(item['pokemon_id']) > -1 || notifiedRarity.indexOf(item['pokemon_rarity']) > -1) {
     if (!skipNotification) {
       if (Store.get('playSound')) {
         audio.play()
@@ -1833,7 +1839,8 @@ $(function () {
   }
 
   $selectExclude = $('#exclude-pokemon')
-  $selectNotify = $('#notify-pokemon')
+  $selectPokemonNotify = $('#notify-pokemon')
+  $selectRarityNotify = $('#notify-rarity')
   var numberOfPokemon = 151
 
   // Load pokemon names and populate lists
@@ -1867,9 +1874,14 @@ $(function () {
       data: pokeList,
       templateResult: formatState
     })
-    $selectNotify.select2({
+    $selectPokemonNotify.select2({
       placeholder: i8ln('Select Pokémon'),
       data: pokeList,
+      templateResult: formatState
+    })
+    $selectRarityNotify.select2({
+      placeholder: i8ln('Select Rarity'),
+      data: [i8ln('Common'), i8ln('Uncommon'), i8ln('Rare'), i8ln('Very Rare'), i8ln('Ultra Rare')],
       templateResult: formatState
     })
 
@@ -1879,14 +1891,19 @@ $(function () {
       clearStaleMarkers()
       Store.set('remember_select_exclude', excludedPokemon)
     })
-    $selectNotify.on('change', function (e) {
-      notifiedPokemon = $selectNotify.val().map(Number)
+    $selectPokemonNotify.on('change', function (e) {
+      notifiedPokemon = $selectPokemonNotify.val().map(Number)
       Store.set('remember_select_notify', notifiedPokemon)
+    })
+    $selectRarityNotify.on('change', function (e) {
+      notifiedRarity = $selectRarityNotify.val().map(String)
+      Store.set('remember_select_rarity_notify', notifiedRarity)
     })
 
     // recall saved lists
     $selectExclude.val(Store.get('remember_select_exclude')).trigger('change')
-    $selectNotify.val(Store.get('remember_select_notify')).trigger('change')
+    $selectPokemonNotify.val(Store.get('remember_select_notify')).trigger('change')
+    $selectRarityNotify.val(Store.get('remember_select_rarity_notify')).trigger('change')
   })
 
   // run interval timers to regularly update map and timediffs

--- a/templates/map.html
+++ b/templates/map.html
@@ -151,6 +151,14 @@
                 </div>
               </label>
             </div>
+            <div class="form-control">
+              <label for="notify-rarity">
+                <h3>Notify of Rarity</h3>
+                <div style="max-height:165px;overflow-y:auto";>
+                  <select id="notify-rarity" multiple="multiple"></select>
+                </div>
+              </label>
+            </div>
             <div class="form-control switch-container">
               <h3>Notify with sound</h3>
               <div class="onoffswitch">


### PR DESCRIPTION
## Description
I added a select in the Notification Settings tab to be able to have notification by rarity rather than by pokemon.

## Motivation and Context
I'm mainly looking for rare pokemons, not a single one in particular. This helps with not having to select every rare pokemon or having to often check the map.

## How Has This Been Tested?
I tested it on my machine (Linux 64 bits).

## Screenshots (if appropriate):

![pokemon go map rarity notification](https://cloud.githubusercontent.com/assets/3845486/17515858/3a92c122-5e3b-11e6-8455-092fd340ab23.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

