### PR TITLE
Fixed Pokestop webhooks sending as Pokemon

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -349,10 +349,9 @@ def parse_map(map_dict, step_location):
                         'latitude': f['latitude'],
                         'longitude': f['longitude'],
                         'last_modified_time': f['last_modified_timestamp_ms'],
-                        'active_fort_modifier': f['active_fort_modifier'],
-                        'is_lured': True
+                        'active_fort_modifier': f['active_fort_modifier']
                     }
-                    send_to_webhook('pokemon', webhook_data)
+                    send_to_webhook('pokestop', webhook_data)
                 else:
                     lure_expiration, active_fort_modifier = None, None
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -334,8 +334,7 @@ def parse_map(map_dict, step_location):
                     'longitude': p['longitude'],
                     'disappear_time': calendar.timegm(d_t.timetuple()),
                     'last_modified_time': p['last_modified_timestamp_ms'],
-                    'time_until_hidden_ms': p['time_till_hidden_ms'],
-                    'is_lured': False
+                    'time_until_hidden_ms': p['time_till_hidden_ms']
                 }
 
                 send_to_webhook('pokemon', webhook_data)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed 'pokemon' to 'pokestop' for pokestop data
Removed is_lured field since no longer needed. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The webhooks need to specify what kind of data they are sending out. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran on local machine with webhooks being thrown.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

* Changed 'pokemon' to 'pokestop' in because it's really pokestop data, not pokemon
* Removed 'is_lured' field since no longer relevant.