### PR TITLE
Prevent header from cutting off bottom of accordion

### DIFF
--- a/static/sass/layout/_nav.scss
+++ b/static/sass/layout/_nav.scss
@@ -7,7 +7,9 @@
 		background: #F8F8F8;
 		box-shadow: none;
 		color: _palette(accent2, fg-bold);
-		height: 100%;
+		height: -webkit-calc(100% - 3.5em);
+		height: -moz-calc(100% - 3.5em);
+		height: calc(100% - 3.5em);
 		max-width: 80%;
 		overflow-y: auto;
 		position: fixed;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
As it stands, if the contents of #nav are taller than the window (ie mobile user), the accordion doesn't scroll all the way to the bottom. It stops short 3.5em (the height of #header).

## Motivation and Context
Mobile users are unable to access options that are located at the bottom of the accordion

## How Has This Been Tested?
Reproduced by making the browser small enough to force the accordion to have to scroll. It would only scroll to a certain point.

Fresh clone, modified _nav.scss and ran build commands

Desktop (Win10): Chrome 52, Firefox 48, Internet Explorer 11
Mobile (Android 6.0): Chrome 52, Firefox 48

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.