### PR TITLE
Added fields to pokéstop webhook data

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -23,6 +23,8 @@
 #gmaps-key:             # your Google Maps API key
 #proxy:                 # Proxy URL e.g. socks5://127.0.0.1:9050
 #webhook:               # webhook URL (including http://)
+#webhook-all-stops:               # send all pokéstops to webhooks, not only lured pokéstops
+#webhook-gyms:               # send gyms to webhooks
 
 # Webserver settings
 #host:                  # address to listen on (default 127.0.0.1)

--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -23,8 +23,7 @@
 #gmaps-key:             # your Google Maps API key
 #proxy:                 # Proxy URL e.g. socks5://127.0.0.1:9050
 #webhook:               # webhook URL (including http://)
-#webhook-all-stops:               # send all pokéstops to webhooks, not only lured pokéstops
-#webhook-gyms:               # send gyms to webhooks
+#webhook-updates-only:               # only send updates to webhooks, (excludes gyms & non-lured pokéstops)
 
 # Webserver settings
 #host:                  # address to listen on (default 127.0.0.1)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -430,7 +430,7 @@ def parse_map(map_dict, step_location):
                         'active_fort_modifier': active_fort_modifier
                     }
 
-                    if not args.webhook_all_forts:
+                    if not args.webhook_all_stops:
                         send_to_webhook('pokestop', webhook_data)
                 else:
                     lure_expiration, active_fort_modifier = None, None

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -446,7 +446,7 @@ def parse_map(map_dict, step_location):
                     'active_fort_modifier': active_fort_modifier,
                 }
 
-                # Send all pokéstops to
+                # Send all pokéstops to webhooks
                 if args.webhook_all_stops:
                     # Explicitly set 'webhook_data', in case we want to change the information pushed to webhooks,
                     # similar to above and previous commits.

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -421,9 +421,12 @@ def parse_map(map_dict, step_location):
                         f['last_modified_timestamp_ms'] / 1000.0) + timedelta(minutes=30)
                     active_fort_modifier = f['active_fort_modifier']
                     webhook_data = {
+                        'pokestop_id': f['id'],
+                        'enabled': f['enabled'],
                         'latitude': f['latitude'],
                         'longitude': f['longitude'],
                         'last_modified_time': f['last_modified_timestamp_ms'],
+                        'lure_expiration': lure_expiration,
                         'active_fort_modifier': active_fort_modifier
                     }
                     send_to_webhook('pokestop', webhook_data)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -429,7 +429,9 @@ def parse_map(map_dict, step_location):
                         'lure_expiration': lure_expiration,
                         'active_fort_modifier': active_fort_modifier
                     }
-                    send_to_webhook('pokestop', webhook_data)
+
+                    if not args.webhook_all_forts:
+                        send_to_webhook('pokestop', webhook_data)
                 else:
                     lure_expiration, active_fort_modifier = None, None
 
@@ -444,6 +446,13 @@ def parse_map(map_dict, step_location):
                     'active_fort_modifier': active_fort_modifier,
                 }
 
+                # Send all pokéstops to
+                if args.webhook_all_stops:
+                    # Explicitly set 'webhook_data', in case we want to change the information pushed to webhooks,
+                    # similar to above and previous commits.
+                    webhook_data = pokestops[f['id']]
+                    send_to_webhook('pokestop', webhook_data)
+
             elif config['parse_gyms'] and f.get('type') is None:  # Currently, there are only stops and gyms
                 gyms[f['id']] = {
                     'gym_id': f['id'],
@@ -456,6 +465,13 @@ def parse_map(map_dict, step_location):
                     'last_modified': datetime.utcfromtimestamp(
                         f['last_modified_timestamp_ms'] / 1000.0),
                 }
+
+                # Send gyms to webhooks
+                if args.webhook_gyms:
+                    # Explicitly set 'webhook_data', in case we want to change the information pushed to webhooks,
+                    # similar to above and previous commits.
+                    webhook_data = gyms[f['id']]
+                    send_to_webhook('gym', webhook_data)
 
     pokemons_upserted = 0
     pokestops_upserted = 0

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -430,7 +430,8 @@ def parse_map(map_dict, step_location):
                         'active_fort_modifier': active_fort_modifier
                     }
 
-                    if not args.webhook_all_stops:
+                    # Include lured pokéstops in our updates to webhooks
+                    if args.webhook_updates_only:
                         send_to_webhook('pokestop', webhook_data)
                 else:
                     lure_expiration, active_fort_modifier = None, None
@@ -447,7 +448,7 @@ def parse_map(map_dict, step_location):
                 }
 
                 # Send all pokéstops to webhooks
