### PR TITLE
Correct the docker container link

### DIFF
--- a/docs/advanced-install/docker.md
+++ b/docs/advanced-install/docker.md
@@ -12,11 +12,11 @@ For your first install, there's only a few steps. Let's get to it!
 
 ### Start the Map 
 
-You'll need to change the command line params. If you don't know what they are, you can run `docker run --rm chuyskywalker/pokemongo-map -h` and you'll get the full help text. The command below examples out a very basic setup.
+You'll need to change the command line params. If you don't know what they are, you can run `docker run --rm ashex/pokemongo-map -h` and you'll get the full help text. The command below examples out a very basic setup.
 
 ```
 docker run -d --name pogomap \
-  chuyskywalker/pokemongo-map \
+  ashex/pokemongo-map \
     -a ptc -u your -p login \
     -k 'google-maps-key' \
     -l 'coords' \
@@ -64,7 +64,7 @@ Run:
 
 ```
 docker rm -f pogomap ngrok
-docker pull chuyskywalker/pokemongo-map
+docker pull ashex/pokemongo-map
 ```
 
 Then redo the steps from "First Install" and you'll be on the latest version!


### PR DESCRIPTION
Correct the docker container link

## Description
Correct the docker container link

## Motivation and Context
The docker container didn't exist anymore.

## How Has This Been Tested?
I've tested it on my computer

## Screenshots (if appropriate):
![chuyskywalker/pokemongo-map](https://cloud.githubusercontent.com/assets/5855339/17832857/213f9494-670e-11e6-8d4e-0b29d1b3b93e.png)
![ashex/pokemongo-map](https://cloud.githubusercontent.com/assets/5855339/17832858/2143c906-670e-11e6-98c5-a763e274e947.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

"chuyskywalker/pokemongo-map" does not exist but "ashex/pokemongo-map" is working!