### PR TITLE
Add user configured jitter to login location

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -593,8 +593,8 @@ def check_login(args, account, api, position, proxy_url):
     i = 0
     new_position = jitterLocation(position, maxMeters=15)
     api.set_position(*new_position)
-    #currentPos = api.get_position()
-    #log.info("Position of {} is: {}, {}".format(account['username'], currentPos[0], currentPos[1], currentPos[2]))
+    # currentPos = api.get_position()
+    # log.info("Position of {} is: {}, {}".format(account['username'], currentPos[0], currentPos[1], currentPos[2]))
     while i < args.login_retries:
         try:
             if proxy_url:

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -591,7 +591,10 @@ def check_login(args, account, api, position, proxy_url):
 
     # Try to login (a few times, but don't get stuck here)
     i = 0
-    api.set_position(position[0], position[1], position[2])
+    new_position = jitterLocation(position, maxMeters=15)
+    api.set_position(*new_position)
+    #currentPos = api.get_position()
+    #log.info("Position of {} is: {}, {}".format(account['username'], currentPos[0], currentPos[1], currentPos[2]))
     while i < args.login_retries:
         try:
             if proxy_url:


### PR DESCRIPTION
## Description

Update:
- Adds jitter before login is checked. Jitter is 15 m max
- Since the pr is old, is has been rebased, and also changed because search.py has been refactored:
  - Now login is checked after the worker gains position from scheduler.py, so the positions already differ now. However, this pr still prevents exact duplicate coordinates if using many loops of the same scan.

So in summary: this pr provides extra jitter for login location in exchange of an extra api.set_position call. 
## Motivation and Context

If all accounts use the exact same coords on login, it's easy to flag these as bots. This adds one step of random.
## How Has This Been Tested?

Tested on local machine
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
