### PR TITLE
Add spawnpoint display

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -108,6 +108,9 @@ class Pogom(Flask):
         if request.args.get('appearances', 'false') == 'true':
             d['appearances'] = Pokemon.get_appearances(request.args.get('pokemonid'), request.args.get('last', type=float))
 
+        if request.args.get('spawnpoints', 'false') == 'true':
+            d['spawnpoints'] = Pokemon.get_spawnpoints(swLat, swLng, neLat, neLng)
+
         return jsonify(d)
 
     def loc(self):

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -184,6 +184,23 @@ class Pokemon(BaseModel):
             appearances.append(a)
         return appearances
 
+    @classmethod
+    def get_spawnpoints(cls, swLat, swLng, neLat, neLng):
+        query = Pokemon.select(Pokemon.latitude, Pokemon.longitude, Pokemon.spawnpoint_id)
+
+        if None not in (swLat, swLng, neLat, neLng):
+            query = (query
+                     .where((Pokemon.latitude >= swLat) &
+                            (Pokemon.longitude >= swLng) &
+                            (Pokemon.latitude <= neLat) &
+                            (Pokemon.longitude <= neLng)
+                        )
+                     )
+
+        query = query.group_by(Pokemon.spawnpoint_id).dicts()
+
+        return list(query)
+
 
 class Pokestop(BaseModel):
     pokestop_id = CharField(primary_key=True, max_length=50)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -194,7 +194,7 @@ class Pokemon(BaseModel):
                             (Pokemon.longitude >= swLng) &
                             (Pokemon.latitude <= neLat) &
                             (Pokemon.longitude <= neLng)
-                        )
+                            )
                      )
 
         query = query.group_by(Pokemon.spawnpoint_id).dicts()

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -617,7 +617,7 @@ var mapData = {
   pokestops: {},
   lurePokemons: {},
   scanned: {},
-  spawnpoints: {},
+  spawnpoints: {}
 }
 var gymTypes = ['Uncontested', 'Mystic', 'Valor', 'Instinct']
 var audio = new Audio('static/sounds/ding.mp3')

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -616,7 +616,8 @@ var mapData = {
   gyms: {},
   pokestops: {},
   lurePokemons: {},
-  scanned: {}
+  scanned: {},
+  spawnpoints: {},
 }
 var gymTypes = ['Uncontested', 'Mystic', 'Valor', 'Instinct']
 var audio = new Audio('static/sounds/ding.mp3')
@@ -725,6 +726,10 @@ var StoreOptions = {
     type: StoreTypes.Number
   },
   'showScanned': {
+    default: false,
+    type: StoreTypes.Boolean
+  },
+  'showSpawnpoints': {
     default: false,
     type: StoreTypes.Boolean
   },
