### PR TITLE
Add username to "Exception in search_worker" error message

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -261,7 +261,7 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
 
         # catch any process exceptions, log them, and continue the thread
         except Exception as e:
-            log.exception('Exception in search_worker: %s', e)
+            log.exception('Exception in search_worker: %s. Username: %s', e, account['username'])
 
 
 def check_login(args, account, api, position):


### PR DESCRIPTION
## Description
Add username to "Exception in search_worker" error message.

## Motivation and Context
Currently it's pretty hard to determine which account fails in multi account setups.
See #180 

## How Has This Been Tested?
Running two of my servers for 24h

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

