### PR TITLE
Add main() function to runserver.py to allow wrapping

### DIFF
--- a/runserver.py
+++ b/runserver.py
@@ -54,6 +54,7 @@ if not hasattr(pgoapi, "__version__") or StrictVersion(pgoapi.__version__) < Str
     log.critical("It seems `pgoapi` is not up-to-date. You must run pip install -r requirements.txt again")
     sys.exit(1)
 
+
 def main():
     # Check if we have the proper encryption library file and get its path
     encryption_lib_path = get_encryption_lib_path()

--- a/runserver.py
+++ b/runserver.py
@@ -54,7 +54,7 @@ if not hasattr(pgoapi, "__version__") or StrictVersion(pgoapi.__version__) < Str
     log.critical("It seems `pgoapi` is not up-to-date. You must run pip install -r requirements.txt again")
     sys.exit(1)
 
-if __name__ == '__main__':
+def main():
     # Check if we have the proper encryption library file and get its path
     encryption_lib_path = get_encryption_lib_path()
     if encryption_lib_path is "":
@@ -199,3 +199,6 @@ if __name__ == '__main__':
             log.info('Web server in SSL mode.')
 
         app.run(threaded=True, use_reloader=False, debug=args.debug, host=args.host, port=args.port, ssl_context=ssl_context)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Description
Wrapping main server code in a function so `runserver.py` can be imported in other modules easily.

## Motivation and Context
For the PokemonGo-DesktopApp I wrap all Python dependencies in a zip file and load it to reduce overhead. I've been patching each distribution, but this would allow me to add the zip file to the import path in a separate file and avoid changing code.

## How Has This Been Tested?
Ran on my Mac and verified behavior did not change.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

