### PR TITLE
Performance Impact displaying Stats

### DIFF
--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -23,16 +23,14 @@ function countMarkers () { // eslint-disable-line no-unused-vars
       pkmnTotal++
     })
     pkmnCount.sort(sortBy('Name', false))
-    $.each(mapData.pokemons, function (key, value) {
-      var pkmnListString = '<table><thead><tr><th>Icon</th><th>Name</th><th>Count</th><th>%</th></tr></thead><tbody><tr><td></td><td>Total</td><td>' + pkmnTotal + '</td><td></td></tr>'
-      for (var i = 0; i < pkmnCount.length; i++) {
-        if (pkmnCount[i] && pkmnCount[i].Count > 0) {
-          pkmnListString += '<tr><td><img src="static/icons/' + pkmnCount[i].ID + '.png" /></td><td><a href=\'http://www.pokemon.com/us/pokedex/' + pkmnCount[i].ID + '\' target=\'_blank\' title=\'View in Pokedex\' style="color: black;">' + pkmnCount[i].Name + '</a></td><td>' + pkmnCount[i].Count + '</td><td>' + Math.round(pkmnCount[i].Count * 100 / pkmnTotal * 10) / 10 + '%</td></tr>'
-        }
+    var pkmnListString = '<table><thead><tr><th>Icon</th><th>Name</th><th>Count</th><th>%</th></tr></thead><tbody><tr><td></td><td>Total</td><td>' + pkmnTotal + '</td><td></td></tr>'
+    for (var i = 0; i < pkmnCount.length; i++) {
+      if (pkmnCount[i] && pkmnCount[i].Count > 0) {
+        pkmnListString += '<tr><td><img src="static/icons/' + pkmnCount[i].ID + '.png" /></td><td><a href=\'http://www.pokemon.com/us/pokedex/' + pkmnCount[i].ID + '\' target=\'_blank\' title=\'View in Pokedex\' style="color: black;">' + pkmnCount[i].Name + '</a></td><td>' + pkmnCount[i].Count + '</td><td>' + Math.round(pkmnCount[i].Count * 100 / pkmnTotal * 10) / 10 + '%</td></tr>'
       }
-      pkmnListString += '</tbody></table>'
-      document.getElementById('pokemonList').innerHTML = pkmnListString
-    })
+    }
+    pkmnListString += '</tbody></table>'
+    document.getElementById('pokemonList').innerHTML = pkmnListString
   } else {
     document.getElementById('pokemonList').innerHTML = 'Pokémons markers are disabled'
   }
@@ -44,23 +42,23 @@ function countMarkers () { // eslint-disable-line no-unused-vars
         arenaCount[mapData.gyms[key]['team_id']] += 1
       }
       arenaTotal++
