### PR TITLE
Added velocity limiter

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -138,6 +138,8 @@ def get_args():
                         nargs='*', default=False, dest='webhooks')
     parser.add_argument('--ssl-certificate', help='Path to SSL certificate file')
     parser.add_argument('--ssl-privatekey', help='Path to SSL private key file')
+    parser.add_argument('--max-speed', help='Maximum speed a scanner can "travel" between scan locations in meters/second \
+                        (0 to disable). Defaults to 24 (88 km/h or 55 mph).', type=float, default=24)
     parser.set_defaults(DEBUG=False)
 
     args = parser.parse_args()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds support for velocity limiting of worker movements. Eliminates teleporting while scanning, especially with the new spawnpoint-based beehive. When the worker moves to a new location, it will calculate the velocity it 'moved' at. If this is higher than some target velocity, it will delay sufficient time before scanning to 'fake' the target velocity. In effect, it's an adaptive scan delay.

It also prints a warning:

```2016-08-14 20:18:27,793 [ search_worker_0][        search][ WARNING] Worker moving faster (94.37 m/s) than maximum allowed (24.00 m/s). Slowing things down. You need more accounts or a longer scan delay (hint: use -sd option)```

This warning might want to be refactored a bit or even changed to a debug line - I'm open to suggestions.

This WILL slow down scans, even multi-account scans, since every worker is essentially in a car. This could be reduced/alleviated by non-sequential scans like spawnpoints (so workers aren't 'driving' past each other constantly) or else a distance-based method of selecting the next scan area... or even assigning workers pie-slice shaped wedges of the scan area.

## Motivation and Context
Teleporting is an easy way to get banned

## How Has This Been Tested?
Ran it on my system

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

