### PR TITLE
Delay/throttle fix when search resumes, preventing burst of search requests

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -222,9 +222,9 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
         # Setting delay interval for filling in search queue to throttle down search workers
         if len(args.accounts) > 1:
             if len(args.accounts) > args.scan_delay:  # force ~1 second delay between threads if you have many accounts
-                delay_interval = ((random.random() - .5) / 2)
+                delay_interval = random.random() / 2
             else:
-                delay_interval = (args.scan_delay / len(args.accounts))
+                delay_interval = args.scan_delay / len(args.accounts)
         else:
             delay_interval = args.scan_delay
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -221,10 +221,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
 
         # Setting delay interval for filling in search queue to throttle down search workers
         if len(args.accounts) > 1:
-            if len(args.accounts) > args.scan_delay:  # force ~1 second delay between threads if you have many accounts
-                delay_interval = random.random() / 2
-            else:
-                delay_interval = args.scan_delay / len(args.accounts)
+            delay_interval = float(args.scan_delay) / float(len(args.accounts))
         else:
             delay_interval = args.scan_delay
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -219,16 +219,28 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
             if len(locations) == 0:
                 log.warning('Nothing to scan!')
 
+        # Setting delay interval for filling in search queue to throttle down search workers
+        if len(args.accounts) > 1:
+            if len(args.accounts) > args.scan_delay:  # force ~1 second delay between threads if you have many accounts
+                delay_interval = ((random.random() - .5) / 2)
+            else:
+                delay_interval = (args.scan_delay / len(args.accounts))
+        else:
+            delay_interval = args.scan_delay
+
         # If there are no search_items_queue either the loop has finished (or been
         # cleared above) -- either way, time to fill it back up
         if search_items_queue.empty():
             log.debug('Search queue empty, restarting loop')
             for step, step_location in enumerate(locations, 1):
+                # Stop filling the queue if paused or new location has been found
+                if pause_bit.is_set() or not new_location_queue.empty():
+                    break
+                # Throttle down the workers by filling the queue slowly
+                time.sleep(delay_interval)
                 log.debug('Queueing step %d @ %f/%f/%f', step, step_location[0], step_location[1], step_location[2])
                 search_args = (step, step_location)
                 search_items_queue.put(search_args)
-        # else:
-        #     log.info('Search queue processing, %d items left', search_items_queue.qsize())
 
         # Now we just give a little pause here
         time.sleep(1)
@@ -295,6 +307,8 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
             if args.proxy:
                 api.set_proxy({'http': args.proxy, 'https': args.proxy})
 
+            api.activate_signature(encryption_lib_path)
+
             # Get current time
             loop_start_time = int(round(time.time() * 1000))
 
@@ -304,7 +318,7 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                 # Grab the next thing to search (when available)
                 step, step_location = search_items_queue.get()
 
-                log.info('Search step %d beginning (queue size is %d)', step, search_items_queue.qsize())
+                log.info('Search step %d beginning', step)
 
                 # Let the api know where we intend to be for this loop
                 api.set_position(*step_location)
@@ -329,8 +343,6 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
 
                     # Ok, let's get started -- check our login status
                     check_login(args, account, api, step_location)
-
-                    api.activate_signature(encryption_lib_path)
 
                     # Make the actual request (finally!)
                     response_dict = map_request(api, step_location)
@@ -357,10 +369,12 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                 # If there's any time left between the start time and the time when we should be kicking off the next
                 # loop, hang out until its up.
                 sleep_delay_remaining = loop_start_time + (args.scan_delay * 1000) - int(round(time.time() * 1000))
-                if sleep_delay_remaining > 0:
+                if sleep_delay_remaining < 0:
+                    time.sleep(args.scan_delay)
+                else:
                     time.sleep(sleep_delay_remaining / 1000)
 
-                loop_start_time += args.scan_delay * 1000
+                loop_start_time = int(round(time.time() * 1000))
 
         # catch any process exceptions, log them, and continue the thread
         except Exception as e:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix for burst of search requests after search resumes, resulting in soft bans.

## Motivation and Context
I have added interval delays to when search queue gets filled up, so that each search thread can only initiate the search at given fixed interval.  That way even if the search resumes after extended period of pause, the search threads won't burst out the request all at once.  **Please comment if the delay interval handled in search queue is a good idea or not**

Spawn point search thread has been left untouched.

## How Has This Been Tested?
Ran, tested repeats of pause and resume for various intervals.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

