### PR TITLE
Status screen improvments - paging, new queues

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -171,6 +171,9 @@ def status_printer(threadStatus, search_items_queue, db_updates_queue, wh_queue)
             width, height = terminalsize.get_terminal_size()
             # Queue and overseer take 2 lines.  Switch message takes up 2 lines.  Remove an extra 2 for things like screen status lines.
             usable_height = height - 6
+            # Prevent people running terminals only 6 lines high from getting a divide by zero
+            if usable_height < 1:
+                usable_height = 1
 
             # Create a list to hold all the status lines, so they can be printed all at once to reduce flicker
             status_text = []

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -182,7 +182,7 @@ def status_printer(threadStatus, search_items_queue, db_updates_queue, wh_queue)
             status_text.append('{} Overseer: {}'.format(threadStatus['Overseer']['method'], threadStatus['Overseer']['message']))
 
             # Calculate the total number of pages.  Subtracting 1 for the overseer.
-            total_pages = math.ceil((len(threadStatus) - 1)/float(usable_height))
+            total_pages = math.ceil((len(threadStatus) - 1) / float(usable_height))
 
             # Prevent moving outside the valid range of pages
             if current_page[0] > total_pages:

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -150,7 +150,6 @@ def switch_status_printer(display_enabled, current_page):
         elif command.isdigit():
                 current_page[0] = int(command)
 
-
 # Thread to print out the status of each worker
 def status_printer(threadStatus, search_items_queue):
     display_enabled = [True]
@@ -166,19 +165,20 @@ def status_printer(threadStatus, search_items_queue):
 
     while True:
         if display_enabled[0]:
-            # Clear the screen
-            os.system('cls' if os.name == 'nt' else 'clear')
 
             # Get the terminal size
             width, height = terminalsize.get_terminal_size()
             # Queue and overseer take 2 lines.  Switch message takes up 2 lines.  Remove an extra 2 for things like screen status lines.
             usable_height = height - 6
 
+            # Create a list to hold all the status lines, so they can be printed all at once to reduce flicker
+            status_text = []
+
             # Print the queue length
-            print 'Queue: {} items'.format(search_items_queue.qsize())
+            status_text.append('Queue: {} items'.format(search_items_queue.qsize()))
 
             # Print status of overseer
-            print 'Overseer: {}'.format(threadStatus['Overseer']['message'])
+            status_text.append('Overseer: {}'.format(threadStatus['Overseer']['message']))
 
             # Calculate the total number of pages.  Subtracting 1 for the overseer.
             total_pages = math.ceil((len(threadStatus) - 1)/float(usable_height))
@@ -206,11 +206,15 @@ def status_printer(threadStatus, search_items_queue):
                         break
 
                     if 'skip' in threadStatus[item]:
-                        print '{} - Success: {}, Failed: {}, No Items: {}, Skipped: {} - {}'.format(item, threadStatus[item]['success'], threadStatus[item]['fail'], threadStatus[item]['noitems'], threadStatus[item]['skip'], threadStatus[item]['message'])
+                        status_text.append('{} - Success: {}, Failed: {}, No Items: {}, Skipped: {} - {}'.format(item, threadStatus[item]['success'], threadStatus[item]['fail'], threadStatus[item]['noitems'], threadStatus[item]['skip'], threadStatus[item]['message']))
                     else:
-                        print '{} - Success: {}, Failed: {}, No Items: {} - {}'.format(item, threadStatus[item]['success'], threadStatus[item]['fail'], threadStatus[item]['noitems'], threadStatus[item]['message'])
-            print 'Page {}/{}.  Type page number and <ENTER> to switch pages.  Press <ENTER> alone to switch between status and log view'.format(current_page[0], total_pages)
-        time.sleep(0.5)
+                        status_text.append('{} - Success: {}, Failed: {}, No Items: {} - {}'.format(item, threadStatus[item]['success'], threadStatus[item]['fail'], threadStatus[item]['noitems'], threadStatus[item]['message']))
+            status_text.append('Page {}/{}.  Type page number and <ENTER> to switch pages.  Press <ENTER> alone to switch between status and log view'.format(current_page[0], total_pages))
+            # Clear the screen
+            os.system('cls' if os.name == 'nt' else 'clear')
+            # Print status
+            print "\n".join(status_text)
+        time.sleep(1)
 
 
 # The main search loop that keeps an eye on the over all process

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -151,7 +151,7 @@ def switch_status_printer(display_enabled, current_page):
                 current_page[0] = int(command)
 
 # Thread to print out the status of each worker
-def status_printer(threadStatus, search_items_queue):
+def status_printer(threadStatus, search_items_queue, db_updates_queue, wh_queue):
     display_enabled = [True]
     current_page = [1]
     logging.disable(logging.ERROR)
@@ -175,10 +175,10 @@ def status_printer(threadStatus, search_items_queue):
             status_text = []
 
             # Print the queue length
-            status_text.append('Queue: {} items'.format(search_items_queue.qsize()))
+            status_text.append('Queues: {} items, {} db updates, {} webhook'.format(search_items_queue.qsize(), db_updates_queue.qsize(), wh_queue.qsize()))
 
             # Print status of overseer
