### PR TITLE
Remove semicolon exception from eslint ruleset

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,8 +29,5 @@
     "darkStyleNoLabels": true,
     "light2StyleNoLabels": true,
     "pGoStyleNoLabels": true
-  },
-  "rules": {
-    "semi": 0
   }
 }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1400,7 +1400,7 @@ function loadRawData () {
 
 function processPokemons (i, item) {
   if (!Store.get('showPokemon')) {
-    return false; // in case the checkbox was unchecked in the meantime.
+    return false // in case the checkbox was unchecked in the meantime.
   }
 
   if (!(item['encounter_id'] in mapData.pokemons) &&
@@ -1448,7 +1448,7 @@ function processPokestops (i, item) {
 
 function processGyms (i, item) {
   if (!Store.get('showGyms')) {
-    return false; // in case the checkbox was unchecked in the meantime.
+    return false // in case the checkbox was unchecked in the meantime.
   }
 
   if (item['gym_id'] in mapData.gyms) {
@@ -1727,7 +1727,7 @@ function i8ln (word) {
 
 function isTouchDevice () {
   // Should cover most browsers
-  return 'ontouchstart' in window || navigator.maxTouchPoints;
+  return 'ontouchstart' in window || navigator.maxTouchPoints
 }
 
 //

--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -95,7 +95,7 @@ function addElement (pokemonId, name) {
 }
 
 function processSeen (seen) {
-  var i;
+  var i
   var total = seen.total
   var shown = []
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Currently eslint has on exception to the StandardJS ruleset. That exception allows semicolons, but it does not enforce removing semicolons nor adding them.

This PR removes that exception, which results in enforced removal of semicolons as per StandardJS ruleset.

Related to #378

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
