### PR TITLE
Reduce UPSERT log spam from DB threads

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -532,10 +532,10 @@ def db_updater(args, q):
                 model, data = q.get()
                 bulk_upsert(model, data)
                 q.task_done()
-                log.info('Upserted to %s, %d records (upsert queue remaining: %d)',
-                         model.__name__,
-                         len(data),
-                         q.qsize())
+                log.debug('Upserted to %s, %d records (upsert queue remaining: %d)',
+                          model.__name__,
+                          len(data),
+                          q.qsize())
                 if q.qsize() > 50:
                     log.warning("DB queue is > 50 (@%d); try increasing --db-threads", q.qsize())
 


### PR DESCRIPTION
## Description
Change log filter to debug for UPSERT log entries from DB threads.

## Motivation and Context
Reduces log entries per scan location from 6 to 2 and only removes redundant or very specific information.

Before (per location scan):
> 2016-08-19 18:03:56,027 [     ss-worker-2][        search][    INFO] Searching step 41, remaining 0
> 2016-08-19 18:03:56,604 [     ss-worker-2][        models][    INFO] Parsing found 4 pokemons, 292 pokestops, and 19 gyms
> 2016-08-19 18:03:56,610 [    db-updater-0][        models][    INFO] Upserted to Pokemon, 4 records (upsert queue remaining: 3)
> 2016-08-19 18:03:56,654 [    db-updater-0][        models][    INFO] Upserted to Pokestop, 292 records (upsert queue remaining: 2)
> 2016-08-19 18:03:56,662 [    db-updater-0][        models][    INFO] Upserted to Gym, 19 records (upsert queue remaining: 1)
> 2016-08-19 18:03:56,667 [    db-updater-0][        models][    INFO] Upserted to ScannedLocation, 1 records (upsert queue remaining: 0)

After (per location scan):
> 2016-08-19 18:03:56,027 [     ss-worker-2][        search][    INFO] Searching step 41, remaining 0
> 2016-08-19 18:03:56,604 [     ss-worker-2][        models][    INFO] Parsing found 4 pokemons, 292 pokestops, and 19 gyms

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

