### PR TITLE
Only add ssh client, not server to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,7 @@ ENTRYPOINT ["python", "./runserver.py", "--host", "0.0.0.0"]
 CMD ["-h"]
 
 # Install required system packages
-RUN apk add --no-cache ca-certificates
-RUN apk add --no-cache bash git openssh
+RUN apk add --no-cache ca-certificates git
 
 COPY requirements.txt /usr/src/app/
 


### PR DESCRIPTION
Atm openssh server componentens get installed, which is unneccessary, because only client components are needed for git+https deps in requirements.txt.

## Description
Changed `apk add [...] openssh` to `apk add [...] openssh-client`

## Motivation and Context
Docker image size is smaller.
Why have unneeded packages installed?
Security concerns...

## How Has This Been Tested?
Built new docker image, runs like a charm.

## Types of changes
- [X] Bug fix (kind of?)