### PR TITLE
Relocate marker when inserting coordinates

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -863,7 +863,7 @@ function initMap () { // eslint-disable-line no-unused-vars
   map.setMapTypeId(Store.get('map_style'))
   google.maps.event.addListener(map, 'idle', updateMap)
 
-  createSearchMarker()
+  marker = createSearchMarker()
 
   addMyLocationButton()
   initSidebar()


### PR DESCRIPTION
Fixed map js when relocating the marker inserting new coordinates in the sidebar.
## Description
the function createSearchMarker was returning an instance of gMapsMarker but wasn't saving the reference for this.

## Motivation and Context
When I was trying to search pokémons in places I could go, I wasn't able to change the coordinates due to an error in the console.

## How Has This Been Tested?
I just tracked it down with the devtoos and tested it in chrome.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

… coordinates