### PR TITLE
Fix for checking logged in status and removing invalid accounts (#3)

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -215,7 +215,9 @@ def account_recycler(accounts_queue, account_failures, args):
                 account_failures.remove(a)
                 accounts_queue.put(a['account'])
             else:
-                log.info('Account {} needs to cool off for {} seconds due to {}'.format(a['account']['username'], a['last_fail_time'] - ok_time, a['reason']))
+                if not 'notified' in a:
+                    log.info('Account {} needs to cool off for {} minutes due to {}'.format(a['account']['username'], round((a['last_fail_time'] - ok_time)/60,0), a['reason']))
+                    a['notified'] = True
 
 
 def worker_status_db_thread(threads_status, name, db_updates_queue):


### PR DESCRIPTION
## Description
i) in models.py:
* catch KeyError and TypeError exceptions, return result to search.py

ii) in search.py:
* Check for parse errors in parse_map function
* Check login status properly
* Remove dead workers or ones that are not logged in, write log to loginerrors.log

## Motivation and Context
In: Response to: https://github.com/PokemonGoMap/PokemonGo-Map/issues/880
As: Alternative to https://github.com/PokemonGoMap/PokemonGo-Map/pull/806

Currently the check_login https://github.com/PokemonGoMap/PokemonGo-Map/blob/develop/pogom/search.py#L637 method fails, it will always proceed, no matter if the login was successful or not. This leads to the process that we are sending accounts which are not even logged in to parse the map, and of course the map object received is invalid. Instead of trying 3 times to get the map, we should check if user is valid and logged in.

This needs a change in pgoapi, because the set_authentication method must return the result. It's a simple change though and already posted here: https://github.com/PokemonGoMap/pgoapi/pull/4

With these changes, invalid accounts can be removed at login, and in the case that an account gets banned, that is already logged in, can be handled with the 3 unsuccessful map download method already present in search.py, but instead of catching the exception on search.py it needs to be caught in models.py parse_map, because that's where the KeyError/TypeError occurs.

## How Has This Been Tested?
Tested on my computer with updated pgoapi. Relies on 

## Screenshots (if appropriate):
Output from console when trying to log on with a wrong account: http://pastebin.com/T5yHhB1a

Output when removing failed workers: http://pastebin.com/T5yHhB1a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Requires:
https://github.com/PokemonGoMap/pgoapi/pull/4

Relies on 'set_authentication' in pgoapi.py to return True if login has succeeded, so wait for status of https://github.com/PokemonGoMap/pgoapi/pull/4 before merging