### PR TITLE
Fixed miss handling of error when parsing map data

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -384,7 +384,7 @@ def parse_map(map_dict, step_location):
         cells = map_dict['responses']['GET_MAP_OBJECTS']['map_cells']
     except KeyError:
         return False
-    
+
     for cell in cells:
         if config['parse_pokemon']:
             for p in cell.get('wild_pokemons', []):

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -379,7 +379,7 @@ def parse_map(map_dict, step_location):
     gyms = {}
     scanned = {}
 
-    #attempt to get cells from map data and return false if it fails (can be caused by banned accounts)
+    # attempt to get cells from map data and return false if it fails (can be caused by banned accounts)
     try:
         cells = map_dict['responses']['GET_MAP_OBJECTS']['map_cells']
     except KeyError:

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -379,7 +379,12 @@ def parse_map(map_dict, step_location):
     gyms = {}
     scanned = {}
 
-    cells = map_dict['responses']['GET_MAP_OBJECTS']['map_cells']
+    #attempt to get cells from map data and return false if it fails (can be caused by banned accounts)
+    try:
+        cells = map_dict['responses']['GET_MAP_OBJECTS']['map_cells']
+    except KeyError:
+        return False
+    
     for cell in cells:
         if config['parse_pokemon']:
             for p in cell.get('wild_pokemons', []):

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -405,12 +405,11 @@ def search_worker_thread_ss(args, account, search_items_queue, parse_lock, encry
                             continue
                         # got responce try and parse it
                         with parse_lock:
-                            try:
-                                parse_map(response_dict, step_location)
+                            if parse_map(response_dict, step_location):
                                 log.debug('Search step %s completed', step)
                                 search_items_queue.task_done()
                                 break
-                            except KeyError:
+                            else:
                                 log.exception('Search step %s map parsing failed, retrying request in %g seconds. Username: %s', step, sleep_time, account['username'])
                                 failed_total += 1
                         time.sleep(sleep_time)

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -349,7 +349,7 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                             search_items_queue.task_done()
                             break
                         else:
-                            log.error('Search step %s map parsing failed, retrying request in %g seconds. Username: %s', step, sleep_time, account['username'])
+                            log.exception('Search step %s map parsing failed, retrying request in %g seconds. Username: %s', step, sleep_time, account['username'])
                             failed_total += 1
                     time.sleep(sleep_time)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The method used to handle an error when parsing map data was incorrect. Will now handle error correctly.

## Description
When the search thread was checking if there was an error when parsing the map it was doing it incorrectly and therefor not looping and increasing failed_total counter. Which means people were just getting a traceback with keyerror.

It will now correctly handle the error and loop as was intended 

## Motivation and Context
Code to rerun a scan on an area was being missed if there was an error. This code now runs as intended.

## How Has This Been Tested?
Tested on functional and banned accounts. 
No longer getting traceback when getting a keyerror.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
