### PR TITLE
Add server conf option to manually specify encrypt lib location

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -31,6 +31,7 @@
 #locale:                # pokemon translation
 #ssl-certificate:       # path to ssl certificate
 #ssl-privatekey:        # path to ssl private key
+#encrypt-lib:           # path to encrypt lib to be used instead of the shipped ones
 
 #Uncomment a line when you want to change its default value (Remove # at the beginning)
 #username, password, location and gmaps-key are required

--- a/runserver.py
+++ b/runserver.py
@@ -57,12 +57,12 @@ if not hasattr(pgoapi, "__version__") or StrictVersion(pgoapi.__version__) < Str
 
 
 def main():
+    args = get_args()
+
     # Check if we have the proper encryption library file and get its path
-    encryption_lib_path = get_encryption_lib_path()
+    encryption_lib_path = get_encryption_lib_path(args)
     if encryption_lib_path is "":
         sys.exit(1)
-
-    args = get_args()
 
     if args.debug:
         log.setLevel(logging.DEBUG)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add config option '-el', '--encrypt-lib' to manually specify encrypt lib location

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since PokemonGo-Map relies on a native C encrypt library, it currently works only on a fixed set of systems and archs, for which this library is provided. However, with this change it can be ported to any system that has the needed prerequisites, with an additional step of compiling encrypt lib for the platform and specifying its location with the newly added parameter

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested to work on a MIPSEL router with manually compiled libencrypt.so

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

This allows running server on any system that has necessary prerequisites and compiled encrypt lib available