### PR TITLE
Remove active modifier from expired lured pokestops during database cleanup

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -553,6 +553,12 @@ def clean_db_loop(args):
                      .where((ScannedLocation.last_modified <
                             (datetime.utcnow() - timedelta(minutes=30)))))
             query.execute()
+            
+            # Remove active modifier from expired lured pokestops
+            query = (Pokestop
+                     .update(lure_expiration=None)
+                     .where((Pokestop.lure_expiration < datetime.utcnow())))
+            query.execute()
 
             # If desired, clear old pokemon spawns
             if args.purge_data > 0:

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -553,7 +553,7 @@ def clean_db_loop(args):
                      .where((ScannedLocation.last_modified <
                             (datetime.utcnow() - timedelta(minutes=30)))))
             query.execute()
-            
+
             # Remove active modifier from expired lured pokestops
             query = (Pokestop
                      .update(lure_expiration=None)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -557,7 +557,7 @@ def clean_db_loop(args):
             # Remove active modifier from expired lured pokestops
             query = (Pokestop
                      .update(lure_expiration=None)
-                     .where((Pokestop.lure_expiration < datetime.utcnow())))
+                     .where(Pokestop.lure_expiration < datetime.utcnow()))
             query.execute()
 
             # If desired, clear old pokemon spawns


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
During database clean up set the `lure_expiration` column back to `NULL` for expired lured pokestops

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #793 where lured pokestops would show as lured forever

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran server with branch, expired lurestops correctly removed every minute

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