-      var arenaListString = '<table><th>Icon</th><th>Team Color</th><th>Count</th><th>%</th><tr><td></td><td>Total</td><td>' + arenaTotal + '</td></tr>'
-      for (var i = 0; i < arenaCount.length; i++) {
-        if (arenaCount[i] > 0) {
-          if (i === 1) {
-            arenaListString += '<tr><td><img src="static/forts/Mystic.png" /></td><td>' + 'Blue' + '</td><td>' + arenaCount[i] + '</td><td>' + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + '%</td></tr>'
-          } else if (i === 2) {
-            arenaListString += '<tr><td><img src="static/forts/Valor.png" /></td><td>' + 'Red' + '</td><td>' + arenaCount[i] + '</td><td>' + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + '%</td></tr>'
-          } else if (i === 3) {
-            arenaListString += '<tr><td><img src="static/forts/Instinct.png" /></td><td>' + 'Yellow' + '</td><td>' + arenaCount[i] + '</td><td>' + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + '%</td></tr>'
-          } else {
-            arenaListString += '<tr><td><img src="static/forts/Uncontested.png" /></td><td>' + 'Clear' + '</td><td>' + arenaCount[i] + '</td><td>' + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + '%</td></tr>'
-          }
+    })
+    var arenaListString = '<table><th>Icon</th><th>Team Color</th><th>Count</th><th>%</th><tr><td></td><td>Total</td><td>' + arenaTotal + '</td></tr>'
+    for (var i = 0; i < arenaCount.length; i++) {
+      if (arenaCount[i] > 0) {
+        if (i === 1) {
+          arenaListString += '<tr><td><img src="static/forts/Mystic.png" /></td><td>' + 'Blue' + '</td><td>' + arenaCount[i] + '</td><td>' + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + '%</td></tr>'
+        } else if (i === 2) {
+          arenaListString += '<tr><td><img src="static/forts/Valor.png" /></td><td>' + 'Red' + '</td><td>' + arenaCount[i] + '</td><td>' + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + '%</td></tr>'
+        } else if (i === 3) {
+          arenaListString += '<tr><td><img src="static/forts/Instinct.png" /></td><td>' + 'Yellow' + '</td><td>' + arenaCount[i] + '</td><td>' + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + '%</td></tr>'
+        } else {
+          arenaListString += '<tr><td><img src="static/forts/Uncontested.png" /></td><td>' + 'Clear' + '</td><td>' + arenaCount[i] + '</td><td>' + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + '%</td></tr>'
         }
       }
-      arenaListString += '</table>'
-      document.getElementById('arenaList').innerHTML = arenaListString
-    })
+    }
+    arenaListString += '</table>'
+    document.getElementById('arenaList').innerHTML = arenaListString
   } else {
     document.getElementById('arenaList').innerHTML = 'Gyms markers are disabled'
   }
@@ -80,19 +78,19 @@ function countMarkers () { // eslint-disable-line no-unused-vars
         }
       }
       pokestopTotal++
-      var pokestopListString = '<table><th>Icon</th><th>Status</th><th>Count</th><th>%</th><tr><td></td><td>Total</td><td>' + pokestopTotal + '</td></tr>'
-      for (var i = 0; i < pokestopCount.length; i++) {
-        if (pokestopCount[i] > 0) {
-          if (i === 0) {
-            pokestopListString += '<tr><td><img src="static/forts/Pstop.png" /></td><td>' + 'Not Lured' + '</td><td>' + pokestopCount[i] + '</td><td>' + Math.round(pokestopCount[i] * 100 / pokestopTotal * 10) / 10 + '%</td></tr>'
-          } else if (i === 1) {
-            pokestopListString += '<tr><td><img src="static/forts/PstopLured.png" /></td><td>' + 'Lured' + '</td><td>' + pokestopCount[i] + '</td><td>' + Math.round(pokestopCount[i] * 100 / pokestopTotal * 10) / 10 + '%</td></tr>'
-          }
+    })
+    var pokestopListString = '<table><th>Icon</th><th>Status</th><th>Count</th><th>%</th><tr><td></td><td>Total</td><td>' + pokestopTotal + '</td></tr>'
+    for (var i = 0; i < pokestopCount.length; i++) {
+      if (pokestopCount[i] > 0) {
+        if (i === 0) {
+          pokestopListString += '<tr><td><img src="static/forts/Pstop.png" /></td><td>' + 'Not Lured' + '</td><td>' + pokestopCount[i] + '</td><td>' + Math.round(pokestopCount[i] * 100 / pokestopTotal * 10) / 10 + '%</td></tr>'
+        } else if (i === 1) {
+          pokestopListString += '<tr><td><img src="static/forts/PstopLured.png" /></td><td>' + 'Lured' + '</td><td>' + pokestopCount[i] + '</td><td>' + Math.round(pokestopCount[i] * 100 / pokestopTotal * 10) / 10 + '%</td></tr>'
         }
       }
-      pokestopListString += '</table>'
-      document.getElementById('pokestopList').innerHTML = pokestopListString
-    })
+    }
+    pokestopListString += '</table>'
+    document.getElementById('pokestopList').innerHTML = pokestopListString
   } else {
     document.getElementById('pokestopList').innerHTML = 'PokéStops markers are disabled'
   }

