### PR TITLE
Removed duplicate results in Pokemon.get_seen

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -162,6 +162,7 @@ class Pokemon(BaseModel):
                          pokemon_count_query.c.count)
                  .join(pokemon_count_query, on=(Pokemon.pokemon_id == pokemon_count_query.c.pokemon_id))
                  .where(Pokemon.disappear_time == pokemon_count_query.c.lastappeared)
+                 .group_by(Pokemon.pokemon_id)
                  .dicts()
                  )
         pokemons = []


### PR DESCRIPTION
## Description
Removed duplicate pokemon in the results affecting total pokemon count in the full stats page.

This affected the total count making all percentage calculations erroneous and also making the outputted json data larger than it needed to be.

## What This Fixes
EVERYTHING! But more specifically the /stats page.
* Correct total count.
* Total count jumping around sporadically.
* Correct percentage.

## Motivation and Context
This bug was due to sending more than one result per pokemon if there were more than one with the same `lastappeared` time or more precisely `disappear_time`.

## How Has This Been Tested?
Double checked any other statistics and if they would be affected, no problems I could find.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.