### PR TITLE
Alternative Scanned Marker

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 args = get_args()
 flaskDb = FlaskDB()
 
-db_schema_version = 5
+db_schema_version = 6
 
 
 class MyRetryDB(RetryOperationalError, PooledMySQLDatabase):
@@ -342,6 +342,7 @@ class ScannedLocation(BaseModel):
     latitude = DoubleField()
     longitude = DoubleField()
     last_modified = DateTimeField(index=True)
+    hue = IntegerField()
 
     class Meta:
         primary_key = CompositeKey('latitude', 'longitude')
@@ -508,6 +509,7 @@ def parse_map(map_dict, step_location):
         'latitude': step_location[0],
         'longitude': step_location[1],
         'last_modified': datetime.utcnow(),
+        'hue': 190
     }
 
     while True:
@@ -651,3 +653,6 @@ def database_migrate(db, old_ver):
                  .where(Pokemon.disappear_time >
                         (datetime.utcnow() - timedelta(hours=24))))
         query.execute()
+
+    if old_ver < 6:
+        db.drop_tables([ScannedLocation])

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1389,7 +1389,7 @@ function showInBoundsMarkers (markers) {
 function loadRawData () {
   var loadPokemon = Store.get('showPokemon')
   var loadGyms = Store.get('showGyms')
-  var loadPokestops = Store.get('showPokestops') || Store.get('showPokemon')
+  var loadPokestops = Store.get('showPokestops')
   var loadScanned = Store.get('showScanned')
   var loadSpawnpoints = Store.get('showSpawnpoints')
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1250,7 +1250,7 @@ function setupPokestopMarker (item) {
   return marker
 }
 
-function getColorByDate (value) {
+function getColorByDate(value, hue) {
   // Changes the color from red to green over 15 mins
   var diff = (Date.now() - value) / 1000 / 60 / 15
 
@@ -1258,9 +1258,9 @@ function getColorByDate (value) {
     diff = 1
   }
 
-  // value from 0 to 1 - Green to Red
-  var hue = ((1 - diff) * 120).toString(10)
-  return ['hsl(', hue, ',100%,50%)'].join('')
+  // value from 0 to 1 - color to white
+  var lightness = (50 + (diff * 50)).toString(10)
+  return ['hsl(',hue,',90%,',lightness,'%)'].join('')
 }
 
 function setupScannedMarker (item) {
@@ -1271,8 +1271,8 @@ function setupScannedMarker (item) {
     clickable: false,
     center: circleCenter,
     radius: 70, // metres
-    fillColor: getColorByDate(item['last_modified']),
-    strokeWeight: 1
+    fillColor: getColorByDate(item['last_modified'], item['hue']),
+    strokeWeight: 0
   })
 
   return marker
@@ -1389,7 +1389,7 @@ function showInBoundsMarkers (markers) {
 function loadRawData () {
   var loadPokemon = Store.get('showPokemon')
   var loadGyms = Store.get('showGyms')
-  var loadPokestops = Store.get('showPokestops')
+  var loadPokestops = Store.get('showPokestops') || Store.get('showPokemon')
   var loadScanned = Store.get('showScanned')
   var loadSpawnpoints = Store.get('showSpawnpoints')
 
@@ -1500,7 +1500,7 @@ function processScanned (i, item) {
 
   if (scanId in mapData.scanned) {
     mapData.scanned[scanId].marker.setOptions({
-      fillColor: getColorByDate(item['last_modified'])
+      fillColor: getColorByDate(item['last_modified'],item['hue'])
     })
   } else { // add marker to map and item to dict
     if (item.marker) {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1500,7 +1500,7 @@ function processScanned (i, item) {
 
   if (scanId in mapData.scanned) {
     mapData.scanned[scanId].marker.setOptions({
-      fillColor: getColorByDate(item['last_modified'],item['hue'])
+      fillColor: getColorByDate(item['last_modified'], item['hue'])
     })
   } else { // add marker to map and item to dict
     if (item.marker) {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1260,7 +1260,7 @@ function getColorByDate(value, hue) {
 
   // value from 0 to 1 - color to white
   var lightness = (50 + (diff * 50)).toString(10)
-  return ['hsl(',hue,',90%,',lightness,'%)'].join('')
+  return ['hsl(', hue, ',90%,', lightness, '%)'].join('')
 }
 
 function setupScannedMarker (item) {


### PR DESCRIPTION
Alternative scanned marker visuals

## Description
I didn't like the way the scanned markers are displayed when using the ss mode.
It was to crowded and to much color. I removed the stroke and changed the green->red coloring to a specified color that will fade away. The default color is now blue.
In preparation to give the scanned locations a color based on the worker thread I stored the hue value in the database. The idea is to give the hue value of 360 / number of threads * worker thread number to each scanned location. This will allow monitoring the individual threads.
This is particularly useful in combination of #787

## How Has This Been Tested?
On Mac OSX with Safari
Requires npm build to create map.min.js in order to work

## Screenshots (if appropriate):
![schermafbeelding 2016-08-18 om 22 52 09](https://cloud.githubusercontent.com/assets/20576546/17790385/79d41a72-6596-11e6-9891-53112cd0845f.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.