### PR TITLE
Fix #418: Notifications crash Chrome for Android

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,8 @@
     "countMarkers": true,
     "skel": true,
     "setupPokemonMarker": true,
+    "createjs": true,
+    "Push": true,
 
     "noLabelsStyle": true,
     "darkStyle": true,

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -4,7 +4,7 @@
 import calendar
 import logging
 
-from flask import Flask, jsonify, render_template, request
+from flask import Flask, jsonify, render_template, request, send_from_directory
 from flask.json import JSONEncoder
 from flask_compress import Compress
 from datetime import datetime
@@ -33,6 +33,7 @@ class Pogom(Flask):
         self.route("/search_control", methods=['GET'])(self.get_search_control)
         self.route("/search_control", methods=['POST'])(self.post_search_control)
         self.route("/stats", methods=['GET'])(self.get_stats)
+        self.route("/sw.js", methods=['GET'])(self.static_from_root)
 
     def set_search_control(self, control):
         self.search_control = control
@@ -222,6 +223,9 @@ class Pogom(Flask):
                                gmaps_key=config['GMAPS_KEY'],
                                valid_input=self.get_valid_stat_input()
                                )
+
+    def static_from_root(self):
+        return send_from_directory(self.static_folder+'/js', request.path[1:])
 
 
 class CustomJSONEncoder(JSONEncoder):

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -225,7 +225,7 @@ class Pogom(Flask):
                                )
 
     def static_from_root(self):
-        return send_from_directory(self.static_folder+'/js', request.path[1:])
+        return send_from_directory(self.static_folder + '/js', request.path[1:])
 
 
 class CustomJSONEncoder(JSONEncoder):

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -619,7 +619,7 @@ var mapData = {
   scanned: {}
 }
 var gymTypes = ['Uncontested', 'Mystic', 'Valor', 'Instinct']
