### PR TITLE
Fix for map style "No Labels" (used to still show labels)

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -33,6 +33,18 @@ var noLabelsStyle = [{
   }]
 }, {
   'featureType': 'all',
+  'elementType': 'labels.text.stroke',
+  'stylers': [{
+    'visibility': 'off'
+  }]
+}, {
+  'featureType': 'all',
+  'elementType': 'labels.text.fill',
+  'stylers': [{
+    'visibility': 'off'
+  }]
+}, {
+  'featureType': 'all',
   'elementType': 'labels.icon',
   'stylers': [{
     'visibility': 'off'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When choosing the map style "No Labels", some labels would still show (such as road names)

## Motivation and Context
Tried to select "No Labels" for a screenshot, and was still getting road names

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![no-labels-fix](https://cloud.githubusercontent.com/assets/1891414/17755690/64f0a2a8-64a9-11e6-8823-a0227068ff6d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
