### PR TITLE
Added -ss Compression

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -28,6 +28,7 @@ import geopy.distance as geopy_distance
 from operator import itemgetter
 from threading import Thread, Lock
 from queue import Queue, Empty
+from collections import deque
 
 from pgoapi import PGoApi
 from pgoapi.utilities import f2i
@@ -270,26 +271,17 @@ def search_overseer_thread_ss(args, new_location_queue, pause_bit, encryption_li
     log.info('%d spawnpoints loaded. Compressing spawnpoints...', len(spawns))
 
     spawns.sort(key=itemgetter('time'), reverse=True)
-    compressed = []
-    while len(spawns) != 0:
-        spawn = spawns.pop(0)
-        compressed.append(spawn)
-        # log.debug('Processing spawn %r', spawn)
 
-        # Remove any other spawns that fall within range of this one
-        redundant = []
-        for sp_to_check in spawns:
-            if timeDif(spawn['time'], sp_to_check['time']) > args.sp_compression:
-                break  # We're already outside the time, no sense continuing
-            dist = geopy_distance.distance((spawn['lat'], spawn['lng']), (sp_to_check['lat'], sp_to_check['lng'])).meters
-            if dist < 70:
-                # log.debug('Removing spawn %d m away: %r', dist, sp_to_check)
-                redundant.append(sp_to_check)
+    if args.sp_compression > 0:
+        spawns_deque = deque(spawns)
+        iterations = len(spawns) if args.aggressive_compress else 1
+        for i in range(iterations):
+            compressed = compress_spawnpoints(spawns_deque, args.sp_compression, len(spawns))
+            if compressed is not None:
+                # We've found a new best optimization, use it
+                spawns = compressed
+            spawns_deque.rotate(1)
 
-        for x in redundant:
-            spawns.remove(x)
-
-    spawns = compressed
     spawns.reverse()  # put them back in ascending order
 
     log.info('Total of %d locations to scan', len(spawns))
@@ -304,6 +296,32 @@ def search_overseer_thread_ss(args, new_location_queue, pause_bit, encryption_li
         search_args = (pos, location, spawns[pos]['time'])
         search_items_queue.put(search_args)
         pos = (pos + 1) % len(spawns)
+
+
+def compress_spawnpoints(spawns, threshold, early_cutoff):
+    compressed = []
+    spawns = deque(spawns)  # duplicate so we can modify it
+    while len(spawns) != 0:
+        spawn = spawns.popleft()
+        compressed.append(spawn)
+        if len(compressed) >= early_cutoff:
+            return None  # List grew too big, no longer optimal
+        # log.debug('Processing spawn %r', spawn)
+
+        # Remove any other spawns that fall within range of this one
+        redundant = []
+        for sp_to_check in spawns:
+            if timeDif(spawn['time'], sp_to_check['time']) > threshold:
+                break  # We're already outside the time, no sense continuing
+            dist = geopy_distance.distance((spawn['lat'], spawn['lng']), (sp_to_check['lat'], sp_to_check['lng'])).meters
+            if dist < 70:
+                # log.debug('Removing spawn %d m away: %r', dist, sp_to_check)
+                redundant.append(sp_to_check)
+
+        for x in redundant:
+            spawns.remove(x)
+
+    return compressed
 
 
 def search_worker_thread(args, account, search_items_queue, parse_lock, encryption_lib_path):

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -123,6 +123,8 @@ def get_args():
                         action='store_true', default=False)
     parser.add_argument('-ss', '--spawnpoint-scanning',
                         help='Use spawnpoint scanning (instead of hex grid)', nargs='?', const='null.null', default=None)
+    parser.add_argument('--sp-compression', help="Don't scan spawnpoints that spawn up to this many seconds before \
+                        another spawnpoint. This reduces redundant scans. Defaults to 120 (2 minutes)", type=int, default=120)
     parser.add_argument('--dump-spawnpoints', help='dump the spawnpoints from the db to json (only for use with -ss)',
                         action='store_true', default=False)
     parser.add_argument('-pd', '--purge-data',

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -123,8 +123,9 @@ def get_args():
                         action='store_true', default=False)
     parser.add_argument('-ss', '--spawnpoint-scanning',
                         help='Use spawnpoint scanning (instead of hex grid)', nargs='?', const='null.null', default=None)
-    parser.add_argument('--sp-compression', help="Don't scan spawnpoints that spawn up to this many seconds before \
-                        another spawnpoint. This reduces redundant scans. Defaults to 120 (2 minutes)", type=int, default=120)
+    parser.add_argument('--sp-compression', help="The maximum time separation (in seconds) of two spawnpoints for them to be \
+                        compressed. Compression reduces redundant scans. Specify 0 to disable compression. Defaults \
+                        to 120 (2 minutes)", type=int, default=120)
     parser.add_argument('--aggressive-compress', help='Spend extra time compressing the spawnpoints to find a better compression',
                         action='store_true', default=False)
     parser.add_argument('--dump-spawnpoints', help='dump the spawnpoints from the db to json (only for use with -ss)',

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -125,6 +125,8 @@ def get_args():
                         help='Use spawnpoint scanning (instead of hex grid)', nargs='?', const='null.null', default=None)
     parser.add_argument('--sp-compression', help="Don't scan spawnpoints that spawn up to this many seconds before \
                         another spawnpoint. This reduces redundant scans. Defaults to 120 (2 minutes)", type=int, default=120)
+    parser.add_argument('--aggressive-compress', help='Spend extra time compressing the spawnpoints to find a better compression',
+                        action='store_true', default=False)
     parser.add_argument('--dump-spawnpoints', help='dump the spawnpoints from the db to json (only for use with -ss)',
                         action='store_true', default=False)
     parser.add_argument('-pd', '--purge-data',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added an algorithm from #179. It compresses the spawnpoints list to reduce the number of redundant calls.

Discussion of the algo can be found on #179, but in a nutshell it removes spawnpoints that would be caught by a (configurable) later scan. This 'lag time' defaults to two minutes. For example, if the spawn points are [1, 2, 3], and 1 and 3 are within 70 meters of each other and 3 spawns within two minutes of 1, the algorithm will forgo scanning 1, since its spawn will be caught when 3 is scanned.

Results: You lose up to two minutes on the time of 1, but make less requests.

Aggressive compression will try all permutations of the spawnpoint list to find the optimal compression. However, this takes quite a bit of time for larger spawnpoint lists, roughly `O(n**2)` growth and doesn't add all that much.

With a 2 minute window (the default) on a -st 7 of santa monica pier (note the timestamps):

```
2016-08-17 01:41:44,617 [   search_thread][        search][    INFO] 260 spawnpoints loaded. Compressing spawnpoints...
2016-08-17 01:41:44,706 [   search_thread][        search][    INFO] Total of 213 locations to scan
```

With `aggressive-compress` (again note the timestamps):
```
2016-08-17 01:43:15,934 [   search_thread][        search][    INFO] 260 spawnpoints loaded. Compressing spawnpoints...
2016-08-17 01:43:31,239 [   search_thread][        search][    INFO] Total of 210 locations to scan
```

## Motivation and Context
Heuristically optimizes the list of spawnpoints to further reduce the strain on Niantic (as well as teleporting)

## How Has This Been Tested?
I tested this in a limited fashion, primarily based on debug output. More eyes wouldn't hurt.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

