### PR TITLE
Fix how -ss scan mode handles proxies

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -437,7 +437,8 @@ def check_login(args, account, api, position):
     while i < args.login_retries:
         try:
             if args.proxy:
-                api.set_authentication(provider=account['auth_service'], username=account['username'], password=account['password'], proxy_config={'http': args.proxy, 'https': args.proxy})
+                api.set_proxy({'http': args.proxy, 'https': args.proxy})
+                api.set_authentication(provider=account['auth_service'], username=account['username'], password=account['password'])
             else:
                 api.set_authentication(provider=account['auth_service'], username=account['username'], password=account['password'])
             break


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Change the way that ss mode handles proxies.

## Motivation and Context
Using a proxy with the new mode does not work.  As mentioned in #754 attempting to do so will give this error:
`2016-08-16 20:15:09,576 [ss_search_worker_0][        search][   ERROR] Exception                                                in search_worker: set_authentication() got an unexpected keyword argument 'prox                                               y_config'
Traceback (most recent call last):
  File "C:\dev2\PokemonGo-Map\pogom\search.py", line 397, in search_worker_threa                                               d_ss
    check_login(args, account, api, step_location)
  File "C:\dev2\PokemonGo-Map\pogom\search.py", line 440, in check_login
    api.set_authentication(provider=account['auth_service'], username=account['u                                               sername'], password=account['password'], proxy_config={'http': args.proxy, 'http                                               s': args.proxy})
TypeError: set_authentication() got an unexpected keyword argument 'proxy_config                                               '`
and will potentially continue scanning outside of the specified proxy.

## How Has This Been Tested?
This has been tested locally, and follows the pattern for setting proxies that has already been established throughout search.py

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

