### PR TITLE
Simplified and fixed scan retries

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -208,7 +208,6 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                 # The loop to try very hard to scan this step
                 failed_total = 0
                 while True:
- 
                     # Get current time
                     loop_start_time = time.time()
 


### PR DESCRIPTION
## Description
Scan retries had odd delay mechanism and the scan delay was not used after successful recovery after several retries.

## Motivation and Context
Scan retry works more as expected, `-sd 10 -sr 12` should try 10 times with roughly 120 seconds.
Fixing the scanner from bursting several tries over few seconds after recovering from retries.

## How Has This Been Tested?
Local instance, which is now returning less (0 pokemons, 0 stops, 0 gyms) due to no more burst after retries.

## Screenshots (if appropriate):

## Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Removed oddly custom delay between retries, and made it linear. (Ex. `-sd 10 -sr 12` should try up to 12 times with 10 delay each ~= 120 seconds at most.)  
Fixed scan burst issue occurring after successful recovery from retries.