### PR TITLE
Quick fix to delay being ignored after resume

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -408,7 +408,6 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                 # Grab the next thing to search (when available)
                 status['message'] = "Waiting for item from queue"
                 step, step_location = search_items_queue.get()
-
                 status['message'] = "Searching at {},{}".format(step_location[0], step_location[1])
                 log.info('Search step %d beginning (queue size is %d)', step, search_items_queue.qsize())
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -453,7 +453,7 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                     response_dict = map_request(api, step_location)
 
                     # Get current time
-                    last_apicall_time = int(round(time.time() * 1000))
+                    loop_start_time = int(round(time.time() * 1000))
 
                     # G'damnit, nothing back. Mark it up, sleep, carry on
                     if not response_dict:
@@ -483,7 +483,7 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
 
                 # If there's any time left between the start time and the time when we should be kicking off the next
                 # loop, hang out until its up.
-                sleep_delay_remaining = last_apicall_time + (args.scan_delay * 1000) - int(round(time.time() * 1000))
+                sleep_delay_remaining = loop_start_time + (args.scan_delay * 1000) - int(round(time.time() * 1000))
                 if sleep_delay_remaining > 0:
                     status['message'] = "Waiting {} seconds for scan delay".format(sleep_delay_remaining / 1000)
                     time.sleep(sleep_delay_remaining / 1000)

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -486,8 +486,11 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                 if sleep_delay_remaining > 0:
                     status['message'] = "Waiting {} seconds for scan delay".format(sleep_delay_remaining / 1000)
                     time.sleep(sleep_delay_remaining / 1000)
+                elif sleep_delay_remaining < 0:
+                    status['message'] = "Waiting {} seconds for scan delay".format(args.scan_delay)
+                    time.sleep(args.scan_delay)
 
-                loop_start_time += args.scan_delay * 1000
+                loop_start_time = int(round(time.time() * 1000))
 
         # catch any process exceptions, log them, and continue the thread
         except Exception as e:


### PR DESCRIPTION
This is a quick patch for scan delay being ignored after extended period of search pause.  This needs to be fixed asap otherwise lots of people will get soft ban after resuming the search.. XD

*** I also tried to find a way to resume search gracefully.  Tried putting interval delays when search queue is being built in the first place, tried PR previously - hoped to get some comments on whether that's a good implementation or not - so that we could find a better way to stagger the threads like in the initial start.  What do you all think?