### PR TITLE
Gitignore config ssl folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ _build_html
 beehive.*
 config/ssl.cert
 config/ssl.key
+config/ssl/


### PR DESCRIPTION
Some ssl configurations require intermediate certificates or multiple domains connecting to the same installation. It's easier to have an ssl folder than to assume everyone will have two files named ssl.crt and ssl.key