### PR TITLE
Pause workers that fail too many times for 2 hours

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -425,6 +425,18 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                         # than have the scanner, essentially, halt.
                         log.error('Search step %d went over max scan_retires; abandoning', step)
                         status['message'] = "Search step went over max scan_retries; abandoning"
+
+                        # Didn't succeed, but we are done with this queue item
+                        search_items_queue.task_done()
+
+                        # Sleep for 2 hours, print a log message every 5 minutes.
+                        long_sleep_time = 0
+                        long_sleep_started = time.strftime("%H:%M")
+                        while long_sleep_time < (2 * 60 * 20):
+                            log.error('Worker %s failed, possibly banned account. Started 2 hour sleep at %s', account['username'], long_sleep_started)
+                            status['message'] = 'Worker {} failed, possibly banned account. Started 2 hour sleep at {}'.format(account['username'], long_sleep_started)
+                            long_sleep_time += 300
+                            time.sleep(300)
                         break
 
                     # Increase sleep delay between each failed scan
@@ -509,6 +521,17 @@ def search_worker_thread_ss(args, account, search_items_queue, parse_lock, encry
                     while True:
                         if failed_total >= args.scan_retries:
                             log.error('Search step %d went over max scan_retires; abandoning', step)
+                            # Didn't succeed, but we are done with this queue item
+                            search_items_queue.task_done()
+
+                            # Sleep for 2 hours, print a log message every 5 minutes.
+                            long_sleep_time = 0
+                            long_sleep_started = time.strftime("%H:%M")
+                            while long_sleep_time < (2 * 60 * 20):
+                                log.error('Worker %s failed, possibly banned account. Started 2 hour sleep at %s', account['username'], long_sleep_started)
+                                status['message'] = 'Worker {} failed, possibly banned account. Started 2 hour sleep at {}'.format(account['username'], long_sleep_started)
+                                long_sleep_time += 300
+                                time.sleep(300)
                             break
                         sleep_time = args.scan_delay * (1 + failed_total)
                         check_login(args, account, api, step_location)


### PR DESCRIPTION
This PR is being resubmitted because I messed up fixing the merge errors...

## Description
When a worker fails `scan_retries` times, pause it for 2 hours.

## Motivation and Context
The most likely cause of the failures is that the account has been banned.  Stopping it for a long time prevents it from continuing to accept queue items, which cause many holes in the data gathered.

Retrying every 2 hours will allow workers that were just soft banned to eventually continue.

If all your workers get banned, this would stop all mapping for at least 2 hours.  But that is better than continually pounding on the servers with banned accounts.

## How Has This Been Tested?
Currently running it on my linux server, with 25 accounts, 10 of which only return map errors and seem to be banned.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
