### PR TITLE
Add .slugignore file for a faster deployment on Scalingo and Heroku

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,3 @@
+/node_modules
+/docs
+/.scalingo/node


### PR DESCRIPTION
Thanks to this file, files used for deployment (node, grunt, etc.) willbe ignored on Scalingo and Heroku after the build, making the deployment faster and lighter.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

