### PR TITLE
Added optional random delay to each step

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -524,12 +524,14 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
 
                 # If there's any time left between the start time and the time when we should be kicking off the next
                 # loop, hang out until its up.
-                sleep_delay_remaining = loop_start_time + (args.scan_delay * 1000) - int(round(time.time() * 1000))
+                # add random delay of 0-5 seconds to avoid account ban
+                randomDelay = random.randint(0,5)
+                sleep_delay_remaining = loop_start_time + ((args.scan_delay + randomDelay) * 1000) - int(round(time.time() * 1000))
                 if sleep_delay_remaining > 0:
                     status['message'] = "Waiting {} seconds for scan delay".format(sleep_delay_remaining / 1000)
                     time.sleep(sleep_delay_remaining / 1000)
 
-                loop_start_time += args.scan_delay * 1000
+                loop_start_time += (args.scan_delay + randomDelay) * 1000
 
         # catch any process exceptions, log them, and continue the thread
         except Exception as e:

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -525,7 +525,7 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                 # If there's any time left between the start time and the time when we should be kicking off the next
                 # loop, hang out until its up.
                 # add random delay of 0-5 seconds to avoid account ban
-                randomDelay = random.randint(0,5)
+                randomDelay = random.randint(0, 5)
                 sleep_delay_remaining = loop_start_time + ((args.scan_delay + randomDelay) * 1000) - int(round(time.time() * 1000))
                 if sleep_delay_remaining > 0:
                     status['message'] = "Waiting {} seconds for scan delay".format(sleep_delay_remaining / 1000)

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -524,14 +524,14 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
 
                 # If there's any time left between the start time and the time when we should be kicking off the next
                 # loop, hang out until its up.
-                # add random delay of 0-5 seconds to avoid account ban
-                randomDelay = random.randint(0, 5)
-                sleep_delay_remaining = loop_start_time + ((args.scan_delay + randomDelay) * 1000) - int(round(time.time() * 1000))
+                # add --random-delay
+                random_delay = random.randint(0, args.random_delay)
+                sleep_delay_remaining = loop_start_time + ((args.scan_delay + random_delay) * 1000) - int(round(time.time() * 1000))
                 if sleep_delay_remaining > 0:
                     status['message'] = "Waiting {} seconds for scan delay".format(sleep_delay_remaining / 1000)
                     time.sleep(sleep_delay_remaining / 1000)
 
-                loop_start_time += (args.scan_delay + randomDelay) * 1000
+                loop_start_time += (args.scan_delay + random_delay) * 1000
 
         # catch any process exceptions, log them, and continue the thread
         except Exception as e:
@@ -584,7 +584,9 @@ def search_worker_thread_ss(args, account, search_items_queue, parse_lock, encry
                                 long_sleep_time += 300
                                 time.sleep(300)
                             break
-                        sleep_time = args.scan_delay * (1 + failed_total)
+                        # add --random-delay
+                        random_delay = random.randint(0, args.random_delay)
+                        sleep_time = args.scan_delay * (1 + failed_total) + random_delay
                         check_login(args, account, api, step_location)
                         # make the map request
                         response_dict = map_request(api, step_location)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -62,6 +62,9 @@ def get_args():
     parser.add_argument('-sd', '--scan-delay',
                         help='Time delay between requests in scan threads',
                         type=float, default=10)
+    parser.add_argument('-rd', '--random-delay',
+                        help='Add additional random delay between 0 and argument to the standard scan delay',
+                        type=int, default=0)
     parser.add_argument('-ld', '--login-delay',
                         help='Time delay between each login attempt',
                         type=float, default=5)


### PR DESCRIPTION
## Description
Added optional random delay to command line so user can specify number of random seconds between 0 and argument to be added to scan delay each time the search worker thread sleeps in an attempt to avoid account bans.

## Motivation and Context
Accounts have been getting banned the past few days creating a need to constantly make more accounts. I have tried a few things (e.g. longer scan delays, lower number of workers, etc) to no avail, this is the first solution I have found that seems to remedy the situation.

## How Has This Been Tested?
Running the develop branch from 2016-08-16 night time PST. My changes are on the current develop branch 2016-08-19 night time PST.

In the 2-3 days prior to 2016-08-17, 1-3 accounts were being banned daily. In the 3 days since I made the code change, no accounts have been banned. However, my test size is small: -st 8 -sd 10 with 6 workers. Therefore, further testing is warranted before we know if this resolves the current method being used to identify accounts.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.