### PR TITLE
Preventing teleportation of accounts in Spawnpoint Scanning mode by pre-scheduling scans to be below a speed limit

### DIFF
--- a/docs/extras/Spawnpoint-Scanning.md
+++ b/docs/extras/Spawnpoint-Scanning.md
@@ -45,3 +45,8 @@ Note: in this mode -st does nothing
 for generating the spawns to use with Spawnpoint Scanning it is recommended to scan the area with a scan that completes in 10 minutes for at least 1 hour, this should guarantee that all spawns are found
 
 spawn files can also be generated with an external tool such as spawnScan
+
+### Speed Limiting
+
+Spawnpoint scanning mode has speed limiting on by default. There are two parameters involved: max-speed (defaults to 30m/s), max-delay (defaults to 60s). You can tune the parameters via `-ms` or `-md`, respectively. Scans are assigned to each worker so that each worker stays under the speed limit. A deley will be added if necessary. If minimum delay needed is over max-delay, the scan point will be dropped. To elinimate dropped points, try either adding more accounts, increasing max-speed, or increassing max-delay.
+

--- a/docs/extras/Spawnpoint-Scanning.md
+++ b/docs/extras/Spawnpoint-Scanning.md
@@ -48,5 +48,5 @@ spawn files can also be generated with an external tool such as spawnScan
 
 ### Speed Limiting
 
-Spawnpoint scanning mode has speed limiting on by default. There are two parameters involved: max-speed (defaults to 30m/s), max-delay (defaults to 60s). You can tune the parameters via `-ms` or `-md`, respectively. Scans are assigned to each worker so that each worker stays under the speed limit. A deley will be added if necessary. If minimum delay needed is over max-delay, the scan point will be dropped. To elinimate dropped points, try either adding more accounts, increasing max-speed, or increassing max-delay.
+Speed limiting scheduler is not used by default. To use it, specify a positive max speed via `-ms` or `-max-speed`. There are two parameters involved: max-speed (defaults to off value of 0), max-delay (defaults to 60s). You can tune the parameters via `-ms` or `-md`, respectively. Scans are assigned to each worker so that each worker stays under the speed limit. A deley will be added if necessary. If minimum delay needed is over max-delay, the scan point will be dropped. To elinimate dropped points, try either adding more accounts, increasing max-speed, or increassing max-delay.
 

--- a/docs/extras/Spawnpoint-Scanning.md
+++ b/docs/extras/Spawnpoint-Scanning.md
@@ -48,5 +48,5 @@ spawn files can also be generated with an external tool such as spawnScan
 
 ### Speed Limiting
 
-Speed limiting scheduler is not used by default. To use it, specify a positive max speed via `-ms` or `-max-speed`. There are two parameters involved: max-speed (defaults to off value of 0), max-delay (defaults to 60s). You can tune the parameters via `-ms` or `-md`, respectively. Scans are assigned to each worker so that each worker stays under the speed limit. A deley will be added if necessary. If minimum delay needed is over max-delay, the scan point will be dropped. To elinimate dropped points, try either adding more accounts, increasing max-speed, or increassing max-delay.
+Speed limiting scheduler is not used by default. To use it, specify a positive max speed via `-ms` or `-max-speed` (units in m/s). There are two parameters involved: max-speed (defaults to off value of 0), max-delay (defaults to 60s). You can tune the parameters via `-ms` or `-md`, respectively. Scans are assigned to each worker so that each worker stays under the speed limit. A delay will be added if necessary. If maximum delay needed is over max-delay, the scan point will be dropped. To eliminate dropped points, try either adding more accounts, increasing max-speed, or increasing max-delay.
 

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -276,6 +276,121 @@ class SpawnScan(BaseScheduler):
             log.debug('Loading spawn points from database')
             self.locations = Pokemon.get_spawnpoints_in_hex(self.scan_location, self.args.step_limit)
 
