### PR TITLE
Opinionated login throttling

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -180,7 +180,7 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
 
     # If we have more than one account, stagger the logins such that they occur evenly over scan_delay
     if len(args.accounts) > 1:
-        if len(args.accounts) > args.scan_delay:  # force 1 second (with jitter) if you have many accounts
+        if len(args.accounts) > args.scan_delay:  # force ~1 second delay between threads if you have many accounts
             delay = args.accounts.index(account) \
                     + ((random.random() - .5) / 2) if args.accounts.index(account) > 0 else 0
         else:

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -182,7 +182,7 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
     if len(args.accounts) > 1:
         if len(args.accounts) > args.scan_delay:  # force ~1 second delay between threads if you have many accounts
             delay = args.accounts.index(account) \
-                    + ((random.random() - .5) / 2) if args.accounts.index(account) > 0 else 0
+                + ((random.random() - .5) / 2) if args.accounts.index(account) > 0 else 0
         else:
             delay = (args.scan_delay / len(args.accounts)) * args.accounts.index(account)
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -18,8 +18,10 @@ Search Architecture:
 '''
 
 import logging
-import time
 import math
+import random
+import time
+
 
 from threading import Thread, Lock
 from queue import Queue, Empty
@@ -178,7 +180,12 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
 
     # If we have more than one account, stagger the logins such that they occur evenly over scan_delay
     if len(args.accounts) > 1:
-        delay = (args.scan_delay / len(args.accounts)) * args.accounts.index(account)
+        if len(args.accounts) > args.scan_delay:  # force 1 second (with jitter) if you have many accounts
+            delay = args.accounts.index(account) \
+                    + ((random.random() - .5) / 2) if args.accounts.index(account) > 0 else 0
+        else:
+            delay = (args.scan_delay / len(args.accounts)) * args.accounts.index(account)
+
         log.debug('Delaying thread startup for %.2f seconds', delay)
         time.sleep(delay)
 


### PR DESCRIPTION
## Description
In #392, somebody has ~180 accounts.  Even with the recent code commits (to spread out logins over scan delay), that can still result in dozens of logins per second.

This commit essentially throttles logins to roughly one per second.  It adds some random jitter to the logins -- .25 seconds in either direction -- so that the load is still spread out evenly.

## Motivation and Context
People are breaking their own stuff and PTC's stuff with overly aggressive logins.

That said, with Niantic's IP-based throttling, I don't know how long mappers with this many accounts have to live anyways.

## How Has This Been Tested?
Works great on my system!

## Screenshots (if appropriate):
Here's what it looks like with 8 accounts and a scan delay of 1:

```
2016-08-11 09:51:20,219 [ search_worker_0][        search][   DEBUG] Delaying thread startup for 0.00 seconds
2016-08-11 09:51:20,244 [ search_worker_1][        search][   DEBUG] Delaying thread startup for 1.13 seconds
2016-08-11 09:51:20,249 [ search_worker_2][        search][   DEBUG] Delaying thread startup for 2.06 seconds
2016-08-11 09:51:20,250 [ search_worker_3][        search][   DEBUG] Delaying thread startup for 3.17 seconds
2016-08-11 09:51:20,250 [ search_worker_4][        search][   DEBUG] Delaying thread startup for 3.77 seconds
2016-08-11 09:51:20,250 [ search_worker_5][        search][   DEBUG] Delaying thread startup for 5.07 seconds
2016-08-11 09:51:20,250 [ search_worker_6][        search][   DEBUG] Delaying thread startup for 5.92 seconds
2016-08-11 09:51:20,266 [ search_worker_7][        search][   DEBUG] Delaying thread startup for 7.12 seconds
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
