### PR TITLE
--scan-delay minimum

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -496,8 +496,8 @@ def search_worker_thread(args, account, search_items_queue, parse_lock, encrypti
                         break
 
                     # Increase sleep delay between each failed scan
-                    # By default scan_dela=5, scan_retries=5 so
-                    # We'd see timeouts of 5, 10, 15, 20, 25
+                    # By default scan_delay=10, scan_retries=5 so
+                    # We'd see timeouts of 10, 20, 30, 40, 50
                     sleep_time = args.scan_delay * (1 + failed_total)
 
                     # Ok, let's get started -- check our login status

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -186,6 +186,10 @@ def get_args():
         if (args.step_limit is None):
             errors.append('Missing `step_limit` either as -st/--step-limit or in config')
 
+        if (args.scan_delay < 10):
+            log.warn("--scan-delay is less than 10, setting to 10")
+            args.scan_delay = 10
+
         if args.auth_service is None:
             args.auth_service = ['ptc']
         else:


### PR DESCRIPTION
Provide a minimum for scan delay.

## Description

Requires `--scan-delay` to be a minimum of 10 seconds.

## Motivation and Context

Derpies not reading documentation.  See #917 

## How Has This Been Tested?

It has not. I winged it.  #LivinOnTheEdge

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the ~~documentation~~ *code comments*.
- [X] I have updated the ~~documentation~~ *code comments* accordingly.