@@ -935,6 +940,7 @@ function initSidebar () {
   $('#geoloc-switch').prop('checked', Store.get('geoLocate'))
   $('#start-at-user-location-switch').prop('checked', Store.get('startAtUserLocation'))
   $('#scanned-switch').prop('checked', Store.get('showScanned'))
+  $('#spawnpoints-switch').prop('checked', Store.get('showSpawnpoints'))
   $('#sound-switch').prop('checked', Store.get('playSound'))
   var searchBox = new google.maps.places.SearchBox(document.getElementById('next-location'))
   $('#next-location').css('background-color', $('#geoloc-switch').prop('checked') ? '#e0e0e0' : '#ffffff')
@@ -1259,6 +1265,21 @@ function setupScannedMarker (item) {
   return marker
 }
 
+function setupSpawnpointMarker (item) {
+  var circleCenter = new google.maps.LatLng(item['latitude'], item['longitude'])
+
+  var marker = new google.maps.Circle({
+    map: map,
+    clickable: false,
+    center: circleCenter,
+    radius: 5, // metres
+    fillColor: 'blue',
+    strokeWeight: 1
+  })
+
+  return marker
+}
+
 function clearSelection () {
   if (document.selection) {
     document.selection.empty()
@@ -1357,6 +1378,7 @@ function loadRawData () {
   var loadGyms = Store.get('showGyms')
   var loadPokestops = Store.get('showPokestops') || Store.get('showPokemon')
   var loadScanned = Store.get('showScanned')
+  var loadSpawnpoints = Store.get('showSpawnpoints')
 
   var bounds = map.getBounds()
   var swPoint = bounds.getSouthWest()
@@ -1374,6 +1396,7 @@ function loadRawData () {
       'pokestops': loadPokestops,
       'gyms': loadGyms,
       'scanned': loadScanned,
+      'spawnpoints': loadSpawnpoints,
       'swLat': swLat,
       'swLng': swLng,
       'neLat': neLat,
@@ -1509,6 +1532,24 @@ function processScanned (i, item) {
   }
 }
 
+function processSpawnpoints (i, item) {
+  if (!Store.get('showSpawnpoints')) {
+    return false
+  }
+
+  var id = item['spawnpoint_id']
+
+  if (id in mapData.spawnpoints) {
+    // In the future: maybe show how long till spawnpoint activates?
+  } else { // add marker to map and item to dict
+    if (item.marker) {
+      item.marker.setMap(null)
+    }
+    item.marker = setupSpawnpointMarker(item)
+    mapData.spawnpoints[id] = item
+  }
+}
+
 function updateMap () {
   loadRawData().done(function (result) {
     $.each(result.pokemons, processPokemons)
@@ -1516,11 +1557,13 @@ function updateMap () {
     $.each(result.pokestops, processLuredPokemon)
     $.each(result.gyms, processGyms)
     $.each(result.scanned, processScanned)
+    $.each(result.spawnpoints, processSpawnpoints)
     showInBoundsMarkers(mapData.pokemons)
     showInBoundsMarkers(mapData.lurePokemons)
     showInBoundsMarkers(mapData.gyms)
     showInBoundsMarkers(mapData.pokestops)
     showInBoundsMarkers(mapData.scanned)
+    showInBoundsMarkers(mapData.spawnpoints)
     clearStaleMarkers()
     if ($('#stats').hasClass('visible')) {
       countMarkers()
@@ -1949,6 +1992,7 @@ $(function () {
   $('#gyms-switch').change(buildSwitchChangeListener(mapData, ['gyms'], 'showGyms'))
   $('#pokemon-switch').change(buildSwitchChangeListener(mapData, ['pokemons', 'lure_pokemons'], 'showPokemon'))
   $('#scanned-switch').change(buildSwitchChangeListener(mapData, ['scanned'], 'showScanned'))
+  $('#spawnpoints-switch').change(buildSwitchChangeListener(mapData, ['spawnpoints'], 'showSpawnpoints'))
 
   $('#pokestops-switch').change(function () {
     var options = {

--- a/templates/map.html
+++ b/templates/map.html
@@ -91,6 +91,16 @@
                 </label>
               </div>
             </div>
+            <div class="form-control switch-container">
+              <h3>Spawn Points</h3>
+              <div class="onoffswitch">
+                <input id="spawnpoints-switch" type="checkbox" name="spawnpoints-switch" class="onoffswitch-checkbox">
+                <label class="onoffswitch-label" for="spawnpoints-switch">
+                <span class="switch-label" data-on="On" data-off="Off"></span>
+                <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
             <div class="form-control">
               <label for="exclude-pokemon">
               <h3>Hide Pokémon</h3>


### PR DESCRIPTION
Shows spawnpoints on the map, based on https://www.reddit.com/r/pokemongodev/comments/4wxteh/i_implemented_tbterras_spawntracker_into/

## Description
While this does not change scanning behavior, it does display all known spawnpoints on the map for informational purposes. Spawnpoints are highlighted as a 5m circle and can be toggled on/off in options, defaulting to off.

## Motivation and Context
Spawnpoint based scanning is apparently the Next Big Thing (tm), and while I didn't want to implement the whole scan stuff, I thought it'd be informative to see where the spawnpoints actually are, if for no other reason than to laugh at how inefficient beehive is.

## How Has This Been Tested?
Spot-checked on Win10 with Chrome, and Android 6.0.1 with Chrome.
Spawnpoint output was (roughly) compared to the output generated from the SQLite query on the Reddit page.

## Screenshots (if appropriate):
Pokemon Off:
![image](https://cloud.githubusercontent.com/assets/5599341/17542830/2c2ceec8-5e9a-11e6-8ffa-4d46ba466b39.png)

Pokemon On:
![image](https://cloud.githubusercontent.com/assets/5599341/17542824/175c1cb2-5e9a-11e6-8998-3c008ca220f3.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. (Probably, I don't know if the UI options are documented)
- [ ] I have updated the documentation accordingly.

