### PR TITLE
Add updated time to gyms

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 args = get_args()
 flaskDb = FlaskDB()
 
-db_schema_version = 2
+db_schema_version = 3
 
 
 class MyRetryDB(RetryOperationalError, PooledMySQLDatabase):
@@ -241,6 +241,7 @@ class Gym(BaseModel):
     latitude = DoubleField()
     longitude = DoubleField()
     last_modified = DateTimeField(index=True)
+    updated_at = DateTimeField(default=datetime.utcnow)
 
     class Meta:
         indexes = ((('latitude', 'longitude'), False),)
@@ -514,6 +515,9 @@ def database_migrate(db, old_ver):
 
     if old_ver < 2:
         migrate(migrator.add_column('pokestop', 'encounter_id', CharField(max_length=50, null=True)))
+
+    if old_ver < 3:
+        migrate(migrator.add_column('gym', 'updated_at', DateTimeField(null=True)))
 
     # Update database schema version
     Versions.update(val=db_schema_version).where(Versions.key == 'schema_version').execute()

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1009,11 +1009,11 @@ function gymLabel (teamName, teamId, gymPoints, latitude, longitude, updatedAt) 
   var updatedAtStr
   if (updatedAt) {
     var updatedAtDate = new Date(updatedAt);
-    updatedAtStr = `${updatedAtDate.getMonth()+1}/${updatedAtDate.getDate()} ${pad(updatedAtDate.getHours())}:${pad(updatedAtDate.getMinutes())}`
+    updatedAtStr = `${updatedAtDate.getMonth() + 1}/${updatedAtDate.getDate()} ${pad(updatedAtDate.getHours())}:${pad(updatedAtDate.getMinutes())}`
   } else {
-    updatedAtStr = "Unknown"
+    updatedAtStr = 'Unknown'
   }
-  
+
   var str
   if (teamId === 0) {
     str = `

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1004,8 +1004,16 @@ function pokemonLabel (name, rarity, types, disappearTime, id, latitude, longitu
   return contentstring
 }
 
-function gymLabel (teamName, teamId, gymPoints, latitude, longitude) {
+function gymLabel (teamName, teamId, gymPoints, latitude, longitude, updatedAt) {
   var gymColor = ['0, 0, 0, .4', '74, 138, 202, .6', '240, 68, 58, .6', '254, 217, 40, .6']
+  var updatedAtStr
+  if (updatedAt) {
+    var updatedAtDate = new Date(updatedAt);
+    updatedAtStr = `${updatedAtDate.getMonth()+1}/${updatedAtDate.getDate()} ${pad(updatedAtDate.getHours())}:${pad(updatedAtDate.getMinutes())}`
+  } else {
+    updatedAtStr = "Unknown"
+  }
+  
   var str
   if (teamId === 0) {
     str = `
@@ -1017,6 +1025,9 @@ function gymLabel (teamName, teamId, gymPoints, latitude, longitude) {
           </div>
           <div>
             Location: ${latitude.toFixed(6)}, ${longitude.toFixed(7)}
+          </div>
+          <div>
+            Updated at: ${updatedAtStr}
           </div>
           <div>
             <a href='https://www.google.com/maps/dir/Current+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
@@ -1044,6 +1055,9 @@ function gymLabel (teamName, teamId, gymPoints, latitude, longitude) {
           </div>
           <div>
             Location: ${latitude.toFixed(6)}, ${longitude.toFixed(7)}
+          </div>
+          <div>
+            Updated at: ${updatedAtStr}
           </div>
           <div>
             <a href='https://www.google.com/maps/dir/Current+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
@@ -1194,7 +1208,7 @@ function setupGymMarker (item) {
   })
 
   marker.infoWindow = new google.maps.InfoWindow({
-    content: gymLabel(gymTypes[item['team_id']], item['team_id'], item['gym_points'], item['latitude'], item['longitude']),
+    content: gymLabel(gymTypes[item['team_id']], item['team_id'], item['gym_points'], item['latitude'], item['longitude'], item['updated_at']),
     disableAutoPan: true
   })
 
@@ -1204,7 +1218,7 @@ function setupGymMarker (item) {
 
 function updateGymMarker (item, marker) {
   marker.setIcon('static/forts/' + gymTypes[item['team_id']] + '.png')
-  marker.infoWindow.setContent(gymLabel(gymTypes[item['team_id']], item['team_id'], item['gym_points'], item['latitude'], item['longitude']))
+  marker.infoWindow.setContent(gymLabel(gymTypes[item['team_id']], item['team_id'], item['gym_points'], item['latitude'], item['longitude'], item['updated_at']))
   return marker
 }
 


### PR DESCRIPTION
## Description
Added last update time to gyms.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since gyms never expire off the map, the team/prestige info can be outdated. This lets you see at glance if the data is recent.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally using a SQLite database pre-schema versioning, migrations were successfully applied, and the map handles unknown dates cleanly.

## Screenshots (if appropriate):
https://i.imgur.com/1nGH7fS.png (known update time)
https://i.imgur.com/wAkUmR0.png (unknown)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

