### PR TITLE
Fix Scan delay between scan

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -322,11 +322,6 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                         log.error('Search step %d went over max scan_retires; abandoning', step)
                         break
 
-                    # Increase sleep delay between each failed scan
-                    # By default scan_dela=5, scan_retries=5 so
-                    # We'd see timeouts of 5, 10, 15, 20, 25
-                    sleep_time = args.scan_delay * (1 + failed_total)
-
                     # Ok, let's get started -- check our login status
                     check_login(args, account, api, step_location)
 
@@ -339,6 +334,7 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                     if not response_dict:
                         log.error('Search step %d area download failed, retrying request in %g seconds', step, sleep_time)
                         failed_total += 1
+                        sleep_time = args.scan_delay * (1 + failed_total)
                         time.sleep(sleep_time)
                         continue
 
@@ -352,7 +348,15 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                         except KeyError:
                             log.exception('Search step %s map parsing failed, retrying request in %g seconds. Username: %s', step, sleep_time, account['username'])
                             failed_total += 1
-                    time.sleep(sleep_time)
+                            # Increase sleep delay between each failed scan
+                            # By default scan_dela=5, scan_retries=5 so
+                            # We'd see timeouts of 5, 10, 15, 20, 25
+                            sleep_time = args.scan_delay * (1 + failed_total)
+
+                            time.sleep(sleep_time)
+
+                time.sleep(args.scan_delay)
+
 
                 # If there's any time left between the start time and the time when we should be kicking off the next
                 # loop, hang out until its up.

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -322,6 +322,11 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                         log.error('Search step %d went over max scan_retires; abandoning', step)
                         break
 
+                    # Increase sleep delay between each failed scan
+                    # By default scan_dela=5, scan_retries=5 so
+                    # We'd see timeouts of 5, 10, 15, 20, 25
+                    sleep_time = args.scan_delay * (1 + failed_total)
+
                     # Ok, let's get started -- check our login status
                     check_login(args, account, api, step_location)
 
@@ -334,7 +339,6 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                     if not response_dict:
                         log.error('Search step %d area download failed, retrying request in %g seconds', step, sleep_time)
                         failed_total += 1
-                        sleep_time = args.scan_delay * (1 + failed_total)
                         time.sleep(sleep_time)
                         continue
 
@@ -348,15 +352,9 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                         except KeyError:
                             log.exception('Search step %s map parsing failed, retrying request in %g seconds. Username: %s', step, sleep_time, account['username'])
                             failed_total += 1
-                            # Increase sleep delay between each failed scan
-                            # By default scan_dela=5, scan_retries=5 so
-                            # We'd see timeouts of 5, 10, 15, 20, 25
-                            sleep_time = args.scan_delay * (1 + failed_total)
-
                             time.sleep(sleep_time)
 
                 time.sleep(args.scan_delay)
-
 
                 # If there's any time left between the start time and the time when we should be kicking off the next
                 # loop, hang out until its up.


### PR DESCRIPTION
Stop the thread for scan_delay between each scan.

## Description
Add a time.sleep(args.scan_delay) after each scan.

## Motivation and Context
Avoid the server block the user for too much requests.

## How Has This Been Tested?
Tested local

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

- correct scan delay