### PR TITLE
Fix `docker stop` running into a timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ EXPOSE 5000
 WORKDIR /usr/src/app
 
 # Set Entrypoint with hard-coded options
-ENTRYPOINT ["python", "./runserver.py", "--host", "0.0.0.0"]
+ENTRYPOINT ["dumb-init", "-r", "15:2", "python", "./runserver.py", "--host", "0.0.0.0"]
 
 # Set default options when container is run without any command line arguments
 CMD ["-h"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ requests==2.10.0
 PySocks==1.5.6
 git+https://github.com/ChrisTM/Flask-CacheBust.git@aa09ad861f104f987928fe9f5107ccfe0e4473c3#egg=flask_cachebust
 protobuf_to_dict==0.1.0
+dumb-init==1.1.3


### PR DESCRIPTION
`docker stop` running into a timeout, takes 10 unnecessary seconds to complete.
While `Dockerfile` supports `STOPSIGNAL` directive from version 1.9 on, this version is not widely used yet. Adding it would break support for many users.

## Description
Adds wrapper.sh file, to be used by `Dockerfile`.
`wrapper.sh` traps SIGTERM which is used by `docker stop` by default, and sends SIGINT to pyhton. It's not graceful either, but it will make `docker stop` exit in less than a second.

`ENTRYPOINT` and `CMD` directives in `Dockerfile` and `docker run` cli arguments can still be used like before. Just inserted "sh", "wrapper.sh" at the beginning of `ENTRYPOINT`

## Motivation and Context
Reduce `docker stop` time by factor >10. Just very inconvenient to wait 10 seconds for each worker when redeploying new containers.

## How Has This Been Tested?
* `docker run ....`
* `docker stop ...` finishes in <1 sec
* `docker log -tail 10 ...`
* output reads "forwarding SIGTERM as SIGINT" (meaning trap function was actually called)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)