### PR TITLE
Accept `?ll=<lat>,<lng>` in query string

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -66,9 +66,21 @@ class Pogom(Flask):
         fixed_display = "none" if args.fixed_location else "inline"
         search_display = "inline" if args.search_control else "none"
 
+        lat = self.current_location[0]
+        lng = self.current_location[1]
+
+        ll = request.args.get('ll')
+        if ll is not None:
+            try:
+                qlat, qlng = ll.split(",")
+                lat = float(qlat)
+                lng = float(qlng)
+            except:
+                pass
+
         return render_template('map.html',
-                               lat=self.current_location[0],
-                               lng=self.current_location[1],
+                               lat=lat,
+                               lng=lng,
                                gmaps_key=config['GMAPS_KEY'],
                                lang=config['LOCALE'],
                                is_fixed=fixed_display,


### PR DESCRIPTION
Accept `?ll=<lat>,<lng>` query string in the map page.

## Description
Accept `?ll=<lat>,<lng>` query string in the map page.


## Motivation and Context
New Feature: allow deep linking to location

## How Has This Been Tested?
Adding `?ll=1.2,3.4` to url. Try malformed lat lng.

## Screenshots (if appropriate):
nil

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

