### PR TITLE
Added switch to disable dragging map marker

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1740,8 +1740,8 @@ function i8ln (word) {
 }
 
 function isTouchDevice () {
-  return 'ontouchstart' in window ||  // works on most browsers
-  navigator.maxTouchPoints;  // works on IE10/11 and Surface
+  // Should cover most browsers
+  return 'ontouchstart' in window || navigator.maxTouchPoints;
 }
 
 //

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -736,6 +736,10 @@ var StoreOptions = {
     default: false,
     type: StoreTypes.Boolean
   },
+  'lockMarker': {
+    default: isTouchDevice(), // default to true if touch device
+    type: StoreTypes.Boolean
+  },
   'startAtUserLocation': {
     default: false,
     type: StoreTypes.Boolean
@@ -891,7 +895,7 @@ function createSearchMarker () {
     },
     map: map,
     animation: google.maps.Animation.DROP,
-    draggable: true,
+    draggable: !Store.get('lockMarker'),
     zIndex: google.maps.Marker.MAX_ZINDEX + 1
   })
 
@@ -933,6 +937,7 @@ function initSidebar () {
   $('#lured-pokestops-only-switch').val(Store.get('showLuredPokestopsOnly'))
   $('#lured-pokestops-only-wrapper').toggle(Store.get('showPokestops'))
   $('#geoloc-switch').prop('checked', Store.get('geoLocate'))
+  $('#lock-marker-switch').prop('checked', Store.get('lockMarker'))
   $('#start-at-user-location-switch').prop('checked', Store.get('startAtUserLocation'))
   $('#scanned-switch').prop('checked', Store.get('showScanned'))
   $('#sound-switch').prop('checked', Store.get('playSound'))
@@ -1734,6 +1739,11 @@ function i8ln (word) {
   }
 }
 
+function isTouchDevice () {
+  return 'ontouchstart' in window ||  // works on most browsers
+  navigator.maxTouchPoints;  // works on IE10/11 and Surface
+}
+
 //
 // Page Ready Exection
 //
@@ -1973,6 +1983,11 @@ $(function () {
     } else {
       Store.set('geoLocate', this.checked)
     }
+  })
+
+  $('#lock-marker-switch').change(function () {
+    Store.set('lockMarker', this.checked)
+    marker.setDraggable(!this.checked)
   })
 
   $('#search-switch').change(function () {

--- a/templates/map.html
+++ b/templates/map.html
@@ -110,6 +110,16 @@
               </label>
             </div>
             <div class="form-control switch-container" style="display:{{is_fixed}}" >
+              <h3>Lock marker</h3>
+              <div class="onoffswitch">
+                <input id="lock-marker-switch" type="checkbox" name="lock-marker-switch" class="onoffswitch-checkbox" checked/>
+                <label class="onoffswitch-label" for="lock-marker-switch">
+                <span class="switch-label" data-on="On" data-off="Off"></span>
+                <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
+            <div class="form-control switch-container" style="display:{{is_fixed}}" >
               <h3>Scan follows location</h3>
               <div class="onoffswitch">
                 <input id="geoloc-switch" type="checkbox" name="geoloc-switch" class="onoffswitch-checkbox" checked/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a switch (client side) to enable / disable dragging of the marker on the map.  It defaults to disabled if the device has touch enabled.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It seemed too easy to accidentally drag the marker when moving the map, particularly on mobile, which would restart scanning.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Desktop:
Windows 7 - IE  11, Chrome 52, Firefox 48
Ubuntu 16.04 - Chrome 54

Mobile:
iPhone - iOS 9.3.2: Chrome 52, Safari,
Android 7: Chrome 52 mobile

## Screenshots (if appropriate):
![marker](https://cloud.githubusercontent.com/assets/16299710/17603185/9dbc1488-5fd5-11e6-8a02-cfd51d49011b.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.