-            status_text.append('Overseer: {}'.format(threadStatus['Overseer']['message']))
+            status_text.append('{} Overseer: {}'.format(threadStatus['Overseer']['method'], threadStatus['Overseer']['message']))
 
             # Calculate the total number of pages.  Subtracting 1 for the overseer.
             total_pages = math.ceil((len(threadStatus) - 1)/float(usable_height))
@@ -229,12 +229,13 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
     threadStatus['Overseer'] = {}
     threadStatus['Overseer']['message'] = "Initializing"
     threadStatus['Overseer']['type'] = "Overseer"
+    threadStatus['Overseer']['method'] = "Hex Grid"
 
     if(args.print_status):
         log.info('Starting status printer thread')
         t = Thread(target=status_printer,
                    name='status_printer',
-                   args=(threadStatus, search_items_queue))
+                   args=(threadStatus, search_items_queue, db_updates_queue, wh_queue))
         t.daemon = True
         t.start()
 
@@ -354,12 +355,13 @@ def search_overseer_thread_ss(args, new_location_queue, pause_bit, encryption_li
     threadStatus['Overseer'] = {}
     threadStatus['Overseer']['message'] = "Initializing"
     threadStatus['Overseer']['type'] = "Overseer"
+    threadStatus['Overseer']['method'] = "Spawn Scan"
 
     if(args.print_status):
         log.info('Starting status printer thread')
         t = Thread(target=status_printer,
                    name='status_printer',
-                   args=(threadStatus, search_items_queue))
+                   args=(threadStatus, search_items_queue, db_updates_queue, wh_queue))
         t.daemon = True
         t.start()
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -150,6 +150,7 @@ def switch_status_printer(display_enabled, current_page):
         elif command.isdigit():
                 current_page[0] = int(command)
 
+
 # Thread to print out the status of each worker
 def status_printer(threadStatus, search_items_queue, db_updates_queue, wh_queue):
     display_enabled = [True]

--- a/pogom/terminalsize.py
+++ b/pogom/terminalsize.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+import os
+import shlex
+import struct
+import platform
+import subprocess
+
+
+def get_terminal_size():
+    """ getTerminalSize()
+     - get width and height of console
+     - works on linux,os x,windows,cygwin(windows)
+     originally retrieved from:
+     http://stackoverflow.com/questions/566746/how-to-get-console-window-width-in-python
+    """
+    current_os = platform.system()
+    tuple_xy = None
+    if current_os == 'Windows':
+        tuple_xy = _get_terminal_size_windows()
+        if tuple_xy is None:
+            tuple_xy = _get_terminal_size_tput()
+            # needed for window's python in cygwin's xterm!
+    if current_os in ['Linux', 'Darwin'] or current_os.startswith('CYGWIN'):
+        tuple_xy = _get_terminal_size_linux()
+    if tuple_xy is None:
+        print "default"
+        tuple_xy = (80, 25)      # default value
+    return tuple_xy
+
+
+def _get_terminal_size_windows():
+    try:
+        from ctypes import windll, create_string_buffer
+        # stdin handle is -10
+        # stdout handle is -11
+        # stderr handle is -12
+        h = windll.kernel32.GetStdHandle(-12)
+        csbi = create_string_buffer(22)
+        res = windll.kernel32.GetConsoleScreenBufferInfo(h, csbi)
+        if res:
+            (bufx, bufy, curx, cury, wattr,
+             left, top, right, bottom,
+             maxx, maxy) = struct.unpack("hhhhHhhhhhh", csbi.raw)
+            sizex = right - left + 1
+            sizey = bottom - top + 1
+            return sizex, sizey
+    except:
+        pass
+
+
+def _get_terminal_size_tput():
+    # get terminal width
+    # src: http://stackoverflow.com/questions/263890/how-do-i-find-the-width-height-of-a-terminal-window
+    try:
+        cols = int(subprocess.check_call(shlex.split('tput cols')))
+        rows = int(subprocess.check_call(shlex.split('tput lines')))
+        return (cols, rows)
+    except:
+        pass
+
+
+def _get_terminal_size_linux():
+    def ioctl_GWINSZ(fd):
+        try:
+            import fcntl
+            import termios
+            cr = struct.unpack('hh',
+                               fcntl.ioctl(fd, termios.TIOCGWINSZ, '1234'))
+            return cr
+        except:
+            pass
+    cr = ioctl_GWINSZ(0) or ioctl_GWINSZ(1) or ioctl_GWINSZ(2)
+    if not cr:
+        try:
+            fd = os.open(os.ctermid(), os.O_RDONLY)
+            cr = ioctl_GWINSZ(fd)
+            os.close(fd)
+        except:
+            pass
+    if not cr:
+        try:
+            cr = (os.environ['LINES'], os.environ['COLUMNS'])
+        except:
+            return None
+    return int(cr[1]), int(cr[0])
+
+
+if __name__ == "__main__":
+    sizex, sizey = get_terminal_size()
+    print 'width =', sizex, 'height =', sizey


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Incorporate paging into the status screen.  It will figure out how many lines fit in your terminal and page the worker list appropriately.

Add the new database and webhook queues to the status screen.

## Motivation and Context
Balthamel asked for paging.  Some people run way too many workers to fit on a screen.
http://feathub.com/PokemonGoMap/PokemonGo-Map/+69 asked for the new queues to be shown.

## How Has This Been Tested?
On my linux server.  Should work on windows as well.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
