### PR TITLE
A simple memoizer to only parse the args once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,19 @@ sudo: false
 language: python
 python:
   - 2.7
+
+# install steps MUST succeed or will immediately halt the build
 install:
   - nvm install 4.4.7
   - pip install flake8
   - pip install -r requirements.txt
-  - npm install grunt-cli -g
   - npm install
-before_script:
-  - "flake8 ."
+
+# script steps, if erroring, will fail the build but not stop the build process
+# this is handy because we want to know that linting is broken, but it shouldn't
+# stop us from testing/linting/compiling other things as well
 script:
+  - flake8 --statistics --show-source --disable-noqa
   - npm run build
   - npm run lint
   - nosetests

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -31,6 +31,7 @@ def verify_config_file_exists(filename):
 
 def memoize(function):
     memo = {}
+
     def wrapper(*args):
         if args in memo:
             return memo[args]

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -29,6 +29,19 @@ def verify_config_file_exists(filename):
         shutil.copy2(fullpath + '.example', fullpath)
 
 
+def memoize(function):
+    memo = {}
+    def wrapper(*args):
+        if args in memo:
+            return memo[args]
+        else:
+            rv = function(*args)
+            memo[args] = rv
+            return rv
+    return wrapper
+
+
+@memoize
 def get_args():
     # fuck PEP8
     configpath = os.path.join(os.path.dirname(__file__), '../config/config.ini')


### PR DESCRIPTION
Previously, every call to `get_args()` would re-parse everything, which is a waste. Now it doesn't.