### PR TITLE
Add notifications when a Pokemon is really near

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1187,7 +1187,7 @@ function setupPokemonMarker (item, skipNotification, isBounceDisabled) {
     }
   }
 
-  if (notifiedPokemon.indexOf(item['pokemon_id']) > -1 || notifiedRarity.indexOf(item['pokemon_rarity']) > -1) {
+  if (!notificationTitle && (notifiedPokemon.indexOf(item['pokemon_id']) > -1 || notifiedRarity.indexOf(item['pokemon_rarity']) > -1)) {
     if (!skipNotification) {
       notificationTitle = 'A wild ' + item['pokemon_name'] + ' appeared!'
       notificationMessage = 'Click to load map'

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1173,29 +1173,34 @@ function setupPokemonMarker (item, skipNotification, isBounceDisabled) {
     disableAutoPan: true
   })
 
+  var notificationTitle
+  var notificationMessage
+
   if (!skipNotification && Store.get('notifNear')) {
-    let distance = google.maps.geometry.spherical.computeDistanceBetween(
+    var distance = google.maps.geometry.spherical.computeDistanceBetween(
       new google.maps.LatLng(item['latitude'], item['longitude']),
       locationMarker.getPosition()
     )
-    if(distance < scanRadius) {
-      if (Store.get('playSound')) {
-        audio.play()
-      }
-      sendNotification('A wild ' + item['pokemon_name'] + ' is right here!', 'Check your phone!', 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
+    if (distance <= scanRadius) {
+      notificationTitle = 'A wild ' + item['pokemon_name'] + ' is right here!'
+      notificationMessage = 'Only ' + Math.round(distance) + ' meters away'
     }
   }
 
   if (notifiedPokemon.indexOf(item['pokemon_id']) > -1 || notifiedRarity.indexOf(item['pokemon_rarity']) > -1) {
     if (!skipNotification) {
-      if (Store.get('playSound')) {
-        audio.play()
-      }
-      sendNotification('A wild ' + item['pokemon_name'] + ' appeared!', 'Click to load map', 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
+      notificationTitle = 'A wild ' + item['pokemon_name'] + ' appeared!'
+      notificationMessage = 'Click to load map'
     }
     if (marker.animationDisabled !== true) {
       marker.setAnimation(google.maps.Animation.BOUNCE)
     }
+  }
+  if (notificationTitle) {
+    if (Store.get('playSound')) {
+      audio.play()
+    }
+    sendNotification(notificationTitle, notificationMessage, 'static/icons/' + item['pokemon_id'] + '.png', item['latitude'], item['longitude'])
   }
 
   addListeners(marker)
@@ -1995,7 +2000,6 @@ $(function () {
   $('#near-switch').change(function () {
     Store.set('notifNear', this.checked)
   })
-
 
   $('#geoloc-switch').change(function () {
     $('#next-location').prop('disabled', this.checked)

--- a/templates/map.html
+++ b/templates/map.html
@@ -189,6 +189,16 @@
                 </label>
               </div>
             </div>
+            <div class="form-control switch-container">
+              <h3>Notify on near Pokemon</h3>
+              <div class="onoffswitch">
+                <input id="near-switch" type="checkbox" name="near-switch" class="onoffswitch-checkbox" checked>
+                <label class="onoffswitch-label" for="near-switch">
+                <span class="switch-label" data-on="On" data-off="Off"></span>
+                <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
           </div>
 
           <h3>Style Settings</h3>

--- a/templates/map.html
+++ b/templates/map.html
@@ -190,7 +190,7 @@
               </div>
             </div>
             <div class="form-control switch-container">
-              <h3>Notify on near Pokemon</h3>
+              <h3>Notify on nearby Pokemon</h3>
               <div class="onoffswitch">
                 <input id="near-switch" type="checkbox" name="near-switch" class="onoffswitch-checkbox" checked>
                 <label class="onoffswitch-label" for="near-switch">


### PR DESCRIPTION
## Description
Add a toggle to enable 'Notify on nearby Pokemon', which notify users when a Pokemon is less than 70 meters away (one scan radius)

## Motivation and Context
I want to be able to have a notification for all nearby Pokemon (no need to move to catch it) without being spammed by a Pidgey 500 meters away.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally, I tried to play (enable, disable, customize) with all notification settings (including mine) and I have never seen a weird behavior.
I changed my location from the web interface and it works too

## Screenshots (if appropriate):
![image](https://cloud.githubusercontent.com/assets/1349751/17681881/3acd7c6a-6316-11e6-8300-d3e54ea6afe6.png)
![image](https://cloud.githubusercontent.com/assets/1349751/17681921/76c33138-6316-11e6-9b13-394f4414a590.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

## Questions:
I am not an native english speaker, is my phrasing incorrect or can be improved ?