### PR TITLE
Add basic support for SSL

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -27,6 +27,8 @@
 #host:                  # address to listen on (default 127.0.0.1)
 #port:                  # port to listen on (default 5000)
 #locale:                # pokemon translation
+#ssl-certificate:       # path to ssl certificate
+#ssl-privatekey:        # path to ssl private key
 
 #Uncomment a line when you want to change its default value (Remove # at the beginning)
 #username, password, location and gmaps-key are required

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -120,6 +120,8 @@ def get_args():
                         type=int, default=5)
     parser.add_argument('-wh', '--webhook', help='Define URL(s) to POST webhook information to',
                         nargs='*', default=False, dest='webhooks')
+    parser.add_argument('--ssl-certificate', help='Path to SSL certificate file')
+    parser.add_argument('--ssl-privatekey', help='Path to SSL private key file')
     parser.set_defaults(DEBUG=False)
 
     args = parser.parse_args()

--- a/runserver.py
+++ b/runserver.py
@@ -8,6 +8,7 @@ import logging
 import time
 import re
 import requests
+import ssl
 
 from distutils.version import StrictVersion
 
@@ -176,4 +177,10 @@ if __name__ == '__main__':
         while search_thread.is_alive():
             time.sleep(60)
     else:
-        app.run(threaded=True, use_reloader=False, debug=args.debug, host=args.host, port=args.port)
+        ssl_context = None
+        if args.ssl_certificate and args.ssl_privatekey:
+            ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+            ssl_context.load_cert_chain(args.ssl_certificate, args.ssl_privatekey)
+            log.info('Web server in SSL mode.')
+
+        app.run(threaded=True, use_reloader=False, debug=args.debug, host=args.host, port=args.port, ssl_context=ssl_context)

--- a/runserver.py
+++ b/runserver.py
@@ -178,7 +178,8 @@ if __name__ == '__main__':
             time.sleep(60)
     else:
         ssl_context = None
-        if args.ssl_certificate and args.ssl_privatekey:
+        if args.ssl_certificate and args.ssl_privatekey \
+                and os.path.exists(args.ssl_certificate) and os.path.exists(args.ssl_privatekey):
             ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
             ssl_context.load_cert_chain(args.ssl_certificate, args.ssl_privatekey)
             log.info('Web server in SSL mode.')


### PR DESCRIPTION
## Description
Add basic support for SSL via 2 new args ``--ssl-certificate`` and ``--ssl-privatekey``

## Motivation and Context
I've read recommendations for users who require https (to enable geolocation for example) to do so via nginx/apache configuration (#316). I run this on an old laptop at home with port forwarding + dynamic dns which allows me to access the map on the run. In my case, a full blown webserver is overkill. With Letsencrypt and their support for dns challenges, it is feasible imo to provide basic SSL support with the built-in webserver.

## How Has This Been Tested?
Tested this in Chrome (OSX, Android), Firefox (OSX). Green lock appears fine. Geolocation features e.g. "Scan follows location" works as expected on mobile and desktop.

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

