### PR TITLE
Update requirements.txt to make flask-cachebust name match

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ sphinx-autobuild==0.6.0
 recommonmark==0.4.0
 sphinx_rtd_theme==0.1.9
 requests==2.10.0
-git+https://github.com/ChrisTM/Flask-CacheBust.git@aa09ad861f104f987928fe9f5107ccfe0e4473c3#egg=flask_cache_bust
+git+https://github.com/ChrisTM/Flask-CacheBust.git@aa09ad861f104f987928fe9f5107ccfe0e4473c3#egg=flask_cachebust


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
removed one underscore that was making the name not consistent

## Motivation and Context
fixes one of the warnings generated when pip install -r requirements.txt is ran.
fixes part of the complaints in issues #255 and #283 
note that this does **NOT** fix the "Could not find a tag or branch..." message, just the one about the fragments.

## How Has This Been Tested?
ran on ubuntu 12.04 server
still worked

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)(not really a bug. more of an annoyance)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Fixes the "Fix your #egg=flask-cache-bust fragments." message