### PR TITLE
More flexibility with spawnpoint import file

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -388,19 +388,20 @@ def search_overseer_thread_ss(args, new_location_queue, pause_bit, encryption_li
         latlng = LatLng.from_point(Cell(CellId(int('{}00000'.format(spawn['spawnpoint_id']),16))).get_center())
         spawn['lat'] = latlng.lat().degrees
         spawn['lng'] = latlng.lng().degrees
+        spawn['time'] = int(spawn['time'])
     log.info('sorting spawnpoints based on time')
     spawns.sort(key=itemgetter('time'))
     log.info('Total of %d spawns to track', len(spawns))
     # find the inital location (spawn thats 60sec old)
     pos = SbSearch(spawns, (curSec() + 3540) % 3600)
     while True:
-        while timeDif(curSec(), int(spawns[pos]['time'])) < 60:
+        while timeDif(curSec(), spawns[pos]['time']) < 60:
             threadStatus['Overseer']['message'] = "Waiting for spawnpoints {} of {} to spawn at {}".format(pos, len(spawns), spawns[pos]['time'])
             time.sleep(1)
         # make location with a dummy height (seems to be more reliable than 0 height)
         threadStatus['Overseer']['message'] = "Queuing spawnpoint {} of {}".format(pos, len(spawns))
         location = [spawns[pos]['lat'], spawns[pos]['lng'], 40.32]
-        search_args = (pos, location, int(spawns[pos]['time']) )
+        search_args = (pos, location, spawns[pos]['time'])
         search_items_queue.put(search_args)
         pos = (pos + 1) % len(spawns)
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -346,35 +346,61 @@ def search_overseer_thread_ss(args, new_location_queue, pause_bit, encryption_li
         t.daemon = True
         t.start()
 
+    if not os.path.isfile(args.spawnpoint_scanning): # if the spawns file does not exist, maybe the user provided a relative path, try to find the full path
+        maybe_this_is_the_file = os.path.join(os.path.dirname(__file__),args.spawnpoint_scanning)
+        if os.path.isfile(maybe_this_is_the_file):
+            args.spawnpoint_scanning = maybe_this_is_the_file
     if os.path.isfile(args.spawnpoint_scanning):  # if the spawns file exists use it
         threadStatus['Overseer']['message'] = "Getting spawnpoints from file"
         try:
             with open(args.spawnpoint_scanning) as file:
-                try:
-                    spawns = json.load(file)
-                except ValueError:
-                    log.error(args.spawnpoint_scanning + " is not valid")
-                    return
+                if args.spawnpoint_scanning.endswith('.csv'):
+                    try:
+                        log.info('trying to load csv')
+                        from csv import DictReader
+                        csvfile = file.read()
+                        csvobj = DictReader(csvfile.splitlines())
+                        thejson = json.dumps([row for row in csvobj])
+                        spawns = json.loads(thejson)
+                    except ValueError:
+                        log.error(args.spawnpoint_scanning + " is not valid csv")
+                        return
+                else:
+                    try:
+                        log.info('trying to load json')
+                        spawns = json.load(file)
+                    except ValueError:
+                        log.error(args.spawnpoint_scanning + " is not valid json")
+                        return
                 file.close()
         except IOError:
             log.error("Error opening " + args.spawnpoint_scanning)
             return
     else:  # if spawns file dose not exist use the db
+        log.info('trying to load spawnpoints from db')
         threadStatus['Overseer']['message'] = "Getting spawnpoints from database"
         loc = new_location_queue.get()
         spawns = Pokemon.get_spawnpoints_in_hex(loc, args.step_limit)
+    #ignore lat and lng provided, we'll calculate it ourselves from spawnpoint ID
+    from s2sphere import LatLng, Cell, CellId
+    log.info('calculating lat and lng for all spawnpoints based on their cell id')
+    for spawn in spawns:
+        latlng = LatLng.from_point(Cell(CellId(int('{}00000'.format(spawn['spawnpoint_id']),16))).get_center())
+        spawn['lat'] = latlng.lat().degrees
+        spawn['lng'] = latlng.lng().degrees
+    log.info('sorting spawnpoints based on time')
     spawns.sort(key=itemgetter('time'))
     log.info('Total of %d spawns to track', len(spawns))
     # find the inital location (spawn thats 60sec old)
     pos = SbSearch(spawns, (curSec() + 3540) % 3600)
     while True:
-        while timeDif(curSec(), spawns[pos]['time']) < 60:
+        while timeDif(curSec(), int(spawns[pos]['time'])) < 60:
             threadStatus['Overseer']['message'] = "Waiting for spawnpoints {} of {} to spawn at {}".format(pos, len(spawns), spawns[pos]['time'])
             time.sleep(1)
         # make location with a dummy height (seems to be more reliable than 0 height)
         threadStatus['Overseer']['message'] = "Queuing spawnpoint {} of {}".format(pos, len(spawns))
         location = [spawns[pos]['lat'], spawns[pos]['lng'], 40.32]
-        search_args = (pos, location, spawns[pos]['time'])
+        search_args = (pos, location, int(spawns[pos]['time']) )
         search_items_queue.put(search_args)
         pos = (pos + 1) % len(spawns)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow the spawnpoint import file to be a CSV. Allow it to not include lat & lng. Allow the provided filename to be a relative path.

## Motivation and Context
Data portability is useful. Some users have a much easier time dumping some database columns, editing in excel, and saving as CSV. This change will allow those users to skip the step of converting their data to json. Furthermore, we don't need users to provide their lat & lng with each spawnpoint. The spawnpoint_id already encodes that information. We just need spawnpoint_id and time (seconds past the top of the hour). Two columns. That's it!

## How Has This Been Tested?
JSON imports still work. CSV imports work. Tested with both JSON and CSV files of 55,000 spawnpoints in length. About 5 seconds is added to startup for a file this size to convert spawnpoints (no lat & lng provided) to lat & lng.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.