### PR TITLE
Include the option db-port in config.ini.example

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -9,6 +9,7 @@
 #db-name:               # required for mysql
 #db-user:               # required for mysql
 #db-pass:               # required for mysql
+#db-port:               # default 3306
 
 # Search settings
 #location:


### PR DESCRIPTION

## Description
Added db-port option to the config.ini.example.
## Motivation and Context
Just a small change so you don't have do give the --db-port argument for every worker
## How Has This Been Tested?
Ran the pokemon go map searcher + server


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