+        # Well shit...
+        # if not self.locations:
+        #    raise Exception('No availabe spawn points!')
+
+        # locations[]:
+        # {"lat": 37.53079079414139, "lng": -122.28811690874117, "spawnpoint_id": "808f9f1601d", "time": 511
+
+        log.info('Total of %d spawns to track', len(self.locations))
+
+        # locations.sort(key=itemgetter('time'))
+
+        if self.args.very_verbose:
+            for i in self.locations:
+                sec = i['time'] % 60
+                minute = (i['time'] / 60) % 60
+                m = 'Scan [{:02}:{:02}] ({}) @ {},{}'.format(minute, sec, i['time'], i['lat'], i['lng'])
+                log.debug(m)
+
+        # 'time' from json and db alike has been munged to appearance time as seconds after the hour
+        # Here we'll convert that to a real timestamp
+        for location in self.locations:
+            # For a scan which should cover all CURRENT pokemon, we can offset
+            # the comparison time by 15 minutes so that the "appears" time
+            # won't be rolled over to the next hour.
+
+            # TODO: Make it work. The original logic (commented out) was producing
+            #       bogus results if your first scan was in the last 15 minute of
+            #       the hour. Wrapping my head around this isn't work right now,
+            #       so I'll just drop the feature for the time being. It does need
+            #       to come back so that repositioning/pausing works more nicely,
+            #       but we can live without it too.
+
+            # if sps_scan_current:
+            #     cursec = (location['time'] + 900) % 3600
+            # else:
+            cursec = location['time']
+
+            if cursec > cur_sec():
+                # hasn't spawn in the current hour
+                from_now = location['time'] - cur_sec()
+                appears = now() + from_now
+            else:
+                # won't spawn till next hour
+                late_by = cur_sec() - location['time']
+                appears = now() + 3600 - late_by
+
+            location['appears'] = appears
+            location['leaves'] = appears + 900
+
+        # Put the spawn points in order of next appearance time
+        self.locations.sort(key=itemgetter('appears'))
+
+        # Match expected structure:
+        # locations = [((lat, lng, alt), ts_appears, ts_leaves),...]
+        retset = []
+        for step, location in enumerate(self.locations, 1):
+            retset.append((step, (location['lat'], location['lng'], 40.32), location['appears'], location['leaves']))
+
+        return retset
+
+    # Schedule the work to be done
+    def schedule(self):
+        if not self.scan_location:
+            log.warning('Cannot schedule work until scan location has been set')
+            return
+
+        # SpawnScan needs to calculate the list every time, since the times will change.
+        self.locations = self._generate_locations()
+
+        for location in self.locations:
+            # FUTURE IMPROVEMENT - For now, queues is assumed to have a single queue.
+            self.queues[0].put(location)
+            log.debug("Added location {}".format(location))
+
+        # Clear the locations list so it gets regenerated next cycle
+        self.size = len(self.locations)
+        self.locations = None
+
+
+# This class adds speed limiting to spawnscan
+class SpawnScanSpeedLimit(BaseScheduler):
+    def __init__(self, queues, status, args):
+        BaseScheduler.__init__(self, queues, status, args)
+        # On the first scan, we want to search the last 15 minutes worth of spawns to get existing
+        # pokemon onto the map.
+        self.firstscan = True
+
+        # If we are only scanning for pokestops/gyms, the scan radius can be 900m.  Otherwise 70m
+        if self.args.no_pokemon:
+            self.step_distance = 0.900
+        else:
+            self.step_distance = 0.070
+
+        self.step_limit = args.step_limit
+        self.locations = False
+
+    # Generate locations is called when the locations list is cleared - the first time it scans or after a location change.
+    def _generate_locations(self):
+        # Attempt to load spawns from file
+        if self.args.spawnpoint_scanning != 'nofile':
+            log.debug('Loading spawn points from json file @ %s', self.args.spawnpoint_scanning)
+            try:
+                with open(self.args.spawnpoint_scanning) as file:
+                    self.locations = json.load(file)
+            except ValueError as e:
+                log.exception(e)
+                log.error('JSON error: %s; will fallback to database', e)
+            except IOError as e:
+                log.error('Error opening json file: %s; will fallback to database', e)
+
+        # No locations yet? Try the database!
+        if not self.locations:
+            log.debug('Loading spawn points from database')
+            self.locations = Pokemon.get_spawnpoints_in_hex(self.scan_location, self.args.step_limit)
+
         # Run the scheduling algorithm
         # This adds a "worker" field
         self.locations = self.assign_spawns(self.locations)
