### PR TITLE
Persistent Data of Pokemon Notifications/Exclusion

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1847,6 +1847,18 @@ $(function () {
     $selectRarityNotify.val(Store.get('remember_select_rarity_notify')).trigger('change')
   })
 
+  // Load saved list of pokemon to exclude and notify on map
+  $.getJSON('static/pokelist.json').done(function (data) {
+    Store.set('remember_select_exclude', data.exclude)
+    $selectExclude.val(Store.get('remember_select_exclude')).trigger('change')
+	
+    Store.set('remember_select_notify', data.notify)
+    $selectPokemonNotify.val(Store.get('remember_select_notify')).trigger('change')
+	
+	Store.set('remember_select_rarity_notify', data.rarity)
+    $selectRarityNotify.val(Store.get('remember_select_rarity_notify')).trigger('change')
+  })
+
   // run interval timers to regularly update map and timediffs
   window.setInterval(updateLabelDiffTime, 1000)
   window.setInterval(updateMap, 5000)

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1851,11 +1851,9 @@ $(function () {
   $.getJSON('static/pokelist.json').done(function (data) {
     Store.set('remember_select_exclude', data.exclude)
     $selectExclude.val(Store.get('remember_select_exclude')).trigger('change')
-	
     Store.set('remember_select_notify', data.notify)
     $selectPokemonNotify.val(Store.get('remember_select_notify')).trigger('change')
-	
-	Store.set('remember_select_rarity_notify', data.rarity)
+    Store.set('remember_select_rarity_notify', data.rarity)
     $selectRarityNotify.val(Store.get('remember_select_rarity_notify')).trigger('change')
   })
 

--- a/static/pokelist.json
+++ b/static/pokelist.json
@@ -1,0 +1,5 @@
+{
+ "exclude" : [16,20,19,96],
+ "notify"  : [3,6,9,150],
+ "rarity"  : ["Ultra Rare","Rare"]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When restarting the server and browser, the list of pokemons to notify/exclude/rarity are cleared. I've created json file to save those list so you don't have to keep updating the list. 

The file is located in ROOT/static/pokelist.json
It has a few pokemons already in the file to provide an example of how to modify it and also to make people aware of this file. Although this should be discussed if the json file should be empty so people dont think this is some kind of bug and mention this in the documentation. An alternative approach can be to include the location of pokelist.json in the placeholder text of the notify/exclude/rarity text boxes so people know where to look.

The contents of pokelist.json: Exlcludes pidgey, rattata, raticate, drowsee. Nofifies charizard, blastoise, venusaur, mewtwo
{
 "exclude" : [16,20,19,96],
 "notify"  : [3,6,9,150],
 "rarity"  : ["Ultra Rare","Rare"]
}

The order of the pokemon numbers are not important. Currently, this feature only reads data but doesn't write. For example, modifying the list in the browser will not update the pokelist.json file. 

## Motivation and Context
Many have requested for this feature. It also very hard clicking the map on mobile when there too many pokemon on the map.

## How Has This Been Tested?
I've tested this in Firefox and Chrome. Once the webpage loads. The list of pokemon from the file should appear in the corresponding dropbox menus of the Options tab.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
