### PR TITLE
Remove dynamic location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ src/
 _build
 _build_html
 beehive.*
+config/ssl*

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -109,7 +109,7 @@ def fake_search_loop():
 
 
 # The main search loop that keeps an eye on the over all process
-def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_path):
+def search_overseer_thread(args, pause_bit, encryption_lib_path):
 
     log.info('Search overseer starting')
 
@@ -143,23 +143,6 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
                     pass
             time.sleep(1)
             continue
-
-        # If a new location has been passed to us, get the most recent one
-        if not new_location_queue.empty():
-            log.info('New location caught, moving search grid')
-            try:
-                while True:
-                    current_location = new_location_queue.get_nowait()
-            except Empty:
-                pass
-
-            # We (may) need to clear the search_items_queue
-            if not search_items_queue.empty():
-                try:
-                    while True:
-                        search_items_queue.get_nowait()
-                except Empty:
-                    pass
 
         # If there are no search_items_queue either the loop has finished (or been
         # cleared above) -- either way, time to fill it back up

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -97,9 +97,6 @@ def get_args():
     parser.add_argument('-nsc', '--no-search-control',
                         help='Disables search control',
                         action='store_false', dest='search_control', default=True)
-    parser.add_argument('-fl', '--fixed-location',
-                        help='Hides the search bar for use in shared maps.',
-                        action='store_true', default=False)
     parser.add_argument('-k', '--gmaps-key',
                         help='Google Maps Javascript API Key',
                         required=True)

--- a/runserver.py
+++ b/runserver.py
@@ -142,15 +142,11 @@ if __name__ == '__main__':
     pause_bit = Event()
     pause_bit.clear()
 
-    # Setup the location tracking queue and push the first location on
-    new_location_queue = Queue()
-    new_location_queue.put(position)
-
     if not args.only_server:
         # Gather the pokemons!
         if not args.mock:
             log.debug('Starting a real search thread')
-            search_thread = Thread(target=search_overseer_thread, args=(args, new_location_queue, pause_bit, encryption_lib_path))
+            search_thread = Thread(target=search_overseer_thread, args=(args, pause_bit, encryption_lib_path))
         else:
             log.debug('Starting a fake search thread')
             insert_mock_data(position)
@@ -167,7 +163,7 @@ if __name__ == '__main__':
     init_cache_busting(app)
 
     app.set_search_control(pause_bit)
-    app.set_location_queue(new_location_queue)
+    app.set_current_location(position)
 
     config['ROOT_PATH'] = app.root_path
     config['GMAPS_KEY'] = args.gmaps_key

--- a/runserver.py
+++ b/runserver.py
@@ -13,7 +13,6 @@ import ssl
 from distutils.version import StrictVersion
 
 from threading import Thread, Event
-from queue import Queue
 from flask_cors import CORS
 from flask_cache_bust import init_cache_busting
 

--- a/templates/map.html
+++ b/templates/map.html
@@ -113,32 +113,6 @@
 
           <h3>Location Settings</h3>
           <div>
-            <div class="form-control switch-container" style="display:{{is_fixed}}" >
-              <label for="next-location">
-              <h3>Change scan location</h3>
-              <input id="next-location" type="text" name="next-location" placeholder="Change your location">
-              </label>
-            </div>
-            <div class="form-control switch-container" style="display:{{is_fixed}}" >
-              <h3>Lock marker</h3>
-              <div class="onoffswitch">
-                <input id="lock-marker-switch" type="checkbox" name="lock-marker-switch" class="onoffswitch-checkbox" checked/>
-                <label class="onoffswitch-label" for="lock-marker-switch">
-                <span class="switch-label" data-on="On" data-off="Off"></span>
-                <span class="switch-handle"></span>
-                </label>
-              </div>
-            </div>
-            <div class="form-control switch-container" style="display:{{is_fixed}}" >
-              <h3>Scan follows location</h3>
-              <div class="onoffswitch">
-                <input id="geoloc-switch" type="checkbox" name="geoloc-switch" class="onoffswitch-checkbox" checked/>
-                <label class="onoffswitch-label" for="geoloc-switch">
-                <span class="switch-label" data-on="On" data-off="Off"></span>
-                <span class="switch-handle"></span>
-                </label>
-              </div>
-            </div>
             <div class="form-control switch-container" >
               <h3>Start at user's location</h3>
               <div class="onoffswitch">


### PR DESCRIPTION
This tears out the client-side location changing system.

When scanning was much, much faster, it made lots of sense to have a
"pulse" of scans running around you and to reset your scan origin
location frequently without worry.

Now that we're getting closer to the realization that spawed pokemon
are scheduled, rather than randomly discovered, optimizations wiil be
coming down the pipe to greatly increase the scan rate for huge areas.

Additionally, this feature added a lot of confusing complexity for
people that ended up sharing their map with others (who controlled
the search center? Who knows!)

With these things in mind, it no longer makes sense to have the web
app "follow" a single user around, but instead have several relatively
large areas pre-mapped so that a user can roam within those freely
while the application takes care of optimally finding pokemon.
(As opposed to a user having a very small scan area that constantly
pulses around them.)