### PR TITLE
Pokestops were showing on the api when unrequested

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -89,7 +89,7 @@ class Pogom(Flask):
             else:
                 d['pokemons'] = Pokemon.get_active(swLat, swLng, neLat, neLng)
 
-        if request.args.get('pokestops', 'false') == 'true':
+        if request.args.get('pokestops', 'true') == 'true':
             d['pokestops'] = Pokestop.get_stops(swLat, swLng, neLat, neLng)
 
         if request.args.get('gyms', 'true') == 'true':


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Pokestops were showing on raw_data when unrequested
and not showing when requested?

## Motivation and Context
No need for sending more data than requested

## How Has This Been Tested?
tested and working.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

