### PR TITLE
Fix 595+ hour pokemon

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-
 import logging
 import calendar
 import sys
@@ -311,9 +310,14 @@ def parse_map(map_dict, step_location):
     for cell in cells:
         if config['parse_pokemon']:
             for p in cell.get('wild_pokemons', []):
-                d_t = datetime.utcfromtimestamp(
-                    (p['last_modified_timestamp_ms'] +
-                     p['time_till_hidden_ms']) / 1000.0)
+                # time_till_hidden_ms was overflowing causing a negative integer. It was also returning a value above 3.6M ms.
+                if (p['time_till_hidden_ms'] > 0 or p['last_modified_timestamp_ms'] < 3600000):
+                    d_t = datetime.utcfromtimestamp(
+                        (p['last_modified_timestamp_ms'] +
+                         p['time_till_hidden_ms']) / 1000.0)
+                else:
+                    # Set a value of 15 minutes because currently its unknown but larger than 15.
+                    d_t = datetime.utcfromtimestamp((p['last_modified_timestamp_ms'] + 900000) / 1000.0)
                 printPokemon(p['pokemon_data']['pokemon_id'], p['latitude'],
                              p['longitude'], d_t)
                 pokemons[p['encounter_id']] = {

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -311,7 +311,7 @@ def parse_map(map_dict, step_location):
         if config['parse_pokemon']:
             for p in cell.get('wild_pokemons', []):
                 # time_till_hidden_ms was overflowing causing a negative integer. It was also returning a value above 3.6M ms.
-                if (p['time_till_hidden_ms'] > 0 or p['time_till_hidden_ms'] < 3600000):
+                if (0 < p['time_till_hidden_ms'] < 3600000):
                     d_t = datetime.utcfromtimestamp(
                         (p['last_modified_timestamp_ms'] +
                          p['time_till_hidden_ms']) / 1000.0)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -311,7 +311,7 @@ def parse_map(map_dict, step_location):
         if config['parse_pokemon']:
             for p in cell.get('wild_pokemons', []):
                 # time_till_hidden_ms was overflowing causing a negative integer. It was also returning a value above 3.6M ms.
-                if (p['time_till_hidden_ms'] > 0 or p['last_modified_timestamp_ms'] < 3600000):
+                if (p['time_till_hidden_ms'] > 0 or p['time_till_hidden_ms'] < 3600000):
                     d_t = datetime.utcfromtimestamp(
                         (p['last_modified_timestamp_ms'] +
                          p['time_till_hidden_ms']) / 1000.0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Pokemon were showing up on the map with 595 hours remaining on their spawns

## Motivation and Context
Removes the +595 hour pokemon and handles the negative integer pokemon correctly.

## How Has This Been Tested?
Painfully. Very very painfully... Running with 2 accounts and multiple people's input we got it working. THANKS GUYS !

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

