### PR TITLE
Workaround for first search step returning 0/0/0 

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -292,6 +292,9 @@ def check_login(args, account, api, position):
 
     log.debug('Login for account %s successful', account['username'])
 
+    # To avoid first search step resulting 0/0/0
+    time.sleep(args.scan_delay)
+
 
 def map_request(api, position):
     try:

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -293,7 +293,7 @@ def check_login(args, account, api, position):
     log.debug('Login for account %s successful', account['username'])
 
     # To avoid first search step resulting 0/0/0
-    time.sleep(5)
+    time.sleep(10)
 
 
 def map_request(api, position):

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -293,7 +293,7 @@ def check_login(args, account, api, position):
     log.debug('Login for account %s successful', account['username'])
 
     # To avoid first search step resulting 0/0/0
-    time.sleep(args.scan_delay)
+    time.sleep(5)
 
 
 def map_request(api, position):


### PR DESCRIPTION
In response to issue #462 

I'm not sure if this is a valid solution but delaying after initial login does seem to resolve first search steps resulting 0/0/0.
