### PR TITLE
Smarter .gitignore for config/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@
 *.sass-cache
 *.orig
 *.json
-config/config.ini
+config/*
+!config/config.ini.example
 static/dist/
 node_modules/
 venv/
@@ -14,5 +15,3 @@ src/
 _build
 _build_html
 beehive.*
-config/ssl.cert
-config/ssl.key


### PR DESCRIPTION
Rather than `.gitignore`ing every new file we add to config, just ignore the `config/` directory, but keep `config.ini.example`

## Description

Uses the `!` syntax of `.gitignore` to ignore ignoring of example configuration files (you read that right).


## Motivation and Context

Seeing bad habits.  Spreading good habits.

## How Has This Been Tested?

```
$ touch config/derpyderp
$ git status --porcelain 2>/dev/null| grep "^??" | wc -l
       0
$ echo "yay"
yay
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

