### PR TITLE
Fix #364: Can't pan map when hovering pokemon or pokestop icon

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1152,7 +1152,6 @@ function setupPokemonMarker (item, skipNotification, isBounceDisabled) {
       lng: item['longitude']
     },
     zIndex: 9999,
-    optimized: false,
     map: map,
     icon: icon,
     animationDisabled: animationDisabled
@@ -1218,7 +1217,6 @@ function setupPokestopMarker (item) {
     },
     map: map,
     zIndex: 2,
-    optimized: false,
     icon: 'static/forts/' + imagename + '.png'
   })
 


### PR DESCRIPTION
Fix for #364. Issue was introduced in 1a4d7ee4314c15abff58854c0f0cfad96f201cc1 (quite a while back)

## Description
Removed `optimized: false` during Marker creation.
Only required for animated GIF and PNG, see https://developers.google.com/maps/documentation/javascript/reference#MarkerOptions

## How Has This Been Tested?
Docker & Chrome on Linux, Chrome on Android 6

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the code style of this project.

