### PR TITLE
Add username to "Search step %s map parsing failed..."

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -249,7 +249,7 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                             search_items_queue.task_done()
                             break  # All done, get out of the request-retry loop
                         except KeyError:
-                            log.exception('Search step %s map parsing failed, retrying request in %g seconds', step, sleep_time)
+                            log.exception('Search step %s map parsing failed, retrying request in %g seconds. Username: %s', step, sleep_time, account['username'])
                             failed_total += 1
                             time.sleep(sleep_time)
 


### PR DESCRIPTION
## Description
Add username to "Search step %s map parsing failed...".

## Motivation and Context
Currently it's pretty hard to determine which account fails in multi account setups.
See also 30eb247

## How Has This Been Tested?
Local test

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

