### PR TITLE
return current loc even when setting new loc

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -137,7 +137,7 @@ class Pogom(Flask):
             self.location_queue.put((lat, lon, 0))
             self.set_current_location((lat, lon, 0))
             log.info('Changing next location: %s,%s', lat, lon)
-            return 'ok'
+            return self.loc()
 
     def list_pokemon(self):
         # todo: check if client is android/iOS/Desktop for geolink, currently


### PR DESCRIPTION
## Description
Returns the currently saved location after setting new location instead of a meaningless "ok" text.

## Motivation and Context
Mobile clients can use the same datamodel of loc/ for next_loc/ to map the result.

## How Has This Been Tested?
updated next_loc(self) in app.py to call and return the result of loc(self)
made sure it does not break the feature and ergo the webinterface

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

