### PR TITLE
Fix installation documentation on OSX El Capitan

### DIFF
--- a/docs/basic-install/index.rst
+++ b/docs/basic-install/index.rst
@@ -78,6 +78,12 @@ Linux/OSX:
 
   sudo -H pip install -r requirements.txt
 
+OSX El Capitan:
+
+.. code-block:: bash
+
+  sudo -H pip install -r requirements.txt --ignore-installed
+
 ``git`` Version Extra Steps
 ===========================
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix of the install documentation for OSX El Capitan.

## Motivation and Context
The six package is already installed and can't be overwritten due to the system protection.
https://github.com/pypa/pip/issues/3165

## How Has This Been Tested?
On my OSX El Capitan

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