-                if args.webhook_all_stops:
+                if not args.webhook_updates_only:
                     # Explicitly set 'webhook_data', in case we want to change the information pushed to webhooks,
                     # similar to above and previous commits.
                     webhook_data = pokestops[f['id']]
@@ -467,7 +468,7 @@ def parse_map(map_dict, step_location):
                 }
 
                 # Send gyms to webhooks
-                if args.webhook_gyms:
+                if not args.webhook_updates_only:
                     # Explicitly set 'webhook_data', in case we want to change the information pushed to webhooks,
                     # similar to above and previous commits.
                     webhook_data = gyms[f['id']]

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -140,6 +140,10 @@ def get_args():
                         type=int, default=5)
     parser.add_argument('-wh', '--webhook', help='Define URL(s) to POST webhook information to',
                         nargs='*', default=False, dest='webhooks')
+    parser.add_argument('-ws', '--webhook-all-stops', help='Send all pokéstops to webhooks, not only lured pokéstops.',
+                        action='store_true', default=False)
+    parser.add_argument('-wg', '--webhook-gyms', help='Send gyms to webhooks.',
+                        action='store_true', default=False)
     parser.add_argument('--ssl-certificate', help='Path to SSL certificate file')
     parser.add_argument('--ssl-privatekey', help='Path to SSL private key file')
     parser.set_defaults(DEBUG=False)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -179,10 +179,12 @@ def get_args():
         else:
             num_auths = len(args.auth_service)
 
-        if args.webhook_all_stops is None:
+        # Can't add CLI, but configargparse requires it by design choice... Figure out what you want guys...
+        # TODO: add to configargparse as CLI & replace "not in" w/ "is None"
+        if "webhook_all_stops" not in args:
             args.webhook_all_stops = False
 
-        if args.webhook_gyms is None:
+        if "webhook_gyms" not in args:
             args.webhook_gyms = False
 
         if num_usernames > 1:

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -140,10 +140,6 @@ def get_args():
                         type=int, default=5)
     parser.add_argument('-wh', '--webhook', help='Define URL(s) to POST webhook information to',
                         nargs='*', default=False, dest='webhooks')
-    parser.add_argument('-ws', '--webhook-all-stops', help='Send all pokéstops to webhooks, not only lured pokéstops.',
-                        action='store_true', default=False)
-    parser.add_argument('-wg', '--webhook-gyms', help='Send gyms to webhooks.',
-                        action='store_true', default=False)
     parser.add_argument('--ssl-certificate', help='Path to SSL certificate file')
     parser.add_argument('--ssl-privatekey', help='Path to SSL private key file')
     parser.set_defaults(DEBUG=False)
@@ -182,6 +178,12 @@ def get_args():
             args.auth_service = ['ptc']
         else:
             num_auths = len(args.auth_service)
+
+        if args.webhook_all_stops is None:
+            args.webhook_all_stops = False
+
+        if args.webhook_gyms is None:
+            args.webhook_gyms = False
 
         if num_usernames > 1:
             if num_passwords > 1 and num_usernames != num_passwords:

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -140,6 +140,8 @@ def get_args():
                         type=int, default=5)
     parser.add_argument('-wh', '--webhook', help='Define URL(s) to POST webhook information to',
                         nargs='*', default=False, dest='webhooks')
+    parser.add_argument('--webhook-updates-only', help='Only send updates (pokémon & lured pokéstops)',
+                        action='store_true', default=False)
     parser.add_argument('--ssl-certificate', help='Path to SSL certificate file')
     parser.add_argument('--ssl-privatekey', help='Path to SSL private key file')
     parser.set_defaults(DEBUG=False)
@@ -178,14 +180,6 @@ def get_args():
             args.auth_service = ['ptc']
         else:
             num_auths = len(args.auth_service)
-
-        # Can't add CLI, but configargparse requires it by design choice... Figure out what you want guys...
-        # TODO: add to configargparse as CLI & replace "not in" w/ "is None"
-        if "webhook_all_stops" not in args:
-            args.webhook_all_stops = False
-
-        if "webhook_gyms" not in args:
-            args.webhook_gyms = False
 
         if num_usernames > 1:
             if num_passwords > 1 and num_usernames != num_passwords:


### PR DESCRIPTION
## Description
Added fields to pokéstop webhook data, changed default behavior to send all data via webhook and added optional params to send only updates (lured pokéstops & pokémon) via webhooks.

## Motivation and Context
Not all data is being sent to webhooks. 3rd party webhooks might not be aware of the data in the scanner's database, so the extra data is welcome.

## Checklist:
- [x] My code follows the code style of this project.

