### PR TITLE
Catch notification exceptions to prevent Android Chrome js errors

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1512,24 +1512,37 @@ function getPointDistance (pointA, pointB) {
 }
 
 function sendNotification (title, text, icon, lat, lng) {
-  if (!('Notification' in window)) {
-    return false // Notifications are not present in browser
-  }
+  try
+  {
+    if (!('Notification' in window)) {
+      return false // Notifications are not present in browser
+    }
 
-  if (Notification.permission !== 'granted') {
-    Notification.requestPermission()
-  } else {
-    var notification = new Notification(title, {
-      icon: icon,
-      body: text,
-      sound: 'sounds/ding.mp3'
-    })
+    if (Notification.permission !== 'granted') {
+      Notification.requestPermission()
+    } else {
+      var notification = new Notification(title, {
+        icon: icon,
+        body: text,
+        sound: 'sounds/ding.mp3'
+      })
 
-    notification.onclick = function () {
-      window.focus()
-      notification.close()
+      notification.onclick = function () {
+        window.focus()
+        notification.close()
 
-      centerMap(lat, lng, 20)
+        centerMap(lat, lng, 20)
+      }
+    }
+  }        
+  catch(e) // Gotta catch em all!
+  {
+    // Some browsers will throw when creating the Notifcation object, 
+    // with an error pointing us towards ServiceWorkerRegistration.showNotification.
+    // Just eat exceptions until someone can implement that.
+    
+    if ( window.console ) {
+      console.log(e)
     }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Chrome on Android throws js exceptions when notifying for pokemon. The window.Notification type exists, but attempting to create a new Notification object throws an error that tell you to use ServiceWorkerRegistration.showNotification instead. This simply catches the exception, so notifications dont cause the js to error out and break the app. 



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issue 418 and 338, maybe others

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