@@ -463,7 +578,8 @@ class SchedulerFactory():
     __schedule_classes = {
         "hexsearch": HexSearch,
         "hexsearchspawnpoint": HexSearchSpawnpoint,
-        "spawnscan": SpawnScan
+        "spawnscan": SpawnScan,
+        "spawnscanspeedlimit": SpawnScanSpeedLimit
     }
 
     @staticmethod

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -371,6 +371,7 @@ class SpawnScanSpeedLimit(BaseScheduler):
 
         self.step_limit = args.step_limit
         self.locations = False
+        self.last_schedule = 0
 
     # Generate locations is called when the locations list is cleared - the first time it scans or after a location change.
     def _generate_locations(self):
@@ -433,6 +434,10 @@ class SpawnScanSpeedLimit(BaseScheduler):
             log.warning('Cannot schedule work until scan location has been set')
             return
 
+        # Only schedule once per hour
+        if now() - self.last_schedule < 3600:
+            return
+
         # SpawnScan needs to calculate the list every time, since the times will change.
         self.locations = self._generate_locations()
 
@@ -440,6 +445,8 @@ class SpawnScanSpeedLimit(BaseScheduler):
             # FUTURE IMPROVEMENT - For now, queues is assumed to have a single queue.
             self.queues[location[0]].put(location[1:])
             log.debug("Added location {}".format(location[1:]))
+
+        self.last_schedule = now()
 
         # Clear the locations list so it gets regenerated next cycle
         self.size = len(self.locations)

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -556,8 +556,6 @@ class SpawnScanSpeedLimit(BaseScheduler):
             log.info('Number of scan delays: %d.' % len(delays))
             log.info('Average delay: %f seconds.' % (sum(delays) / len(delays)))
             log.info('Max delay: %f seconds.' % max(delays))
-            if max(delays) > self.args.max_delay:
-                log.info('Cannot assign spawn points under max-delay. Try increasing number of accounts, decreasing number of spawn points, or increasing max-delay.')
         else:
             log.info('No additional delay is added to any spawn point.')
 

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -556,8 +556,8 @@ class SpawnScanSpeedLimit(BaseScheduler):
             log.info('Number of scan delays: %d.' % len(delays))
             log.info('Average delay: %f seconds.' % (sum(delays) / len(delays)))
             log.info('Max delay: %f seconds.' % max(delays))
-            if max(delays) > 60:
-                log.info('Cannot assign spawn points with delay less than a minute. You should try increasing number of accounts or decreasing number of spawn points.')
+            if max(delays) > self.args.max_delay:
+                log.info('Cannot assign spawn points under max-delay. Try increasing number of accounts, decreasing number of spawn points, or increasing max-delay.')
         else:
             log.info('No additional delay is added to any spawn point.')
 

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -280,11 +280,6 @@ class SpawnScan(BaseScheduler):
         # This adds a "worker" field
         self.locations = self.assign_spawns(self.locations)
 
-
-        # Well shit...
-        # if not self.locations:
-        #    raise Exception('No availabe spawn points!')
-
         # locations[]:
         # {"lat": 37.53079079414139, "lng": -122.28811690874117, "spawnpoint_id": "808f9f1601d", "time": 511, "worker": 1}
 
@@ -312,8 +307,8 @@ class SpawnScan(BaseScheduler):
         # Match expected structure:
         # locations = [((lat, lng, alt), ts_scan_time, ts_leaves),...]
         retset = [(location['worker'], step, (location['lat'], location['lng'],
-            40.32), location['scan_time'], location['leaves']) for step,
-            location in enumerate(self.locations, 1)]
+                   40.32), location['scan_time'], location['leaves']) for step,
+                   location in enumerate(self.locations, 1)]
 
         return retset
 
