### PR TITLE
Added basic authentication to scan location change

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -13,6 +13,7 @@
 
 # Search settings
 #location:
+#tokens:                # token for scan location change authority
 #no-gyms:               # disables gym scanning (default false)
 #no-pokemon:            # disables pokemon scanning (default false)
 #no-pokestops:          # disables pokestop scanning (default false)

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -128,15 +128,23 @@ class Pogom(Flask):
         if request.args:
             lat = request.args.get('lat', type=float)
             lon = request.args.get('lon', type=float)
+            userToken = request.args.get('userToken', type=str)
         # from post requests
         if request.form:
             lat = request.form.get('lat', type=float)
             lon = request.form.get('lon', type=float)
+            userToken = request.args.get('userToken', type=str)
 
         if not (lat and lon):
             log.warning('Invalid next location: %s,%s', lat, lon)
             return 'bad parameters', 400
         else:
+            if args.tokens:
+                if userToken in args.tokens:
+                    log.info('userToken check PASSED: %s                     ---- %s ----', userToken, request.remote_addr)
+                else:
+                    log.info('userToken check FAILED: %s                     ---- %s ----', userToken, request.remote_addr)
+                    return 'bad token', 401
             self.location_queue.put((lat, lon, 0))
             self.set_current_location((lat, lon, 0))
             log.info('Changing next location: %s,%s', lat, lon)

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -51,6 +51,14 @@ class Pogom(Flask):
         if not args.search_control:
             return 'Search control is disabled', 403
         action = request.args.get('action', 'none')
+        userToken = request.args.get('userToken', type=str)
+
+        if args.tokens:
+            if userToken in args.tokens:
+                log.info('userToken check PASSED: %s                     ---- %s ----', userToken, request.remote_addr)
+            else:
+                log.info('userToken check FAILED: %s                     ---- %s ----', userToken, request.remote_addr)
+                return 'bad token', 401
         if action == 'on':
             self.search_control.clear()
             log.info('Search thread resumed')

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -65,6 +65,7 @@ class Pogom(Flask):
         args = get_args()
         fixed_display = "none" if args.fixed_location else "inline"
         search_display = "inline" if args.search_control else "none"
+        authentication_display = "fixed" if args.tokens else "none"
 
         return render_template('map.html',
                                lat=self.current_location[0],
@@ -72,7 +73,8 @@ class Pogom(Flask):
                                gmaps_key=config['GMAPS_KEY'],
                                lang=config['LOCALE'],
                                is_fixed=fixed_display,
-                               search_control=search_display
+                               search_control=search_display,
+                               authentication_control=authentication_display
                                )
 
     def raw_data(self):

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -56,6 +56,8 @@ def get_args():
                         help='Passwords, either single one for all accounts or one per account.')
     parser.add_argument('-l', '--location', type=parse_unicode,
                         help='Location, can be an address or coordinates')
