### PR TITLE
Add optional logging to file

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -360,7 +360,7 @@ def get_sps_location_list(args, current_location, sps_scan_current):
 
     locations.sort(key=itemgetter('time'))
 
-    if args.debug:
+    if args.verbose or args.very_verbose:
         for i in locations:
             sec = i['time'] % 60
             minute = (i['time'] / 60) % 60

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -89,7 +89,6 @@ def get_args():
     parser.add_argument('-c', '--china',
                         help='Coordinates transformer for China',
                         action='store_true')
-    parser.add_argument('-d', '--debug', help='Depreciated, use -v or -vv instead.', action='store_true')
     parser.add_argument('-m', '--mock', type=str,
                         help='Mock mode - point to a fpgo endpoint instead of using the real PogoApi, ec: http://127.0.0.1:9090',
                         default='')
@@ -159,6 +158,7 @@ def get_args():
     verbosity = parser.add_mutually_exclusive_group()
     verbosity.add_argument('-v', '--verbose', help='Show debug messages from PomemonGo-Map and pgoapi. Optionally specify file to log to.', nargs='?', const='nofile', default=False, metavar='filename.log')
     verbosity.add_argument('-vv', '--very-verbose', help='Like verbose, but show debug messages from all modules as well.  Optionally specify file to log to.', nargs='?', const='nofile', default=False, metavar='filename.log')
+    verbosity.add_argument('-d', '--debug', help='Depreciated, use -v or -vv instead.', action='store_true')
     parser.set_defaults(DEBUG=False)
 
     args = parser.parse_args()

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -90,6 +90,8 @@ def get_args():
                         help='Coordinates transformer for China',
                         action='store_true')
     parser.add_argument('-d', '--debug', help='Debug Mode', action='store_true')
+    parser.add_argument('-f', '--logfile', nargs='?', const='pokemongo-map.log',
+                        help='Append log messages to a log file')
     parser.add_argument('-m', '--mock', type=str,
                         help='Mock mode - point to a fpgo endpoint instead of using the real PogoApi, ec: http://127.0.0.1:9090',
                         default='')

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -89,9 +89,7 @@ def get_args():
     parser.add_argument('-c', '--china',
                         help='Coordinates transformer for China',
                         action='store_true')
-    parser.add_argument('-d', '--debug', help='Debug Mode', action='store_true')
-    parser.add_argument('-f', '--logfile', nargs='?', const='pokemongo-map.log',
-                        help='Append log messages to a log file')
+    parser.add_argument('-d', '--debug', help='Depreciated, use -v or -vv instead.', action='store_true')
     parser.add_argument('-m', '--mock', type=str,
                         help='Mock mode - point to a fpgo endpoint instead of using the real PogoApi, ec: http://127.0.0.1:9090',
                         default='')
@@ -158,6 +156,9 @@ def get_args():
     parser.add_argument('-ps', '--print-status', action='store_true',
                         help='Show a status screen instead of log messages. Can switch between status and logs by pressing enter.', default=False)
     parser.add_argument('-el', '--encrypt-lib', help='Path to encrypt lib to be used instead of the shipped ones')
+    verbosity = parser.add_mutually_exclusive_group()
+    verbosity.add_argument('-v', '--verbose', help='Show debug messages from PomemonGo-Map and pgoapi. Optionally specify file to log to.', nargs='?', const='nofile', default=False, metavar='filename.log')
+    verbosity.add_argument('-vv', '--very-verbose', help='Like verbose, but show debug messages from all modules as well.  Optionally specify file to log to.', nargs='?', const='nofile', default=False, metavar='filename.log')
     parser.set_defaults(DEBUG=False)
 
     args = parser.parse_args()

--- a/runserver.py
+++ b/runserver.py
@@ -59,6 +59,11 @@ if not hasattr(pgoapi, "__version__") or StrictVersion(pgoapi.__version__) < Str
 def main():
     args = get_args()
 
+    # Check for depreciated argumented
+    if args.debug:
+        log.warning('--debug is depreciated. Please use --verbose instead.  Enabling --verbose')
+        args.verbose = 'nofile'
+
     # Add file logging if enabled
     if args.verbose and args.verbose != 'nofile':
         filelog = logging.FileHandler(args.verbose)
