### PR TITLE
Scan circles appear the correct size on the map when no-pokemon is

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -70,7 +70,7 @@ def generate_location_steps(initial_loc, step_count, step_distance):
     SOUTH = 180
     WEST = 270
 
-    pulse_radius = step_distance            # km - radius of players heartbeat is 70m
+    pulse_radius = step_distance            # km - radius of players heartbeat is 70m, and 900m for gyms/pokestops
     xdist = math.sqrt(3) * pulse_radius   # dist between column centers
     ydist = 3 * (pulse_radius / 2)          # dist between row centers
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1278,7 +1278,7 @@ function setupScannedMarker (item) {
     map: map,
     clickable: false,
     center: circleCenter,
-    radius: 70, // metres
+    radius: item['radius'], // metres
     fillColor: getColorByDate(item['last_modified']),
     strokeWeight: 1
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

<!--- Describe your changes in detail -->

Scan circles were stuck at 70m regardless of whether we're scanning gyms/pokestops only, or for Pokemon. Changed so that it dynamically switches circle size based on scan type from #748 
## Motivation and Context

Scan circles were improperly sized when scanning for only pokestops/gyms 

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->
## How Has This Been Tested?

I see that the circles change size between pokemon scanning and non pokemon scanning

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

enabled now
