### PR TITLE
Intelligently decide scanning step distance

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -61,14 +61,14 @@ def get_new_coords(init_loc, distance, bearing):
     return [math.degrees(new_lat), math.degrees(new_lon)]
 
 
-def generate_location_steps(initial_loc, step_count):
+def generate_location_steps(initial_loc, step_count, step_distance):
     # Bearing (degrees)
     NORTH = 0
     EAST = 90
     SOUTH = 180
     WEST = 270
 
-    pulse_radius = 0.07                 # km - radius of players heartbeat is 70m
+    pulse_radius = step_distance            # km - radius of players heartbeat is 70m
     xdist = math.sqrt(3) * pulse_radius   # dist between column centers
     ydist = 3 * (pulse_radius / 2)          # dist between row centers
 
@@ -194,8 +194,16 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
                 except Empty:
                     pass
 
+            # if we are only scanning for pokestops/gyms, then increase step radius to visibility range
+            if args.no_pokemon:
+                step_distance = 0.9
+            else:
+                step_distance = 0.07
+
+            log.info('Scan Distance is %.2f km', step_distance)
+
             # update our list of coords
-            locations = list(generate_location_steps(current_location, args.step_limit))
+            locations = list(generate_location_steps(current_location, args.step_limit, step_distance))
 
             # repopulate our spawn points
             if args.spawnpoints_only:

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -219,7 +219,7 @@ def insert_mock_data(position):
 
     latitude, longitude = float(position[0]), float(position[1])
 
-    locations = [l for l in generate_location_steps((latitude, longitude), num_pokemon)]
+    locations = [l for l in generate_location_steps((latitude, longitude), num_pokemon, 0.07)]
     disappear_time = datetime.now() + timedelta(hours=1)
 
     detect_time = datetime.now()


### PR DESCRIPTION
Intelligently decide scanning step distance

## Description

If a scanner is only doing gyms and/or poke-stops, increase the step distance to 0.9km.

0.9km was specifically chosen because 99.99% of pokestops and gyms are visible within 0.9km and there have been issues with `get_gym_details()` with pokestops and gyms above 0.9km.

## Motivation and Context

If someone wants to only scan gyms and poke-stops, the step distance needs to be manually increased and custom docker containers must be manually built.   This allows the application to decide intelligently the step distance.

I didn't want to add ANOTHER environment variable so I made it intelligent (artificially).

## How Has This Been Tested?

Docker with all 6 permutations of options (`-np`, `-nk`, `-ng`).

## Screenshots (if appropriate):

![image](https://cloud.githubusercontent.com/assets/387006/17713421/d891a0ea-63c8-11e6-8495-6faca80f8377.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
