### PR TITLE
Prevent 404 errors on next_loc when hosting from subfolder

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1916,13 +1916,12 @@ $(function () {
   window.setInterval(function () {
     if (navigator.geolocation && Store.get('geoLocate')) {
       navigator.geolocation.getCurrentPosition(function (position) {
-        var baseURL = location.protocol + '//' + location.hostname + (location.port ? ':' + location.port : '')
         var lat = position.coords.latitude
         var lon = position.coords.longitude
 
         // the search function makes any small movements cause a loop. Need to increase resolution
         if (getPointDistance(marker.getPosition(), (new google.maps.LatLng(lat, lon))) > 40) {
-          $.post(baseURL + '/next_loc?lat=' + lat + '&lon=' + lon).done(function () {
+          $.post('next_loc?lat=' + lat + '&lon=' + lon).done(function () {
             var center = new google.maps.LatLng(lat, lon)
             map.panTo(center)
             marker.setPosition(center)


### PR DESCRIPTION
## Description
Removed the baseURL var

## Motivation and Context
This change is required to prevent continuous 404 errors on the interval calling /next_loc 
This happens when hosting from subfolder(s) for ex: domain.tld/sub1/sub2/pokemongomap

## How Has This Been Tested?
Changed the file map.min.js in a copy of my master.
Started runserver.py 
Created a nginx location /go/test/ proxying to http://127.0.0.1:5000
Tested -> Works
Removed ngingx location proxy and tried serving on /
Tested -> works

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.