--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -3,6 +3,7 @@ function countMarkers () { // eslint-disable-line no-unused-vars
   document.getElementById('stats-gym-label').innerHTML = 'Gyms'
   document.getElementById('stats-pkstop-label').innerHTML = 'PokéStops'
 
+  var i = 0
   var arenaCount = []
   var arenaTotal = 0
   var pkmnCount = []
@@ -24,7 +25,7 @@ function countMarkers () { // eslint-disable-line no-unused-vars
     })
     pkmnCount.sort(sortBy('Name', false))
     var pkmnListString = '<table><thead><tr><th>Icon</th><th>Name</th><th>Count</th><th>%</th></tr></thead><tbody><tr><td></td><td>Total</td><td>' + pkmnTotal + '</td><td></td></tr>'
-    for (var i = 0; i < pkmnCount.length; i++) {
+    for (i = 0; i < pkmnCount.length; i++) {
       if (pkmnCount[i] && pkmnCount[i].Count > 0) {
         pkmnListString += '<tr><td><img src="static/icons/' + pkmnCount[i].ID + '.png" /></td><td><a href=\'http://www.pokemon.com/us/pokedex/' + pkmnCount[i].ID + '\' target=\'_blank\' title=\'View in Pokedex\' style="color: black;">' + pkmnCount[i].Name + '</a></td><td>' + pkmnCount[i].Count + '</td><td>' + Math.round(pkmnCount[i].Count * 100 / pkmnTotal * 10) / 10 + '%</td></tr>'
       }
@@ -44,7 +45,7 @@ function countMarkers () { // eslint-disable-line no-unused-vars
       arenaTotal++
     })
     var arenaListString = '<table><th>Icon</th><th>Team Color</th><th>Count</th><th>%</th><tr><td></td><td>Total</td><td>' + arenaTotal + '</td></tr>'
-    for (var i = 0; i < arenaCount.length; i++) {
+    for (i = 0; i < arenaCount.length; i++) {
       if (arenaCount[i] > 0) {
         if (i === 1) {
           arenaListString += '<tr><td><img src="static/forts/Mystic.png" /></td><td>' + 'Blue' + '</td><td>' + arenaCount[i] + '</td><td>' + Math.round(arenaCount[i] * 100 / arenaTotal * 10) / 10 + '%</td></tr>'
@@ -80,7 +81,7 @@ function countMarkers () { // eslint-disable-line no-unused-vars
       pokestopTotal++
     })
     var pokestopListString = '<table><th>Icon</th><th>Status</th><th>Count</th><th>%</th><tr><td></td><td>Total</td><td>' + pokestopTotal + '</td></tr>'
-    for (var i = 0; i < pokestopCount.length; i++) {
+    for (i = 0; i < pokestopCount.length; i++) {
       if (pokestopCount[i] > 0) {
         if (i === 0) {
           pokestopListString += '<tr><td><img src="static/forts/Pstop.png" /></td><td>' + 'Not Lured' + '</td><td>' + pokestopCount[i] + '</td><td>' + Math.round(pokestopCount[i] * 100 / pokestopTotal * 10) / 10 + '%</td></tr>'


### PR DESCRIPTION
## Description
Moved updating innerHTML out of the calculation loops.
It was done inside the loops, while it should only be set once after the counting is done.

## Motivation and Context
Displaying Stats for larger mapData (e.g. 1,000+ Pokémon) was very slow and laggy.

## How Has This Been Tested?
Comparison of performance before and after the change.

## Screenshots:
![countmarkers](https://cloud.githubusercontent.com/assets/3057715/17592162/6d47928a-5fe1-11e6-86f3-d70238ae20a7.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