@@ -351,13 +346,6 @@ class SpawnScan(BaseScheduler):
                 return float('inf')
             else:
                 return dist(sp1, sp2) / time
-
-        def print_speed(q):
-            s = []
-            for i in range(len(q)):
-                j = (i + 1) % len(q)
-                s.append(speed(q[i], q[j]))
-            print 'Max speed: %f, avg speed %f' % (max(s), sum(s)/len(s))
 
         # Insert has has two modes of operation.
         # If dry=True, it will simulate inserting sp and return the "cost" of
@@ -422,7 +410,7 @@ class SpawnScan(BaseScheduler):
         # set of points that cannot be covered (bad).
         def greedy_assign(spawns, n):
             for sp in spawns:
-                sp['scan_time'] = (sp['time'] + 10) % 3600 # 10 seconds grace period
+                sp['scan_time'] = (sp['time'] + 10) % 3600  # 10 seconds grace period
             spawns.sort(key=itemgetter('scan_time'))
             Q = [[] for i in range(n)]
             delays = []
@@ -439,7 +427,7 @@ class SpawnScan(BaseScheduler):
                     bad.append(sp)
 
             log.info("Assigned %d spawn points to %d workers, left out %d points" %
-                    (len(spawns) - len(bad), n, len(bad)))
+                     (len(spawns) - len(bad), n, len(bad)))
             return Q, delays, bad
 
         Q, delays, bad = greedy_assign(spawns, num_workers)

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -474,7 +474,12 @@ class SpawnScanSpeedLimit(BaseScheduler):
             if len(queue) == 0:
                 if not dry:
                     queue.append(sp)
-                return self.args.max_delay / 3, self.args.max_speed, self.args.max_speed, self.args.max_speed
+                    return 0, self.args.max_speed, self.args.max_speed, self.args.max_speed
+                else:
+                    # Return bogus deley so that a new worker only comes in
+                    # when existing workers cannot take the point with less
+                    # than a thrid of max_delay
+                    return self.args.max_delay / 3, self.args.max_speed, self.args.max_speed, self.args.max_speed
 
             # A potential position P could be scheduled between A and B if A
             # happens before P + max_delay and B happens after P

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -308,7 +308,7 @@ class SpawnScan(BaseScheduler):
         # locations = [((lat, lng, alt), ts_scan_time, ts_leaves),...]
         retset = [(location['worker'], step, (location['lat'], location['lng'],
                    40.32), location['scan_time'], location['leaves']) for step,
-                   location in enumerate(self.locations, 1)]
+                  location in enumerate(self.locations, 1)]
 
         return retset
 

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -413,8 +413,8 @@ class SpawnScanSpeedLimit(BaseScheduler):
         # 'time' from json and db alike has been munged to appearance time as seconds after the hour
         # Here we'll convert that to a real timestamp
         for location in self.locations:
-            location['scan_time'] = now() + (cur_sec() - location['scan_time']) % 3600
-            location['leaves'] = now() + (cur_sec() - location['time']) % 3600 + 900
+            location['scan_time'] = now() + (location['scan_time'] - cur_sec()) % 3600
+            location['leaves'] = now() + (location['time'] - cur_sec()) % 3600 + 900
 
         # Put the spawn points in order of the scheduled scan time
         self.locations.sort(key=itemgetter('scan_time'))

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -88,7 +88,7 @@ def switch_status_printer(display_type, current_page):
 
 
 # Thread to print out the status of each worker
-def status_printer(threadStatus, search_items_queue, db_updates_queue, wh_queue, account_queue, account_failures):
+def status_printer(threadStatus, search_items_queues, db_updates_queue, wh_queue, account_queue, account_failures):
     display_type = ["workers"]
     current_page = [1]
 
