### PR TITLE
Update requirements.txt to fix #926

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ peewee==2.8.1
 wsgiref==0.1.2
 geopy==1.11.0
 s2sphere==0.2.4
-gpsoauth==0.3.0
+gpsoauth==0.4.0
 PyMySQL==0.7.5
 flask-cors==2.1.2
 flask-compress==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ peewee==2.8.1
 wsgiref==0.1.2
 geopy==1.11.0
 s2sphere==0.2.4
-gpsoauth==0.4.0
 PyMySQL==0.7.5
 flask-cors==2.1.2
 flask-compress==1.3.0


### PR DESCRIPTION
Due to the new proxy signature used for google logins the requirements.txt needs to be updated to use gpsoauth 0.4.0 instead of 0.3.0.