### PR TITLE
Don't keep parse lock after map parse fail

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -276,7 +276,6 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                         continue
 
                     # Got the response, lock for parsing and do so (or fail, whatever)
-                    fail_wait = False
                     with parse_lock:
                         try:
                             parse_map(response_dict, step_location)
@@ -286,9 +285,7 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                         except KeyError:
                             log.exception('Search step %s map parsing failed, retrying request in %g seconds. Username: %s', step, sleep_time, account['username'])
                             failed_total += 1
-                            fail_wait = True
-                    if fail_wait:
-                        time.sleep(sleep_time)
+                    time.sleep(sleep_time)
 
                 # If there's any time left between the start time and the time when we should be kicking off the next
                 # loop, hang out until its up.

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -276,6 +276,7 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                         continue
 
                     # Got the response, lock for parsing and do so (or fail, whatever)
+                    fail_wait = False
                     with parse_lock:
                         try:
                             parse_map(response_dict, step_location)
@@ -285,7 +286,9 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                         except KeyError:
                             log.exception('Search step %s map parsing failed, retrying request in %g seconds. Username: %s', step, sleep_time, account['username'])
                             failed_total += 1
-                            time.sleep(sleep_time)
+                            fail_wait = True
+                    if fail_wait:
+                        time.sleep(sleep_time)
 
                 # If there's any time left between the start time and the time when we should be kicking off the next
                 # loop, hang out until its up.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If there was a map parse fail, it would hold the map parse lock while it waited for a retry. Change it so that it releases the lock before it waits.
<!--- Describe your changes in detail -->

## Motivation and Context
This allows other threads to continue while we wait to retry the failed thread.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Ran it on my Windows computer with 10 accounts.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