@@ -126,7 +126,7 @@ def status_printer(threadStatus, search_items_queue, db_updates_queue, wh_queue,
                     skip_total += threadStatus[item]['skip']
 
             # Print the queue length
-            status_text.append('Queues: {} search items, {} db updates, {} webhook.  Total skipped items: {}. Spare accounts available: {}. Accounts on hold: {}'.format(search_items_queue.qsize(), db_updates_queue.qsize(), wh_queue.qsize(), skip_total, account_queue.qsize(), len(account_failures)))
+            status_text.append('Queues: {} search items, {} db updates, {} webhook.  Total skipped items: {}. Spare accounts available: {}. Accounts on hold: {}'.format(str([q.qsize() for q in search_items_queues]), db_updates_queue.qsize(), wh_queue.qsize(), skip_total, account_queue.qsize(), len(account_failures)))
 
             # Print status of overseer
             status_text.append('{} Overseer: {}'.format(threadStatus['Overseer']['scheduler'], threadStatus['Overseer']['message']))
@@ -255,7 +255,11 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
 
     log.info('Search overseer starting')
 
-    search_items_queue = Queue()
+    if args.scheduler.lower() == "spawnscan":
+        search_items_queues = [Queue() for a in args.accounts]
+    else:
+        search_items_queues = [Queue()]
+
     account_queue = Queue()
     threadStatus = {}
 
@@ -281,7 +285,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
         log.info('Starting status printer thread')
         t = Thread(target=status_printer,
                    name='status_printer',
-                   args=(threadStatus, search_items_queue, db_updates_queue, wh_queue, account_queue, account_failures))
+                   args=(threadStatus, search_items_queues, db_updates_queue, wh_queue, account_queue, account_failures))
         t.daemon = True
         t.start()
 