-createjs.Sound.registerSound("static/sounds/ding.mp3", "ding")
+createjs.Sound.registerSound('static/sounds/ding.mp3', 'ding')
 var pokemonSprites = {
   normal: {
     columns: 12,
@@ -1170,7 +1170,7 @@ function setupPokemonMarker (item, skipNotification, isBounceDisabled) {
   if (notifiedPokemon.indexOf(item['pokemon_id']) > -1 || notifiedRarity.indexOf(item['pokemon_rarity']) > -1) {
     if (!skipNotification) {
       if (Store.get('playSound')) {
-        createjs.Sound.play("ding");
+        createjs.Sound.play('ding');
       }
       sendNotification('A wild ' + item['pokemon_name'] + ' appeared!', 'Click to load map', 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
     }
@@ -1579,6 +1579,7 @@ function sendNotification (title, text, icon, lat, lng) {
     Push.create(title, {
       icon: icon,
       body: text,
+      vibrate: 1000,
       onClick: function () {
         window.focus()
         this.close()
@@ -1587,7 +1588,6 @@ function sendNotification (title, text, icon, lat, lng) {
       }
     })
   }
-  navigator.vibrate(1000)
 }
 
 function myLocationButton (map, marker) {
@@ -1736,14 +1736,12 @@ function i8ln (word) {
 //
 
 $(function () {
-  if (!Notification) {
+  if (!Push.isSupported) {
     console.log('could not load notifications')
     return
   }
 
-  if (Notification.permission !== 'granted') {
-    Notification.requestPermission()
-  }
+  Push.Permission.request()
 })
 
 $(function () {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1578,21 +1578,21 @@ function sendNotification (title, text, icon, lat, lng) {
   if (Notification.permission !== 'granted') {
     Notification.requestPermission()
   } else {
-	  try {
-		  var notification = new Notification(title, {
-		    icon: icon,
-		    body: text,
-		    sound: 'sounds/ding.mp3'
-		  })
+    try {
+      var notification = new Notification(title, {
+        icon: icon,
+        body: text,
+        sound: 'sounds/ding.mp3'
+      })
 
-		  notification.onclick = function () {
-		    window.focus()
-		    notification.close()
+      notification.onclick = function () {
+        window.focus()
+        notification.close()
 
-		    centerMap(lat, lng, 20)
-		  }
-	  } catch (e) {
-		  if (e.name === 'TypeError') {
+        centerMap(lat, lng, 20)
+      }
+    } catch (e) {
+      if (e.name === 'TypeError') {
         navigator.vibrate(1000)
       }
     }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1578,17 +1578,23 @@ function sendNotification (title, text, icon, lat, lng) {
   if (Notification.permission !== 'granted') {
     Notification.requestPermission()
   } else {
-    var notification = new Notification(title, {
-      icon: icon,
-      body: text,
-      sound: 'sounds/ding.mp3'
-    })
+	  try {
+		  var notification = new Notification(title, {
+		    icon: icon,
+		    body: text,
+		    sound: 'sounds/ding.mp3'
+		  })
 
-    notification.onclick = function () {
-      window.focus()
-      notification.close()
+		  notification.onclick = function () {
+		    window.focus()
+		    notification.close()
 
-      centerMap(lat, lng, 20)
+		    centerMap(lat, lng, 20)
+		  }
+	  } catch (e) {
+		  if (e.name === 'TypeError') {
+        navigator.vibrate(1000)
+      }
     }
   }
 }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1170,7 +1170,7 @@ function setupPokemonMarker (item, skipNotification, isBounceDisabled) {
   if (notifiedPokemon.indexOf(item['pokemon_id']) > -1 || notifiedRarity.indexOf(item['pokemon_rarity']) > -1) {
     if (!skipNotification) {
       if (Store.get('playSound')) {
-        createjs.Sound.play('ding');
+        createjs.Sound.play('ding')
       }
       sendNotification('A wild ' + item['pokemon_name'] + ' appeared!', 'Click to load map', 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
     }
@@ -1394,7 +1394,7 @@ function loadRawData () {
 
 function processPokemons (i, item) {
   if (!Store.get('showPokemon')) {
-    return false; // in case the checkbox was unchecked in the meantime.
+    return false // in case the checkbox was unchecked in the meantime.
   }
 
   if (!(item['encounter_id'] in mapData.pokemons) &&
@@ -1478,7 +1478,7 @@ function processLuredPokemon (i, item) {
 
 function processGyms (i, item) {
   if (!Store.get('showGyms')) {
-    return false; // in case the checkbox was unchecked in the meantime.
+    return false // in case the checkbox was unchecked in the meantime.
   }
 
   if (item['gym_id'] in mapData.gyms) {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -619,7 +619,7 @@ var mapData = {
   scanned: {}
 }
 var gymTypes = ['Uncontested', 'Mystic', 'Valor', 'Instinct']
-var audio = new Audio('static/sounds/ding.mp3')
+createjs.Sound.registerSound("static/sounds/ding.mp3", "ding")
 var pokemonSprites = {
   normal: {
     columns: 12,
@@ -1170,7 +1170,7 @@ function setupPokemonMarker (item, skipNotification, isBounceDisabled) {
   if (notifiedPokemon.indexOf(item['pokemon_id']) > -1 || notifiedRarity.indexOf(item['pokemon_rarity']) > -1) {
     if (!skipNotification) {
       if (Store.get('playSound')) {
-        audio.play()
+        createjs.Sound.play("ding");
       }
       sendNotification('A wild ' + item['pokemon_name'] + ' appeared!', 'Click to load map', 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
     }
@@ -1575,32 +1575,19 @@ function sendNotification (title, text, icon, lat, lng) {
     return false // Notifications are not present in browser
   }
 
-  if (Notification.permission !== 'granted') {
-    Notification.requestPermission()
-  } else {
-    try {
-      var notification = new Notification(title, {
-        icon: icon,
-        body: text,
-        sound: 'sounds/ding.mp3'
-      })
-
-      notification.onclick = function () {
+  if (Push.isSupported) {
+    Push.create(title, {
+      icon: icon,
+      body: text,
+      onClick: function () {
         window.focus()
-        notification.close()
-
+        this.close()
+		  
         centerMap(lat, lng, 20)
       }
-    } catch (e) {
-      if (e.name === 'TypeError') {
-        try {
-          navigator.vibrate(1000)
-        } catch (e) {
-          return false // If the browser doesn't support vibrate either, exit gracefully
-        }
-      }
-    }
+    })
   }
+  navigator.vibrate(1000)
 }
 
 function myLocationButton (map, marker) {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1593,7 +1593,11 @@ function sendNotification (title, text, icon, lat, lng) {
       }
     } catch (e) {
       if (e.name === 'TypeError') {
-        navigator.vibrate(1000)
+        try {
+          navigator.vibrate(1000)
+        } catch (e) {
+          return false // If the browser doesn't support vibrate either, exit gracefully
+        }
       }
     }
   }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1582,7 +1582,6 @@ function sendNotification (title, text, icon, lat, lng) {
       onClick: function () {
         window.focus()
         this.close()
-		  
         centerMap(lat, lng, 20)
       }
     })

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1582,6 +1582,7 @@ function sendNotification (title, text, icon, lat, lng) {
       onClick: function () {
         window.focus()
         this.close()
+
         centerMap(lat, lng, 20)
       }
     })

--- a/templates/map.html
+++ b/templates/map.html
@@ -218,6 +218,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.0/jquery-ui.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/skel/3.0.1/skel.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.3/js/select2.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/SoundJS/0.6.0/soundjs.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/push.js/0.0.10/push.min.js"></script>
     <script src="{{ url_for('static', filename='dist/js/app.min.js').lstrip('/') }}"></script>
     <script src="{{ url_for('static', filename='js/vendor/classie.js').lstrip('/') }}"></script>
     <script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes notifications from crashing the page on Android

## Motivation and Context
With notifications enabled while viewing on your phone, the page would crash, not showing any new Pokemon. This commit prevents the page from crashing, while still alerting a user of a nearby Pokemon by vibrating the phone for one second
https://github.com/PokemonGoMap/PokemonGo-Map/issues/418

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
