### PR TITLE
Fix of parse_map method when GET_MAP_OBJECTS is empty

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -296,6 +296,9 @@ def parse_map(map_dict, step_location):
     gyms = {}
     scanned = {}
 
+    if len(map_dict['responses']['GET_MAP_OBJECTS']) < 1:
+        return False
+
     cells = map_dict['responses']['GET_MAP_OBJECTS']['map_cells']
     for cell in cells:
         if config['parse_pokemon']:


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When I run the server, I received empty GET_MAP_OBJECTS array. Probably there's a problem, on API call or response, but this shouldn't be blocking. The worker must continu to search others locations.

```sh
Traceback (most recent call last):
  File "/Users/Oak/Projects/pokemap/pogom/search.py", line 242, in search_worker_thread
    parse_map(response_dict, step_location)
  File "/Users/Oak/Projects/pokemap/pogom/models.py", line 302, in parse_map
    cells = map_dict['responses']['GET_MAP_OBJECTS']['map_cells']
KeyError: 'map_cells'
```

## How Has This Been Tested?
 - OSX El Capitan
 - Python 2.7.10
 - pip 8.1.2 from /Library/Python/2.7/site-packages/pip-8.1.2-py2.7.egg (python 2.7)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
