### PR TITLE
Output nice error when map download fails and remove worker after 3 f…

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -18,6 +18,7 @@ from . import config
 from .utils import get_pokemon_name, get_pokemon_rarity, get_pokemon_types, get_args, send_to_webhook
 from .transform import transform_from_wgs_to_gcj
 from .customLog import printPokemon
+from pgoapi.exceptions import AuthException
 
 log = logging.getLogger(__name__)
 
@@ -378,8 +379,18 @@ def parse_map(map_dict, step_location):
     pokestops = {}
     gyms = {}
     scanned = {}
-
-    cells = map_dict['responses']['GET_MAP_OBJECTS']['map_cells']
+    
+    
+        
+    try:
+        cells = map_dict['responses']['GET_MAP_OBJECTS']['map_cells']['map_cells']
+    except KeyError as e:
+        log.error("Unable to parse map: {}".format(e))
+        raise AuthException
+    except TypeError as e:
+        log.error("Unable to parse map: {}".format(e))
+        raise AuthException
+    
     for cell in cells:
         if config['parse_pokemon']:
             for p in cell.get('wild_pokemons', []):
@@ -434,7 +445,7 @@ def parse_map(map_dict, step_location):
                         'active_fort_modifier': active_fort_modifier
                     }
 
-                    # Include lured pokÃ©stops in our updates to webhooks
+                    # Include lured pokéstops in our updates to webhooks
                     if args.webhook_updates_only:
                         send_to_webhook('pokestop', webhook_data)
                 else:
@@ -451,7 +462,7 @@ def parse_map(map_dict, step_location):
                     'active_fort_modifier': active_fort_modifier,
                 }
 
-                # Send all pokÃ©stops to webhooks
+                # Send all pokéstops to webhooks
                 if not args.webhook_updates_only:
                     # Explicitly set 'webhook_data', in case we want to change the information pushed to webhooks,
                     # similar to above and previous commits.

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -353,7 +353,8 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                         log.error('User {}: search area download failed: not logged in'.format(account['username'],e))
                         account['disabled'] = True
                         with open("loginerrors.log", "a") as myfile:
-                            myfile.write(str(time_now) + "\t" + str(account['username']) + "\t" + str(response_dict))
+                            myfile.write(str(time_now) + "\t" + str(account['username']) + "\t Reason: " + str(response_dict))
+                            myfile.write("\n")
                         return
                         
                     elif not response_dict or type(response_dict) != type({}):
@@ -366,7 +367,8 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                             account['disabled'] = True
                             log.error('User {}: Exceeded map download retries: removed worker'.format(account['username']))
                             with open("loginerrors.log", "a") as myfile:
-                                myfile.write(str(time_now) + "\t" + str(account['username']) + "\t" + str(response_dict))
+                                myfile.write(str(time_now) + "\t" + str(account['username']) + "\t Reason: " + str(response_dict))
+                                myfile.write("\n")
                         time.sleep(sleep_time)
                         continue
 
@@ -375,6 +377,7 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                         try:
                             parse_map(response_dict, step_location)
                             log.debug('Search step %s completed', step)
+                            account['fails'] = 0
                             search_items_queue.task_done()
                             break  # All done, get out of the request-retry loop
                         except KeyError as e:
@@ -401,7 +404,8 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                             if account['fails'] > 3:
                                 account['disabled'] = True
                                 with open("loginerrors.log", "a") as myfile:
-                                    myfile.write(str(time_now) + "\t" + str(account['username']) + "\t" + str(e))
+                                    myfile.write(str(time_now) + "\t" + str(account['username']) + "\t Reason: " + str(response_dict))
+                                    myfile.write("\n")
                                 log.error('User {}: Exceeded map parsing retries: removed worker'.format(account['username']))
                             break
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -24,6 +24,7 @@ import os
 import random
 import time
 import geopy.distance as geopy_distance
+from datetime import datetime
 
 from operator import itemgetter
 from threading import Thread, Lock
@@ -32,7 +33,7 @@ from queue import Queue, Empty
 from pgoapi import PGoApi
 from pgoapi.utilities import f2i
 from pgoapi import utilities as util
-from pgoapi.exceptions import AuthException
+from pgoapi.exceptions import AuthException,NotLoggedInException
 
 from .models import parse_map, Pokemon
 
@@ -312,7 +313,7 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                 # Grab the next thing to search (when available)
                 step, step_location = search_items_queue.get()
 
-                log.info('Search step %d beginning (queue size is %d)', step, search_items_queue.qsize())
+                log.debug('Search step %d beginning (queue size is %d)', step, search_items_queue.qsize())
 
                 # Let the api know where we intend to be for this loop
                 api.set_position(*step_location)
