### PR TITLE
Limit the radius of spawnpoint based scanning relative to the search marker and account for search marker movement (aka spawnscan while driving)

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -18,6 +18,7 @@
 #no-pokestops:          # disables pokestop scanning (default false)
 #scan-delay:            # default 10
 #step-limit:            # default 12
+#spawnpoint-limit-radius # if using spawnpoint-scanning above, will skip any spawnpoints which are this distance or more away from the search location (default 0 which is unlimited)
 
 # Misc
 #gmaps-key:             # your Google Maps API key

--- a/docs/basic-install/linux.rst
+++ b/docs/basic-install/linux.rst
@@ -29,6 +29,8 @@ Debian's sources lists are out of date and will not fetch the correct versions o
 	ln -s /opt/python/bin/python2.7 /usr/bin/python2.7
 	ln -s /usr/bin/python2.7 /usr/bin/python
 	ln -s /usr/local/bin/python2.7 /usr/local/bin/python
+	ln -s /opt/python/bin/pip /usr/bin/pip
+	ln -s /opt/python/bin/pip /usr/local/bin/pip
 	sed -e '$a\PATH="$PATH:/opt/python/bin"\' ~/.profile
 	source ~/.profile
 	wget https://bootstrap.pypa.io/get-pip.py

--- a/docs/basic-install/linux.rst
+++ b/docs/basic-install/linux.rst
@@ -19,7 +19,7 @@ Debian's sources lists are out of date and will not fetch the correct versions o
 
 .. code-block:: bash
 
-	sudo apt-get install -y build-essential libbz2-dev libsqlite3-dev libreadline-dev zlib1g-dev libncurses5-dev libssl-dev libgdbm-dev python-dev
+	sudo apt-get install -y build-essential libbz2-dev libsqlite3-dev libreadline-dev zlib1g-dev libncurses5-dev libssl-dev libgdbm-dev python-dev nodejs npm
 	wget https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tgz
 	tar xzf Python-2.7.12.tgz && cd Python-2.7.12
 	./configure --prefix=/opt/python
@@ -31,6 +31,7 @@ Debian's sources lists are out of date and will not fetch the correct versions o
 	ln -s /usr/local/bin/python2.7 /usr/local/bin/python
 	ln -s /opt/python/bin/pip /usr/bin/pip
 	ln -s /opt/python/bin/pip /usr/local/bin/pip
+	ln -s /usr/bin/nodejs /usr/bin/node
 	sed -e '$a\PATH="$PATH:/opt/python/bin"\' ~/.profile
 	source ~/.profile
 	wget https://bootstrap.pypa.io/get-pip.py
@@ -45,8 +46,23 @@ After install, check that you have the correct versions in your environment vari
 	~$ pip --version
 		pip 8.1.2 from /home/user/.local/lib/python2.7/site-packages (python 2.7)
 		
-If your output looks as above, you can proceed with installation normally
+If your output looks as above, you can proceed with installation:
 
+.. code-block:: bash
+
+	pip install -r requirements.txt
+	npm install
+	npm install -g grunt-cli
+	grunt build
+
+troubleshooting:
+	
+	If you have preciously installed pip packages before following this guide, you may need to remove them before installing:
+	
+.. code-block:: bash
+
+	pip freeze | xargs pip uninstall -y
+	
 
 Red Hat or CentOs or Fedora
 ***************************

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -126,6 +126,7 @@ def get_args():
                         help='Use spawnpoint scanning (instead of hex grid)', nargs='?', const='null.null', default=None)
     parser.add_argument('--dump-spawnpoints', help='dump the spawnpoints from the db to json (only for use with -ss)',
                         action='store_true', default=False)
+    parser.add_argument('-slr','--spawnpoint-limit-radius',type=int,default=0)
     parser.add_argument('-pd', '--purge-data',
                         help='Clear pokemon from database this many hours after they disappear \
                         (0 to disable)', type=int, default=0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Provides a command line argument which allows users to skip scanning a spawnpoint which is greater than X meters from their current search location. This is dynamic and keeps up with the search marker location as it moves.

## Motivation and Context
Spawnpoint based scanning which uses the database or an import file will scan ALL points provided, no matter where the search marker location is. If a user has spawnpoint locations covering a large area, they may travel within that area and wish to have the scan follow their location. This is possible with the regular scanning method, but not with spawnpoint based scanning. This allows a user to set a radius of X meters around them, and any spawnpoints in their list that are too far away will simply be skipped over. Additionally, since the user is moving while using this feature, it makes sense to scan points which might have spawned in the last 10 minutes. Previously this was limited to starting the scan at 1 minute old spawns. 10 minutes might not even be enough, we might want to adjust that further.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