@@ -330,7 +334,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
 
         t = Thread(target=search_worker_thread,
                    name='search-worker-{}'.format(i),
-                   args=(args, account_queue, account_failures, search_items_queue, pause_bit,
+                   args=(args, account_queue, account_failures, search_items_queues[i % len(search_items_queues)], pause_bit,
                          encryption_lib_path, threadStatus[workerId],
                          db_updates_queue, wh_queue))
         t.daemon = True
@@ -340,7 +344,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
     current_location = False
 
     # Create the appropriate type of scheduler to handle the search queue.
-    scheduler = schedulers.SchedulerFactory.get_scheduler(args.scheduler, [search_items_queue], threadStatus, args)
+    scheduler = schedulers.SchedulerFactory.get_scheduler(args.scheduler, search_items_queues, threadStatus, args)
 
     # The real work starts here but will halt on pause_bit.set()
     while True:
@@ -362,19 +366,23 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
 
         # If there are no search_items_queue either the loop has finished (or been
         # cleared above) -- either way, time to fill it back up
-        if search_items_queue.empty():
-            log.debug('Search queue empty, scheduling more items to scan')
-            scheduler.schedule()
-        else:
-            nextitem = search_items_queue.queue[0]
-            threadStatus['Overseer']['message'] = 'Processing search queue, next item is {:6f},{:6f}'.format(nextitem[1][0], nextitem[1][1])
-            # If times are specified, print the time of the next queue item, and how many seconds ahead/behind realtime
-            if nextitem[2]:
-                threadStatus['Overseer']['message'] += ' @ {}'.format(time.strftime('%H:%M:%S', time.localtime(nextitem[2])))
-                if nextitem[2] > now():
-                    threadStatus['Overseer']['message'] += ' ({}s ahead)'.format(nextitem[2] - now())
-                else:
-                    threadStatus['Overseer']['message'] += ' ({}s behind)'.format(now() - nextitem[2])
+        msgs = []
+        for search_items_queue in search_items_queues:
+            if search_items_queue.empty():
+                log.debug('Search queue empty, scheduling more items to scan')
+                scheduler.schedule()
+            else:
+                nextitem = search_items_queue.queue[0]
+                msg = '{:6f},{:6f}'.format(nextitem[1][0], nextitem[1][1])
+                # If times are specified, print the time of the next queue item, and how many seconds ahead/behind realtime
+                if nextitem[2]:
+                    msg += ' @ {}'.format(time.strftime('%H:%M:%S', time.localtime(nextitem[2])))
+                    if nextitem[2] > now():
+                        msg += ' ({}s ahead)'.format(nextitem[2] - now())
+                    else:
+                        msg += ' ({}s behind)'.format(now() - nextitem[2])
+                msgs.append(msg)
+        threadStatus['Overseer']['message'] = 'next item(s): ' + ', '.join(msgs)
 
         # Now we just give a little pause here
         time.sleep(1)
@@ -447,17 +455,17 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
 
                 # Grab the next thing to search (when available)
                 status['message'] = 'Waiting for item from queue'
-                step, step_location, appears, leaves = search_items_queue.get()
+                step, step_location, scan_time, leaves = search_items_queue.get()
 
                 # too soon?
-                if appears and now() < appears + 10:  # adding a 10 second grace period
+                if scan_time and now() < scan_time:  # adding a 10 second grace period
                     first_loop = True
                     paused = False
-                    while now() < appears + 10:
+                    while now() < scan_time:
                         if pause_bit.is_set():
                             paused = True
                             break  # why can't python just have `break 2`...
-                        remain = appears - now() + 10
+                        remain = scan_time - now()
                         status['message'] = 'Early for {:6f},{:6f}; waiting {}s...'.format(step_location[0], step_location[1], remain)
                         if first_loop:
                             log.info(status['message'])

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -255,7 +255,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
 
     log.info('Search overseer starting')
 
-    if args.scheduler.lower() == "spawnscan":
+    if args.scheduler.lower() == "spawnscanspeedlimit":
         search_items_queues = [Queue() for i in range(args.workers)]
     else:
         search_items_queues = [Queue()]

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -256,7 +256,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
     log.info('Search overseer starting')
 
     if args.scheduler.lower() == "spawnscan":
-        search_items_queues = [Queue() for a in args.accounts]
+        search_items_queues = [Queue() for i in range(args.workers)]
     else:
         search_items_queues = [Queue()]
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -366,23 +366,12 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
 
         # If there are no search_items_queue either the loop has finished (or been
         # cleared above) -- either way, time to fill it back up
-        msgs = []
+        threadStatus['Overseer']['message'] = ''
         for search_items_queue in search_items_queues:
             if search_items_queue.empty():
                 log.debug('Search queue empty, scheduling more items to scan')
+                threadStatus['Overseer']['message'] = 'Some queues are empty, scheduling..'
                 scheduler.schedule()
-            else:
-                nextitem = search_items_queue.queue[0]
-                msg = '{:6f},{:6f}'.format(nextitem[1][0], nextitem[1][1])
-                # If times are specified, print the time of the next queue item, and how many seconds ahead/behind realtime
-                if nextitem[2]:
-                    msg += ' @ {}'.format(time.strftime('%H:%M:%S', time.localtime(nextitem[2])))
-                    if nextitem[2] > now():
-                        msg += ' ({}s ahead)'.format(nextitem[2] - now())
-                    else:
-                        msg += ' ({}s behind)'.format(now() - nextitem[2])
-                msgs.append(msg)
-        threadStatus['Overseer']['message'] = 'next item(s): ' + ', '.join(msgs)
 
         # Now we just give a little pause here
         time.sleep(1)

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -370,8 +370,13 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
         for search_items_queue in search_items_queues:
             if search_items_queue.empty():
                 log.debug('Search queue empty, scheduling more items to scan')
-                threadStatus['Overseer']['message'] = 'Some queues are empty, scheduling..'
+                threadStatus['Overseer']['message'] = 'Some queues are empty, scheduling.. '
                 scheduler.schedule()
+
+        try:
+            threadStatus['Overseer']['message'] += scheduler.print_status()
+        except AttributeError:
+            pass
 
         # Now we just give a little pause here
         time.sleep(1)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -136,9 +136,9 @@ def get_args():
     parser.add_argument('--dump-spawnpoints', help='dump the spawnpoints from the db to json (only for use with -ss)',
                         action='store_true', default=False)
     parser.add_argument('-ms', '--max-speed',
-                        help='Max speed allowed in spawnpoint mode. Workers shall not travel exceeding this speed. Defaults to 30 m/s.', type=float, default=30)
+                        help='A positive value will turn on speed limiting scheduler (value in m/s). Defaults to off value of 0.', type=float, default=0)
     parser.add_argument('-md', '--max-delay',
-                        help='Max delay allowed in spawnpoint mode. Points shall be dropped if they cannot be scheduled within this delay. Defaults to 60s.', type=float, default=60)
+                        help='Max delay allowed in spawnpoint speed-limiting mode. Points shall be dropped if they cannot be scheduled within this delay. Defaults to 60s.', type=float, default=60)
     parser.add_argument('-pd', '--purge-data',
                         help='Clear pokemon from database this many hours after they disappear \
                         (0 to disable)', type=int, default=0)
