### PR TITLE
UI wont load if Recent Scanned Location Query is too big

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -282,7 +282,9 @@ class ScannedLocation(BaseModel):
                         (ScannedLocation.latitude <= neLat) &
                         (ScannedLocation.longitude <= neLng))
                  .dicts())
-
+        #UI wont load if this query is too big so cropping the query might Fix it
+        if len(query.values()) > 10000:
+            query = query.objects.order_by('last_modified')[:10000]
         scans = []
         for s in query:
             scans.append(s)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -282,7 +282,6 @@ class ScannedLocation(BaseModel):
                         (ScannedLocation.latitude <= neLat) &
                         (ScannedLocation.longitude <= neLng))
                  .dicts())
-        #UI wont load if this query is too big so cropping the query might Fix it
         if len(query.values()) > 10000:
             query = query.objects.order_by('last_modified')[:10000]
         scans = []

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -281,7 +281,7 @@ class ScannedLocation(BaseModel):
                         (ScannedLocation.longitude >= swLng) &
                         (ScannedLocation.latitude <= neLat) &
                         (ScannedLocation.longitude <= neLng))
-                 .order_by(-ScannedLocation.last_modified)[:10000]
+                 .order_by(ScannedLocation.last_modified.desc())[:10000]
                  .dicts())
         scans = []
         for s in query:

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -281,7 +281,7 @@ class ScannedLocation(BaseModel):
                         (ScannedLocation.longitude >= swLng) &
                         (ScannedLocation.latitude <= neLat) &
                         (ScannedLocation.longitude <= neLng))
-                 .order_by(ScannedLocation.last_modified.desc())[:10000]
+                 .order_by(-ScannedLocation.last_modified)[:10000]
                  .dicts())
         scans = []
         for s in query:

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -281,7 +281,8 @@ class ScannedLocation(BaseModel):
                         (ScannedLocation.longitude >= swLng) &
                         (ScannedLocation.latitude <= neLat) &
                         (ScannedLocation.longitude <= neLng))
-                 .order_by(ScannedLocation.last_modified.desc())[:5000]
+                 .order_by(ScannedLocation.last_modified.desc())
+                 .limit(5000)
                  .dicts())
         scans = []
         for s in query:

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -281,9 +281,8 @@ class ScannedLocation(BaseModel):
                         (ScannedLocation.longitude >= swLng) &
                         (ScannedLocation.latitude <= neLat) &
                         (ScannedLocation.longitude <= neLng))
+                 .order_by(-ScannedLocation.last_modified)[:10000]
                  .dicts())
-        if len(query.values()) > 10000:
-            query = query.objects.order_by('last_modified')[:10000]
         scans = []
         for s in query:
             scans.append(s)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -281,7 +281,7 @@ class ScannedLocation(BaseModel):
                         (ScannedLocation.longitude >= swLng) &
                         (ScannedLocation.latitude <= neLat) &
                         (ScannedLocation.longitude <= neLng))
-                 .order_by(-ScannedLocation.last_modified)[:10000]
+                 .order_by(ScannedLocation.last_modified.desc())[:5000]
                  .dicts())
         scans = []
         for s in query:


### PR DESCRIPTION
In the UI, if show scanned locations is turned on and the amount of recent scanned locations in the DB are above 15k or 20k the UI wont load (freezes the UI). You will encounter this kind of error if you have a BIG scan area with many workers. There is probably a better way to implement this, i suck with sql queries.