+    parser.add_argument('-t', '--tokens', action='append',
+                        help='Enable token requirement on /next_loc API')
     parser.add_argument('-st', '--step-limit', help='Steps', type=int,
                         default=12)
     parser.add_argument('-sd', '--scan-delay',

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -2,6 +2,7 @@
   'use strict'
 
   // Methods/polyfills.
+  $('#userToken').val(document.cookie)
 
   // addEventsListener
   var addEventsListener = function (o, t, e) {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -2,7 +2,6 @@
   'use strict'
 
   // Methods/polyfills.
-  $('#userToken').val(document.cookie)
 
   // addEventsListener
   var addEventsListener = function (o, t, e) {
@@ -157,6 +156,9 @@
     $statsClose.tabIndex = 0
     $stats.appendChild($statsClose)
   }
+
+  // Fill user token field from cookie
+  $('#userToken').val(document.cookie)
 
   // Event: Hide on ESC.
   window.addEventListener('keydown', function (event) {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1689,7 +1689,19 @@ function changeLocation (lat, lng) {
 }
 
 function changeSearchLocation (lat, lng) {
-  return $.post('next_loc?lat=' + lat + '&lon=' + lng, {})
+  return $.post('next_loc?lat=' + lat + '&lon=' + lng + '&userToken=' + getToken(), {})
+}
+
+function getToken () {
+  var userToken = $('#userToken').val()
+  if (userToken == "") {
+    userToken = document.cookie;
+    $('#userToken').val(userToken)
+  } else {
+    document.cookie = userToken;
+  }
+
+  return userToken
 }
 
 function centerMap (lat, lng, zoom) {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1694,11 +1694,11 @@ function changeSearchLocation (lat, lng) {
 
 function getToken () {
   var userToken = $('#userToken').val()
-  if (userToken == "") {
-    userToken = document.cookie;
+  if (userToken === '') {
+    userToken = document.cookie
     $('#userToken').val(userToken)
   } else {
-    document.cookie = userToken;
+    document.cookie = userToken
   }
 
   return userToken

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -923,7 +923,7 @@ function createSearchMarker () {
 
 var searchControlURI = 'search_control'
 function searchControl (action) {
-  $.post(searchControlURI + '?action=' + encodeURIComponent(action))
+  $.post(searchControlURI + '?action=' + encodeURIComponent(action) + '&userToken=' + getToken())
 }
 function updateSearchStatus () {
   $.getJSON(searchControlURI).then(function (data) {

--- a/templates/map.html
+++ b/templates/map.html
@@ -114,6 +114,10 @@
           <h3>Location Settings</h3>
           <div>
             <div class="form-control switch-container" style="display:{{is_fixed}}" >
+              <h3>Scan location authentication</h3>
+              <input id="userToken" type="password" name="userToken" placeholder="Please input user token">
+            </div>
+            <div class="form-control switch-container" style="display:{{is_fixed}}" >
               <label for="next-location">
               <h3>Change scan location</h3>
               <input id="next-location" type="text" name="next-location" placeholder="Change your location">

--- a/templates/map.html
+++ b/templates/map.html
@@ -113,7 +113,7 @@
 
           <h3>Location Settings</h3>
           <div>
-            <div class="form-control switch-container" style="display:{{is_fixed}}" >
+            <div class="form-control switch-container" style="display:{{authentication_control}}" >
               <h3>Scan location authentication</h3>
               <input id="userToken" type="password" name="userToken" placeholder="Please input user token">
             </div>


### PR DESCRIPTION
## Description
Added -t command line and tokens config.ini options to set an authentication requirement for scan location changes 

## Motivation and Context
I like to share viewing access of my public instance of PokemonGo-Map with trainers I often meet at PokéStops and Gyms. The problem arose that everyone was trigger happy, causing the search location to jump wildly across the city, preventing a complete scan of each area. By restricting users without a token/password to view-only access, it should limit this issue.

## How Has This Been Tested?
1. With command line argument
2. With config.ini
3. Not configured

## Screenshots (if appropriate):

- Entry field is visible only if server is configured for it
![image](https://cloud.githubusercontent.com/assets/3058438/17647062/6f0c4ba8-61e2-11e6-912b-746b1579755d.png)

- Example config
![image](https://cloud.githubusercontent.com/assets/3058438/17647065/9e9aad6a-61e2-11e6-8afa-132342297035.png)

- 401 on authentication failure
![image](https://cloud.githubusercontent.com/assets/3058438/17647074/086acfb8-61e3-11e6-975a-a21a9590269f.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
(Travis CI informed me of my errors - fixed)
- [x] My change requires a change to the documentation.
(ddition to command line documentation)
- [ ] I have updated the documentation accordingly.
(If this PR gets accepted, I will certainly update the wiki!)

## Notes
This is really basic plaintext authentication! Unhashed password is stored as cookie!

TODO: stop using plaintext ;)
