### PR TITLE
fixed wrong redirection in Mozilla Firefox

### DIFF
--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -89,7 +89,8 @@ function addElement (pokemonId, name) {
   }).appendTo('#seen_' + pokemonId + '_details')
 
   jQuery('<a/>', {
-    href: 'javascript:showOverlay(' + pokemonId + ');',
+    href: '#',
+    onclick: 'showOverlay(' + pokemonId + ')',
     text: 'All Locations'
   }).appendTo('#seen_' + pokemonId + '_details')
 }


### PR DESCRIPTION
Fixed wrong redirection in Mozilla Firefox

## Description
In Mozilla Firefox on a Desktop PC, the "return false;" caused the browser to display a blank website with "false" on it instead of showing the map overlay.

## How Has This Been Tested?
Tested it locally with Mozilla Firefox 48.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

