### PR TITLE
add spawnpoints-only: option to config.ini.example

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -18,6 +18,7 @@
 #no-pokestops:          # disables pokestop scanning (default false)
 #scan-delay:            # default 10
 #step-limit:            # default 12
+#spawnpoints-only:      # only scan known spawnpoints for pokemon (default false) needs an already populated DB
 
 # Misc
 #gmaps-key:             # your Google Maps API key


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add the option --spawnpoints-only to the coinfig.ini.example.
Not sure if the comment "  # only scan known spawnpoints for pokemon (default false) needs an already populated DB" is to long for your taste but you can obviously remove the 2nd part of the comment if you don't like it ;)
## Motivation and Context
Small change to make it more clear that  you don't have to add the option --spawnpoints-only to every command/ Add it manually to every line in beehive.sh

## How Has This Been Tested?
Ran it on my server

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