@@ -341,7 +341,10 @@ def get_args():
 
         # Decide which scanning mode to use
         if args.spawnpoint_scanning:
-            args.scheduler = 'SpawnScan'
+            if args.max_speed > 0:
+                args.scheduler = 'SpawnScanSpeedLimit'
+            else:
+                args.scheduler = 'SpawnScan'
         elif args.spawnpoints_only:
             args.scheduler = 'HexSearchSpawnpoint'
         else:

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -135,6 +135,10 @@ def get_args():
                         help='Use spawnpoint scanning (instead of hex grid). Scans in a circle based on step_limit when on DB', nargs='?', const='nofile', default=False)
     parser.add_argument('--dump-spawnpoints', help='dump the spawnpoints from the db to json (only for use with -ss)',
                         action='store_true', default=False)
+    parser.add_argument('-ms', '--max-speed',
+                        help='Max speed allowed in spawnpoint mode. Workers shall not travel exceeding this speed. Defaults to 30 m/s.', type=float, default=30)
+    parser.add_argument('-md', '--max-delay',
+                        help='Max delay allowed in spawnpoint mode. Points shall be dropped if they cannot be scheduled within this delay. Defaults to 60s.', type=float, default=60)
     parser.add_argument('-pd', '--purge-data',
                         help='Clear pokemon from database this many hours after they disappear \
                         (0 to disable)', type=int, default=0)


### PR DESCRIPTION
## Description

This commit adds a method `assign_spawns' to assign a worker id to each
spawn point. The goal is to keep each worker's scanning speed to be
below a set limit (defaults to 30m/s). The algorithm greedily tries to
assign each spawnpoint to the account that need to travel the slowest to
scan that location. If this cannot be done, an additional delay will be
added. User will be prompted to increase the number of accounts used if
such delay is larger than 60s.
## Motivation and Context

Spawnpoint scanning of a large area can create soft bans since account sometimes teleport (i.e. travel with very fast speed). This commit pre-schedules scans to each account so that all scans are done under the default speed limit of 30 m/s (~67mi/h, 108km/h). The speed limit is configurable via the new option "-ms", "--max-speed".
## How Has This Been Tested?

Changes:
- Method `assign_spawns` is added. `assign_spawns` takes the list of spawnpoints, number of workers / accounts, the max speed, and returns the same list of spawns with an extra field "worker" that contains which worker the spawnpoint is assigned.
- `search_items_queue` is changed to a list of queues instead. Each worker gets a queue that the overseer thread will fill based on the field "worker" of the spawnpoint.

Tested on update-to-date Arch linux setup. Experiments shows that under a number of spawnpoint distributions, 50 spawnpoints / account is the sweet spot of staying under the speed limit.

These changes only affect spawnpoint scanning mode. Changes are also made so that existing interfaces of Spawnpoint Scanning are changed as minimally as possible.
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