@@ -320,7 +321,10 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                 # The loop to try very hard to scan this step
                 failed_total = 0
                 while True:
-
+                    time_now = datetime.now().strftime("%Y-%m-%d %H:%M")
+                    
+                    if 'disabled' in account and account['disabled']: return
+                    
                     # After so many attempts, let's get out of here
                     if failed_total >= args.scan_retries:
                         # I am choosing to NOT place this item back in the queue
@@ -344,9 +348,25 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                     response_dict = map_request(api, step_location)
 
                     # G'damnit, nothing back. Mark it up, sleep, carry on
-                    if not response_dict:
-                        log.error('Search step %d area download failed, retrying request in %g seconds', step, sleep_time)
+                    
+                    if response_dict is NotLoggedInException:
+                        log.error('User {}: search area download failed: not logged in'.format(account['username'],e))
+                        account['disabled'] = True
+                        with open("loginerrors.log", "a") as myfile:
+                            myfile.write(str(time_now) + "\t" + str(account['username']) + "\t" + str(response_dict))
+                        return
+                        
+                    elif not response_dict or type(response_dict) != type({}):
+                        log.error('User {}: search step %d area download failed, retrying request in %g seconds'.format(account['username']), step, sleep_time)
                         failed_total += 1
+                        
+                        if not 'fails' in account: account['fails'] = 0
+                        account['fails'] += 1
+                        if account['fails'] > 3:
+                            account['disabled'] = True
+                            log.error('User {}: Exceeded map download retries: removed worker'.format(account['username']))
+                            with open("loginerrors.log", "a") as myfile:
+                                myfile.write(str(time_now) + "\t" + str(account['username']) + "\t" + str(response_dict))
                         time.sleep(sleep_time)
                         continue
 
@@ -357,16 +377,33 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                             log.debug('Search step %s completed', step)
                             search_items_queue.task_done()
                             break  # All done, get out of the request-retry loop
-                        except KeyError:
-                            log.exception('Search step %s map parsing failed, retrying request in %g seconds. Username: %s', step, sleep_time, account['username'])
+                        except KeyError as e:
+                            log.warning('User {}: Search step {} map parsing failed: {}, retrying request in {} seconds'.format(account['username'],step,e,sleep_time))
                             failed_total += 1
-                    time.sleep(sleep_time)
+                            time.sleep(sleep_time)
+                        except TypeError as e:
+                            log.warning('User {}: Search step {} map parsing failed: {}, retrying request in {} seconds'.format(account['username'],step,e,sleep_time))
+                            failed_total += 1
+                            time.sleep(sleep_time)
+                        except AuthException as e:
+                            log.warning('User {}: Search step {} map parsing failed!, retrying request in {} seconds'.format(account['username'],step,e,sleep_time))
+                            failed_total += 1
+                            time.sleep(sleep_time)
+                        # If there's any time left between the start time and the time when we should be kicking off the next
+                        # loop, hang out until its up.
+                        sleep_delay_remaining = loop_start_time + (args.scan_delay * 1000) - int(round(time.time() * 1000))
+                        if sleep_delay_remaining > 0:
+                            time.sleep(sleep_delay_remaining / 1000)
 
-                # If there's any time left between the start time and the time when we should be kicking off the next
-                # loop, hang out until its up.
-                sleep_delay_remaining = loop_start_time + (args.scan_delay * 1000) - int(round(time.time() * 1000))
-                if sleep_delay_remaining > 0:
-                    time.sleep(sleep_delay_remaining / 1000)
+                            if not 'fails' in account: account['fails'] = 0
+                            account['fails'] += 1
+                            
+                            if account['fails'] > 3:
+                                account['disabled'] = True
+                                with open("loginerrors.log", "a") as myfile:
+                                    myfile.write(str(time_now) + "\t" + str(account['username']) + "\t" + str(e))
+                                log.error('User {}: Exceeded map parsing retries: removed worker'.format(account['username']))
+                            break
 
                 loop_start_time += args.scan_delay * 1000
 


### PR DESCRIPTION
## Description
i) Catch some exceptions in models.pyL385, raise AuthException. Exceptions needed to catch here because they are first triggered here

ii) In search.py:
- Check if response_dict is of type 'dict'
- Output account name if map download or parse fails
- Remove worker (account name) if repeatedly failing
- Log removed workers in loginerrors.log in root dir

## Motivation and Context
Users are confused with error messages such as "list indices must be integers, not str" etc and spam in #general or #help

## How Has This Been Tested?
Tested on my development branch

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

…ailed attemps. Log removed workers to file 'loginerrors.log'