### PR TITLE
Fix #206: "No Labels" style setting only removes POI's but not street names

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -26,16 +26,10 @@ var locationMarker
 var marker
 
 var noLabelsStyle = [{
-  featureType: 'poi',
+  featureType: 'all',
   elementType: 'labels',
   stylers: [{
     visibility: 'off'
-  }]
-}, {
-  'featureType': 'all',
-  'elementType': 'labels.icon',
-  'stylers': [{
-    'visibility': 'off'
   }]
 }]
 var light2Style = [{


### PR DESCRIPTION
## Description
Correctly sets visibility of labels for all feature types of the map.

## How Has This Been Tested?
Docker and Chrome on Linux, Chrome on Android 6

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.