### PR TITLE
setup.bat now won't set paths if already set, now also installs npm

### DIFF
--- a/Tools/Easy-Setup/setup.bat
+++ b/Tools/Easy-Setup/setup.bat
@@ -36,20 +36,20 @@ set /p PATH2= Specify Python path:
 )
 
 
-echo ;%PATH%; | find /C /I "%PATH2%" > temp.txt
-find /c "1" temp.txt
-if %errorlevel% equ 1 goto Notfound
+for /f "tokens=*" %%i in ('echo "%PATH%" ^| find /c /i "%PATH2%"') do set output=%%i
+if %output% equ 1 (
 goto found
+) else (
+goto notfound
+)
 
 :found
 cls
-del temp.txt
 echo Path is already set, skipping...
 goto Continue
 
 :notfound
 cls
-del temp.txt
 setx PATH "%PATH%;%PATH2%;%PATH2%\Scripts;"
 echo.
 echo Path set, continuing..

--- a/Tools/Easy-Setup/setup.bat
+++ b/Tools/Easy-Setup/setup.bat
@@ -36,20 +36,20 @@ set /p PATH2= Specify Python path:
 )
 
 
-echo ;%PATH%; | find /C /I "%PATH2%" > echo.txt
-find /c "1" echo.txt
+echo ;%PATH%; | find /C /I "%PATH2%" > temp.txt
+find /c "1" temp.txt
 if %errorlevel% equ 1 goto Notfound
 goto found
 
 :found
 cls
-del echo.txt
+del temp.txt
 echo Path is already set, skipping...
 goto Continue
 
 :notfound
 cls
-del echo.txt
+del temp.txt
 setx PATH "%PATH%;%PATH2%;%PATH2%\Scripts;"
 echo.
 echo Path set, continuing..

--- a/Tools/Easy-Setup/setup.bat
+++ b/Tools/Easy-Setup/setup.bat
@@ -1,4 +1,5 @@
 @echo off
+echo Requesting Administrator Access...
 pushd %~dp0
     :: Running prompt elevated
 :-------------------------------------
@@ -22,22 +23,54 @@ if '%errorlevel%' NEQ '0' (
     pushd "%CD%"
     CD /D "%~dp0"
 :--------------------------------------
+echo.
+echo Setting PATHs...
+echo.
 
 IF EXIST C:\Python27 (
 set PATH2=C:\Python27
 ) ELSE (
 echo Python path not found, please specify or install.
+echo.
 set /p PATH2= Specify Python path: 
 )
 
+
+echo ;%PATH%; | find /C /I "%PATH2%" > echo.txt
+find /c "1" echo.txt
+if %errorlevel% equ 1 goto Notfound
+goto found
+
+:found
+cls
+del echo.txt
+echo Path is already set, skipping...
+goto Continue
+
+:notfound
+cls
+del echo.txt
 setx PATH "%PATH%;%PATH2%;%PATH2%\Scripts;"
+echo.
+echo Path set, continuing..
+goto Continue
+
+
+:Continue
 
 popd
+
+echo.
+echo Installing requirements...
+echo. 
 
 "%PATH2%\python" get-pip.py
 cd ..\..
 "%PATH2%\Scripts\pip" install -r requirements.txt
 "%PATH2%\Scripts\pip" install -r requirements.txt --upgrade
+
+call npm install
+call npm run build
 
 cd config
 set /p API= Enter your Google API key here:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated setup.bat to only set paths if not already set. It now also installs npm, and gives a bit more user output.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If the setup was used more than once on a machine it would fill the PATH variable with several copies of the same path. It installs npm because of new dependencies.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested with PATH already set and not aswell as with default path to Python and using a custom path.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.