### PR TITLE
Stop scanning for Pokemon < 7.5 minutes.

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -270,7 +270,7 @@ def search_overseer_thread_ss(args, new_location_queue, pause_bit, encryption_li
     # find the inital location (spawn thats 60sec old)
     pos = SbSearch(spawns, (curSec() + 3540) % 3600)
     while True:
-        while timeDif(curSec(), spawns[pos]['time']) < 30:
+        while timeDif(curSec(), spawns[pos]['time']) < 10:
             time.sleep(1)
         # make location with a dummy height (seems to be more reliable than 0 height)
         location = [spawns[pos]['lat'], spawns[pos]['lng'], 40.32]

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -383,7 +383,7 @@ def search_worker_thread_ss(args, account, search_items_queue, parse_lock, encry
             while True:
                 # Grab the next thing to search (when available)
                 step, step_location, spawntime = search_items_queue.get()
-                if timeDif(curSec(), spawntime) < 90:  # If we aren't 1.5 minutes too late
+                if timeDif(curSec(), spawntime) < args.max_dt:  # If we aren't 'args.max_dt' seconds too late
                     log.info('Searching step %d, remaining %d', step, search_items_queue.qsize())
                     # set position
                     api.set_position(*step_location)

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -383,8 +383,8 @@ def search_worker_thread_ss(args, account, search_items_queue, parse_lock, encry
             while True:
                 # Grab the next thing to search (when available)
                 step, step_location, spawntime = search_items_queue.get()
-                log.info('Searching step %d, remaining %d', step, search_items_queue.qsize())
-                if timeDif(curSec(), spawntime) < 840:  # if we arnt 14mins too late
+                if timeDif(curSec(), spawntime) < 90:  # If we aren't 1.5 minutes too late
+                    log.info('Searching step %d, remaining %d', step, search_items_queue.qsize())
                     # set position
                     api.set_position(*step_location)
                     # try scan (with retries)

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -270,7 +270,7 @@ def search_overseer_thread_ss(args, new_location_queue, pause_bit, encryption_li
     # find the inital location (spawn thats 60sec old)
     pos = SbSearch(spawns, (curSec() + 3540) % 3600)
     while True:
-        while timeDif(curSec(), spawns[pos]['time']) < 60:
+        while timeDif(curSec(), spawns[pos]['time']) < 30:
             time.sleep(1)
         # make location with a dummy height (seems to be more reliable than 0 height)
         location = [spawns[pos]['lat'], spawns[pos]['lng'], 40.32]

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -125,6 +125,8 @@ def get_args():
                         help='Use spawnpoint scanning (instead of hex grid)', nargs='?', const='null.null', default=None)
     parser.add_argument('--dump-spawnpoints', help='dump the spawnpoints from the db to json (only for use with -ss)',
                         action='store_true', default=False)
+    parser.add_argument('--max-dt', help='The max amount of time off of a pokemons expiry clock when its scanned using -ss. (Default is 450)',
+                        type=int, default=450)
     parser.add_argument('-pd', '--purge-data',
                         help='Clear pokemon from database this many hours after they disappear \
                         (0 to disable)', type=int, default=0)


### PR DESCRIPTION
## Description
 Currently if the queue gets too large it starts scanning for pokemon with only 1 minute left on their timer.

## Motivation and Context
Stops scanning for pokemon with less than 7.5 minutes

## How Has This Been Tested?
Tested my multiple people. Been running for 2 days continuously no crashes. Over a total spawn point count of 34k+

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

