### PR TITLE
hotfix to correct times got from db, also doumentation changes

### DIFF
--- a/docs/extras/Spawnpoint-Scanning.md
+++ b/docs/extras/Spawnpoint-Scanning.md
@@ -6,6 +6,8 @@ Spawnpoint Scanning consists of only scanning an area in which a spawn has recen
 
 Spawnpoint Scanning is particularly useful in areas where spawns are spread out
 
+## Spawnpoint Scanning can be run in one of three different modes:
+
 ### Scans based on database
 
 ```
@@ -21,14 +23,12 @@ Note: when using the mode when not in a beehive, it is recommended to use an -st
 ### Dump scans from database then use the created file
 
 ```
-python runserver.py -ss YOURFILE.json -l YOURLOCATION -st STEPS --dump-spawns
+python runserver.py -ss YOURFILE.json -l YOURLOCATION -st STEPS --dump-spawnpoints
 ```
 
 Where YOURFILE.json is the file containing all the spawns, YOURLOCATION is the location the map should be centered at and also the center of the hex to get spawn locations from and -st sets the size of the clipping hexagon (hexagon is the same size as the scan of the same -st value)
 
 This mode is mainly used for switching from database mode to spawnFile mode, and can also be used simply for dumping all spawns to file (use a very large -st and close the program once it has created the file)
-
-## Spawnpoint Scanning can be run in one of three different modes:
 
 ### Scans based on file
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -226,7 +226,7 @@ class Pokemon(BaseModel):
         query = (Pokemon
                  .select(Pokemon.latitude.alias('lat'),
                          Pokemon.longitude.alias('lng'),
-                         ((Pokemon.disappear_time.minute * 60) + (Pokemon.disappear_time.second + 2700) % 3600).alias('time'),
+                         ((Pokemon.disappear_time.minute * 60) + Pokemon.disappear_time.second).alias('time'),
                          Pokemon.spawnpoint_id
                          ))
         query = (query.where((Pokemon.latitude <= north) &
@@ -244,6 +244,7 @@ class Pokemon(BaseModel):
         # for each spawn work out if it is in the hex (clipping the diagonals)
         trueSpawns = []
         for spawn in s:
+            spawn['time'] = (spawn['time'] + 2700) % 3600
             # get the offset from the center of each spawn in km
             offset = [math.radians(spawn['lat'] - center[0]) * R, math.radians(spawn['lng'] - center[1]) * (R * math.cos(math.radians(center[0])))]
             # check agains the 4 lines that make up the diagonals

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -414,7 +414,7 @@ def search_worker_thread_ss(args, account, search_items_queue, parse_lock, encry
                                 log.exception('Search step %s map parsing failed, retrying request in %g seconds. Username: %s', step, sleep_time, account['username'])
                                 failed_total += 1
                         time.sleep(sleep_time)
-                    time.sleep(sleep_time)
+                    time.sleep(args.scan_delay)
                 else:
                     search_items_queue.task_done()
                     log.info('Cant keep up. Skipping')

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -414,7 +414,7 @@ def search_worker_thread_ss(args, account, search_items_queue, parse_lock, encry
                                 log.exception('Search step %s map parsing failed, retrying request in %g seconds. Username: %s', step, sleep_time, account['username'])
                                 failed_total += 1
                         time.sleep(sleep_time)
-                    time.sleep(args.scan_delay)
+                    time.sleep(sleep_time)
                 else:
                     search_items_queue.task_done()
                     log.info('Cant keep up. Skipping')


### PR DESCRIPTION
changes the time that spawns are checked when is -ss mode and are pulling their data from db

## Description
the original commit had the database return the despawn time rather than the (est) spawn time, causing it to not work when -ss was used without a fill, and also causing --dump-spawnpoints to generate an incorrect file

also ive updated the -ss documentation to not have so many formatting/spelling errors

## Motivation and Context
Motivation: fix it before people start blaming me

## How Has This Been Tested?
only tests over the original is that --dump-spawnpoints was used to get the output in human readable format to check that spawn times where not off by 15mins

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