@@ -236,8 +241,10 @@ def main():
             ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
             ssl_context.load_cert_chain(args.ssl_certificate, args.ssl_privatekey)
             log.info('Web server in SSL mode.')
-
-        app.run(threaded=True, use_reloader=False, debug=args.debug, host=args.host, port=args.port, ssl_context=ssl_context)
+        if args.verbose or args.very_verbose:
+            app.run(threaded=True, use_reloader=False, debug=True, host=args.host, port=args.port, ssl_context=ssl_context)
+        else:
+            app.run(threaded=True, use_reloader=False, debug=False, host=args.host, port=args.port, ssl_context=ssl_context)
 
 if __name__ == '__main__':
     main()

--- a/runserver.py
+++ b/runserver.py
@@ -60,8 +60,12 @@ def main():
     args = get_args()
 
     # Add file logging if enabled
-    if args.logfile:
-        filelog = logging.FileHandler(args.logfile)
+    if args.verbose and args.verbose != 'nofile':
+        filelog = logging.FileHandler(args.verbose)
+        filelog.setFormatter(logging.Formatter('%(asctime)s [%(threadName)16s][%(module)14s][%(levelname)8s] %(message)s'))
+        logging.getLogger('').addHandler(filelog)
+    if args.very_verbose and args.very_verbose != 'nofile':
+        filelog = logging.FileHandler(args.very_verbose)
         filelog.setFormatter(logging.Formatter('%(asctime)s [%(threadName)16s][%(module)14s][%(levelname)8s] %(message)s'))
         logging.getLogger('').addHandler(filelog)
 
@@ -70,7 +74,7 @@ def main():
     if encryption_lib_path is "":
         sys.exit(1)
 
-    if args.debug:
+    if args.verbose or args.very_verbose:
         log.setLevel(logging.DEBUG)
     else:
         log.setLevel(logging.INFO)
@@ -93,10 +97,15 @@ def main():
     config['parse_gyms'] = not args.no_gyms
 
     # Turn these back up if debugging
-    if args.debug:
-        logging.getLogger('requests').setLevel(logging.DEBUG)
+    if args.verbose or args.very_verbose:
         logging.getLogger('pgoapi').setLevel(logging.DEBUG)
+    if args.very_verbose:
+        logging.getLogger('peewee').setLevel(logging.DEBUG)
+        logging.getLogger('requests').setLevel(logging.DEBUG)
+        logging.getLogger('pgoapi.pgoapi').setLevel(logging.DEBUG)
+        logging.getLogger('pgoapi.rpc_api').setLevel(logging.DEBUG)
         logging.getLogger('rpc_api').setLevel(logging.DEBUG)
+        logging.getLogger('werkzeug').setLevel(logging.DEBUG)
 
     # use lat/lng directly if matches such a pattern
     prog = re.compile("^(\-?\d+\.\d+),?\s?(\-?\d+\.\d+)$")

--- a/runserver.py
+++ b/runserver.py
@@ -59,6 +59,12 @@ if not hasattr(pgoapi, "__version__") or StrictVersion(pgoapi.__version__) < Str
 def main():
     args = get_args()
 
+    # Add file logging if enabled
+    if args.logfile:
+        filelog = logging.FileHandler(args.logfile)
+        filelog.setFormatter(logging.Formatter('%(asctime)s [%(threadName)16s][%(module)14s][%(levelname)8s] %(message)s'))
+        logging.getLogger('').addHandler(filelog)
+
     # Check if we have the proper encryption library file and get its path
     encryption_lib_path = get_encryption_lib_path(args)
     if encryption_lib_path is "":


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
With the status screen, output can't easily be redirected to a log file anymore.

This adds two parameters:
`-v <optional filename>` will enable debug logging for the main program and pgoapi
`-vv <optional filename>` will enable debug logging for all the imported modules as well

If a filename is specified, log messages will be appended to that file, in addition to being shown on screen.

The `-d` debug parameter no longer does anything, and has been marked as depreciated (but not removed yet, so as not to break anyone's launch scripts.  

References to args.debug have been removed, save one in runserver.py that warns the user the argument is depreciated, and turns on --verbose, so -d can be removed easily at a later date.


## Motivation and Context
Allows saving log messages more easily, helps with troubleshooting.

## How Has This Been Tested?
On my server
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

