### PR TITLE
Fix pip requirement installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,11 +15,11 @@ PyMySQL==0.7.5
 flask-cors==2.1.2
 flask-compress==1.3.0
 LatLon==1.0.1
-git+https://github.com/keyphact/pgoapi.git@dc1b222030c688747b33a8d18dd7f3af7457a79d#egg=pgoapi
+-e git://github.com/keyphact/pgoapi.git@b4bf0e089dfe09903f8dda37dae56910e01f94cc#egg=pgoapi
 xxhash
 sphinx==1.4.5
 sphinx-autobuild==0.6.0
 recommonmark==0.4.0
 sphinx_rtd_theme==0.1.9
 requests==2.10.0
-git+https://github.com/ChrisTM/Flask-CacheBust.git@aa09ad861f104f987928fe9f5107ccfe0e4473c3#egg=flask_cache_bust
+-e git://github.com/ChrisTM/Flask-CacheBust.git@aa09ad861f104f987928fe9f5107ccfe0e4473c3#egg=flask_cache_bust


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
pip requirements can't be install for projects in development.
Tickets resolutions: #283 #277 #276 

## Motivation and Context
The installation can't be complete on pip requirements

## How Has This Been Tested?
 - OSX El Capitan
 - Python 2.7.10
 - pip 8.1.2 from /Library/Python/2.7/site-packages/pip-8.1.2-py2.7.egg (python 2.7)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

