### PR TITLE
Fix map not hiding lured Pokemon when toggled off.

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1930,7 +1930,7 @@ $(function () {
 
   // Setup UI element interactions
   $('#gyms-switch').change(buildSwitchChangeListener(mapData, ['gyms'], 'showGyms'))
-  $('#pokemon-switch').change(buildSwitchChangeListener(mapData, ['pokemons', 'lure_pokemons'], 'showPokemon'))
+  $('#pokemon-switch').change(buildSwitchChangeListener(mapData, ['pokemons', 'lurePokemons'], 'showPokemon'))
   $('#scanned-switch').change(buildSwitchChangeListener(mapData, ['scanned'], 'showScanned'))
 
   $('#pokestops-switch').change(function () {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Corrected a typo in map.js that prevented lured pokemon from being hidden when toggling off the "Pokemon" option on the map.

## Motivation and Context
Fixes #358 

## How Has This Been Tested?
Rebuilt after change. Now lured pokemon are also hidden.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

