### PR TITLE
Make too late scanning configurable

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -18,6 +18,7 @@
 #no-pokestops:          # disables pokestop scanning (default false)
 #scan-delay:            # default 10
 #step-limit:            # default 12
+#min-seconds-left:      # time that must be left on a spawn before considering it too late and skipping it (default 0)
 
 # Misc
 #gmaps-key:             # your Google Maps API key

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -438,7 +438,7 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
                     end_sleep = now() + (3600 * 2)
                     long_sleep_started = time.strftime('%H:%M:%S')
                     while now() < end_sleep:
-                        status['message'] = 'Worker failed more than {} scans; possibly banned account. Sleeping for 2 hour sleep as of {}'.format(args.max_failures, long_sleep_started)
+                        status['message'] = 'Worker {} failed more than {} scans; possibly banned account. Sleeping for 2 hour sleep as of {}'.format(account['username'], args.max_failures, long_sleep_started)
                         log.error(status['message'])
                         time.sleep(300)
                     break  # exit this loop to have the API recreated
@@ -508,7 +508,7 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
                     log.debug(status['message'])
                 except KeyError:
                     status['fail'] += 1
-                    status['message'] = 'Map parse failed at {:6f},{:6f}, abandoning location'.format(step_location[0], step_location[1])
+                    status['message'] = 'Map parse failed at {:6f},{:6f}, abandoning location. {} may be banned.'.format(step_location[0], step_location[1], account['username'])
                     log.exception(status['message'])
 
                 # Always delay the desired amount after "scan" completion

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -277,7 +277,15 @@ def search_overseer_thread(args, method, new_location_queue, pause_bit, encrypti
                 search_args = (step, step_location[0], step_location[1], step_location[2])
                 search_items_queue.put(search_args)
         else:
-            threadStatus['Overseer']['message'] = 'Processing search queue'
+            nextitem = search_items_queue.queue[0]
+            threadStatus['Overseer']['message'] = 'Processing search queue, next item is {:6f},{:6f}'.format(nextitem[1][0], nextitem[1][1])
+            # If times are specified, print the time of the next queue item, and how many seconds ahead/behind realtime
+            if nextitem[2]:
+                threadStatus['Overseer']['message'] += ' @ {}'.format(time.strftime('%H:%M:%S', time.localtime(nextitem[2])))
+                if nextitem[2] > now():
+                    threadStatus['Overseer']['message'] += ' ({}s ahead)'.format(nextitem[2] - now())
+                else:
+                    threadStatus['Overseer']['message'] += ' ({}s behind)'.format(now() - nextitem[2])
 
         # Now we just give a little pause here
         time.sleep(1)
@@ -428,9 +436,9 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
                 # If this account has been messing up too hard, let it rest
                 if status['fail'] >= args.max_failures:
                     end_sleep = now() + (3600 * 2)
-                    long_sleep_started = time.strftime('%H:%M')
+                    long_sleep_started = time.strftime('%H:%M:%S')
                     while now() < end_sleep:
-                        status['message'] = 'Account "{}" has failed more than {} scans; possibly banned account. Sleeping for 2 hour sleep as of {}'.format(account['username'], args.max_failures, long_sleep_started)
+                        status['message'] = 'Worker failed more than {} scans; possibly banned account. Sleeping for 2 hour sleep as of {}'.format(args.max_failures, long_sleep_started)
                         log.error(status['message'])
                         time.sleep(300)
                     break  # exit this loop to have the API recreated
@@ -452,7 +460,7 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
                             paused = True
                             break  # why can't python just have `break 2`...
                         remain = appears - now() + 10
-                        status['message'] = '{}s early for location {},{}; waiting...'.format(remain, step_location[0], step_location[1])
+                        status['message'] = 'Early for {:6f},{:6f}; waiting {}s...'.format(step_location[0], step_location[1], remain)
                         if first_loop:
                             log.info(status['message'])
                             first_loop = False
@@ -466,12 +474,12 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
                     search_items_queue.task_done()
                     status['skip'] += 1
                     # it is slightly silly to put this in status['message'] since it'll be overwritten very shortly after. Oh well.
-                    status['message'] = 'Too late for location {},{}; skipping'.format(step_location[0], step_location[1])
+                    status['message'] = 'Too late for location {:6f},{:6f}; skipping'.format(step_location[0], step_location[1])
                     log.info(status['message'])
                     # No sleep here; we've not done anything worth sleeping for. Plus we clearly need to catch up!
                     continue
 
-                status['message'] = 'Searching at {},{}'.format(step_location[0], step_location[1])
+                status['message'] = 'Searching at {:6f},{:6f}'.format(step_location[0], step_location[1])
                 log.info(status['message'])
 
                 # Let the api know where we intend to be for this loop
@@ -486,7 +494,7 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
                 # G'damnit, nothing back. Mark it up, sleep, carry on
                 if not response_dict:
                     status['fail'] += 1
-                    status['message'] = 'Invalid response at {},{}, abandoning location'.format(step_location[0], step_location[1])
+                    status['message'] = 'Invalid response at {:6f},{:6f}, abandoning location'.format(step_location[0], step_location[1])
                     log.error(status['message'])
                     time.sleep(args.scan_delay)
                     continue
@@ -496,14 +504,15 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
                     findCount = parse_map(args, response_dict, step_location, dbq, whq)
                     search_items_queue.task_done()
                     status[('success' if findCount > 0 else 'noitems')] += 1
-                    status['message'] = 'Search at {},{} completed with {} finds'.format(step_location[0], step_location[1], findCount)
+                    status['message'] = 'Search at {:6f},{:6f} completed with {} finds'.format(step_location[0], step_location[1], findCount)
                     log.debug(status['message'])
                 except KeyError:
                     status['fail'] += 1
-                    status['message'] = 'Map parse failed at {},{}, abandoning location'.format(step_location[0], step_location[1])
+                    status['message'] = 'Map parse failed at {:6f},{:6f}, abandoning location'.format(step_location[0], step_location[1])
                     log.exception(status['message'])
 
                 # Always delay the desired amount after "scan" completion
+                status['message'] += ', sleeping {}s until {}'.format(args.scan_delay, time.strftime('%H:%M:%S', time.localtime(time.time() + args.scan_delay)))
                 time.sleep(args.scan_delay)
 
         # catch any process exceptions, log them, and continue the thread

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -106,8 +106,14 @@ def status_printer(threadStatus, search_items_queue, db_updates_queue, wh_queue)
             # Create a list to hold all the status lines, so they can be printed all at once to reduce flicker
             status_text = []
 
+            # Calculate total skipped items
+            skip_total = 0
+            for item in threadStatus:
+                if 'skip' in threadStatus[item]:
+                    skip_total += threadStatus[item]['skip']
+
             # Print the queue length
-            status_text.append('Queues: {} items, {} db updates, {} webhook'.format(search_items_queue.qsize(), db_updates_queue.qsize(), wh_queue.qsize()))
+            status_text.append('Queues: {} search items, {} db updates, {} webhook.  Total skipped items: {}'.format(search_items_queue.qsize(), db_updates_queue.qsize(), wh_queue.qsize(), skip_total))
 
             # Print status of overseer
             status_text.append('{} Overseer: {}'.format(threadStatus['Overseer']['method'], threadStatus['Overseer']['message']))

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -470,7 +470,7 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
                         continue
 
                 # too late?
-                if leaves and now() > leaves:
+                if leaves and now() > (leaves - args.min_seconds_left):
                     search_items_queue.task_done()
                     status['skip'] += 1
                     # it is slightly silly to put this in status['message'] since it'll be overwritten very shortly after. Oh well.

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -73,6 +73,9 @@ def get_args():
     parser.add_argument('-mf', '--max-failures',
                         help='Maximum number of failures to parse locations before an account will go into a two hour sleep',
                         type=int, default=5)
+    parser.add_argument('-msl', '--min-seconds-left',
+                        help='Time that must be left on a spawn before considering it too late and skipping it. eg. 600 would skip anything with < 10 minutes remaining. Default 0.',
+                        type=int, default=0)
     parser.add_argument('-dc', '--display-in-console',
                         help='Display Found Pokemon in Console',
                         action='store_true', default=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ peewee==2.8.1
 wsgiref==0.1.2
 geopy==1.11.0
 s2sphere==0.2.4
-gpsoauth==0.3.0
 PyMySQL==0.7.5
 flask-cors==2.1.2
 flask-compress==1.3.0

--- a/static/sass/layout/_nav.scss
+++ b/static/sass/layout/_nav.scss
@@ -7,7 +7,9 @@
 		background: #F8F8F8;
 		box-shadow: none;
 		color: _palette(accent2, fg-bold);
-		height: 100%;
+		height: -webkit-calc(100% - 3.5em);
+		height: -moz-calc(100% - 3.5em);
+		height: calc(100% - 3.5em);
 		max-width: 80%;
 		overflow-y: auto;
 		position: fixed;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a new parameter, --min-seconds-left that specifies when to start dropping queue items instead of scanning them.

## Motivation and Context
When workers get behind, this allows them to skip scanning spawns that have less than the specified seconds remaining, so they can catch up.

Not everyone cares about the spawns with 10 seconds left on them, and would rather catch up so they can start getting 15 minute alerts again.

## How Has This Been Tested?
Tested on my server

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Some would rather catch all spawns (for statistical analysis)
Others only want ones they can get to in time.

Making this configurable allows you to start skipping queued items earlier, so if workers get behind they can eventually catch up again.