### PR TITLE
Added spawnpoints-only mode to beehive

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -21,7 +21,7 @@ import logging
 import math
 import random
 import time
-
+import geopy.distance as geopy_distance
 
 from threading import Thread, Lock
 from queue import Queue, Empty
@@ -31,7 +31,7 @@ from pgoapi.utilities import f2i
 from pgoapi import utilities as util
 from pgoapi.exceptions import AuthException
 
-from .models import parse_map
+from .models import parse_map, Pokemon
 
 log = logging.getLogger(__name__)
 
@@ -129,6 +129,8 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
 
     # A place to track the current location
     current_location = False
+    locations = []
+    spawnpoints = set()
 
     # The real work starts here but will halt on pause_bit.set()
     while True:
@@ -161,11 +163,33 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
                 except Empty:
                     pass
 
+            # update our list of coords
+            locations = list(generate_location_steps(current_location, args.step_limit))
+
+            # repopulate our spawn points
+            if args.spawnpoints_only:
+                # We need to get all spawnpoints in range. This is a square 70m * step_limit * 2
+                sp_dist = 0.07 * 2 * args.step_limit
+                log.debug('Spawnpoint search radius: %f', sp_dist)
+                # generate coords of the midpoints of each edge of the square
+                south, west = get_new_coords(current_location, sp_dist, 180), get_new_coords(current_location, sp_dist, 270)
+                north, east = get_new_coords(current_location, sp_dist, 0), get_new_coords(current_location, sp_dist, 90)
+                # Use the midpoints to arrive at the corners
+                log.debug('Searching for spawnpoints between %f, %f and %f, %f', south[0], west[1], north[0], east[1])
+                spawnpoints = set((d['latitude'], d['longitude']) for d in Pokemon.get_spawnpoints(south[0], west[1], north[0], east[1]))
+                if len(spawnpoints) == 0:
+                    log.warning('No spawnpoints found in the specified area! (Did you forget to run a normal scan in this area first?)')
+                any_spawnpoints_in_range = lambda coords: any(geopy_distance.distance(coords, x).meters <= 70 for x in spawnpoints)  # NOQA
+                locations = [x for x in locations if any_spawnpoints_in_range(x)]
+
+            if len(locations) == 0:
+                log.warning('Nothing to scan!')
+
         # If there are no search_items_queue either the loop has finished (or been
         # cleared above) -- either way, time to fill it back up
         if search_items_queue.empty():
             log.debug('Search queue empty, restarting loop')
-            for step, step_location in enumerate(generate_location_steps(current_location, args.step_limit), 1):
+            for step, step_location in enumerate(locations, 1):
                 log.debug('Queueing step %d @ %f/%f/%f', step, step_location[0], step_location[1], step_location[2])
                 search_args = (step, step_location)
                 search_items_queue.put(search_args)

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -179,8 +179,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
                 spawnpoints = set((d['latitude'], d['longitude']) for d in Pokemon.get_spawnpoints(south[0], west[1], north[0], east[1]))
                 if len(spawnpoints) == 0:
                     log.warning('No spawnpoints found in the specified area! (Did you forget to run a normal scan in this area first?)')
-                any_spawnpoints_in_range = lambda coords: any(geopy_distance.distance(coords, x).meters <= 70 for x in spawnpoints)  # NOQA
-                locations = [x for x in locations if any_spawnpoints_in_range(x)]
+                locations = [coords for coords in locations if any(geopy_distance.distance(coords, x).meters <= 70 for x in spawnpoints)]
 
             if len(locations) == 0:
                 log.warning('Nothing to scan!')

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -103,6 +103,8 @@ def get_args():
     parser.add_argument('-k', '--gmaps-key',
                         help='Google Maps Javascript API Key',
                         required=True)
+    parser.add_argument('--spawnpoints-only', help='Only scan locations with spawnpoints in them.',
+                        action='store_true', default=False)
     parser.add_argument('-C', '--cors', help='Enable CORS on web server',
                         action='store_true', default=False)
     parser.add_argument('-D', '--db', help='Database filename',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Beehive can be quite inefficient, scanning over and over areas that have no spawnpoints. I've implemented this PR to automatically remove areas without spawnpoints from beehive's searches.

## Motivation and Context
Implemented as a proof of concept of filtering a search location based on spawnpoints. This is a useful proof of concept, though, in that it significantly reduces the work needed to scan an area with beehive, once spawnpoints have been collected. It's kind of a hybrid beehive/spawnpoint scanner that's a quick way to get some benefits of spawnpoint scanning.

When using this option, it's possible to reduce the number of accounts or increase the scan delay time and still scan the same area in the same time. Useful if you're being rate-limited or live in a rural area.

Also, generated locations are now cached in a list instead of being re-computed every time.

## How Has This Been Tested?
I ran both in spawnpoints mode and regular mode.

## Screenshots (if appropriate):
![image](https://cloud.githubusercontent.com/assets/5599341/17645960/70b64cc4-6183-11e6-9937-96f5f15bb9c5.png)

![image](https://cloud.githubusercontent.com/assets/5599341/17646223/feb62340-618e-11e6-80c9-3f1d6f359a7e.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

