### PR TITLE
Override 70m step distance with new argument 'step_distance'

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -18,6 +18,7 @@
 #no-pokestops:          # disables pokestop scanning (default false)
 #scan-delay:            # default 10
 #step-limit:            # default 12
+#step-distance:         # default 70
 #min-seconds-left:      # time that must be left on a spawn before considering it too late and skipping it (default 0)
 
 # Misc

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -300,12 +300,10 @@ def search_overseer_thread(args, method, new_location_queue, pause_bit, encrypti
 def get_hex_location_list(args, current_location):
     # if we are only scanning for pokestops/gyms, then increase step radius to visibility range
     if args.no_pokemon:
-        step_distance = 0.900
-    else:
-        step_distance = 0.070
+        args.step_distance = 900
 
     # update our list of coords
-    locations = list(generate_location_steps(current_location, args.step_limit, step_distance))
+    locations = list(generate_location_steps(current_location, args.step_limit, args.step.distance / 1000 ))
 
     # In hex "spawns only" mode, filter out scan locations with no history of pokemons
     if args.spawnpoints_only and not args.no_pokemon:

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -303,7 +303,7 @@ def get_hex_location_list(args, current_location):
         args.step_distance = 900
 
     # update our list of coords
-    locations = list(generate_location_steps(current_location, args.step_limit, args.step.distance / 1000 ))
+    locations = list(generate_location_steps(current_location, args.step_limit, args.step.distance / 1000))
 
     # In hex "spawns only" mode, filter out scan locations with no history of pokemons
     if args.spawnpoints_only and not args.no_pokemon:

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -60,6 +60,8 @@ def get_args():
                         action='store_true', default=False)
     parser.add_argument('-st', '--step-limit', help='Steps', type=int,
                         default=12)
+    parser.add_argument('-std', '--step-distance', help='Distance between steps', type=int,
+                        default=70)
     parser.add_argument('-sd', '--scan-delay',
                         help='Time delay between requests in scan threads',
                         type=float, default=10)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Yes, another command line argument

## Motivation and Context
Recent developments on the data contained within encounter_id shows that it is possible to determine the exact location of a pokemon when seen from up to 200m away (via the nearby list). Although this map has not yet implemented that feature, it is in the works. That feature is independent of this one, thus the separate PR, but I already know that once that feature exists some people will want to only scan 200m at a time (given the account bans, nobody wants to use any more accounts than necessary, and upping the radius from 70 to 200 will let you scan about 8x more area per worker)

## How Has This Been Tested?
Changed scan-distance in config to a few random values, watched scans happen at larger intervals.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Yet another command line argument

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Will update documentation when this variable becomes useful. For now, nobody will need or want to use it.

Feel free to leave this PR sit and wait, but I am hoping to get it at least reviewed so it's ready to go when it becomes useful to be able to adjust the scan distance manually.

