### PR TITLE
Moved webhook to grequests for async so it doesn't slow down the scanner

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -9,7 +9,7 @@ import json
 from datetime import datetime, timedelta
 import logging
 import shutil
-import requests
+import grequests
 import platform
 
 from . import config
@@ -316,10 +316,9 @@ def send_to_webhook(message_type, message):
 
         for w in webhooks:
             try:
-                requests.post(w, json=data, timeout=(None, 1))
-            except requests.exceptions.ReadTimeout:
-                log.debug('Response timeout on webhook endpoint %s', w)
-            except requests.exceptions.RequestException as e:
+                req = grequests.post(w, json=data, timeout=(None, 1))
+                grequests.send(req, grequests.Pool(1))
+            except Exception as e:
                 log.debug(e)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ sphinx==1.4.5
 sphinx-autobuild==0.6.0
 recommonmark==0.4.0
 sphinx_rtd_theme==0.1.9
-requests==2.10.0
+grequests==0.3.0
 PySocks==1.5.6
 git+https://github.com/ChrisTM/Flask-CacheBust.git@aa09ad861f104f987928fe9f5107ccfe0e4473c3#egg=flask_cachebust
 protobuf_to_dict==0.1.0


### PR DESCRIPTION
## Description
Moved webhook to grequests for async so it doesn't slow down the scanner.

## Motivation and Context
Scanner shouldn't wait for a webhook request, it should just continue scanning. grequests uses gevent.

## How Has This Been Tested?
Tested on Win10 Py2.7.11 & Thunderfox tested as well.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.