### PR TITLE
Add new database and webhook queues to status screen

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -148,7 +148,7 @@ def switch_status_printer(display_enabled):
 
 
 # Thread to print out the status of each worker
-def status_printer(threadStatus, search_items_queue):
+def status_printer(threadStatus, search_items_queue, db_updates_queue, wh_queue):
     display_enabled = [True]
     logging.disable(logging.ERROR)
 
@@ -165,10 +165,10 @@ def status_printer(threadStatus, search_items_queue):
             os.system('cls' if os.name == 'nt' else 'clear')
 
             # Print the queue length
-            print 'Queue: {} items'.format(search_items_queue.qsize())
+            print 'Queues: {} scans, {} db updates, {} webhook'.format(search_items_queue.qsize(), db_updates_queue.qsize(), wh_queue.qsize())
 
             # Print status of overseer
-            print 'Overseer: {}'.format(threadStatus['Overseer']['message'])
+            print '{} Overseer: {}'.format(threadStatus['Overseer']['method'], threadStatus['Overseer']['message'])
 
             # Print the status of each worker, sorted by worker number
             for item in sorted(threadStatus):
@@ -193,12 +193,13 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
     threadStatus['Overseer'] = {}
     threadStatus['Overseer']['message'] = "Initializing"
     threadStatus['Overseer']['type'] = "Overseer"
+    threadStatus['Overseer']['method'] = "Hex Grid"
 
     if(args.print_status):
         log.info('Starting status printer thread')
         t = Thread(target=status_printer,
                    name='status_printer',
-                   args=(threadStatus, search_items_queue))
+                   args=(threadStatus, search_items_queue, db_updates_queue, wh_queue))
         t.daemon = True
         t.start()
 
@@ -318,12 +319,13 @@ def search_overseer_thread_ss(args, new_location_queue, pause_bit, encryption_li
     threadStatus['Overseer'] = {}
     threadStatus['Overseer']['message'] = "Initializing"
     threadStatus['Overseer']['type'] = "Overseer"
+    threadStatus['Overseer']['method'] = "Spawn Scan"
 
     if(args.print_status):
         log.info('Starting status printer thread')
         t = Thread(target=status_printer,
                    name='status_printer',
-                   args=(threadStatus, search_items_queue))
+                   args=(threadStatus, search_items_queue, db_updates_queue, wh_queue))
         t.daemon = True
         t.start()
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Shows the recently added database and webhook queues in the status screen.

## Motivation and Context
Need to be able to monitor those queues to see when you need to increases the threads.

Requested on feathub: http://feathub.com/PokemonGoMap/PokemonGo-Map/+69

## How Has This Been Tested?
On my linux server.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Also show which kind of search method you are using on the status scren