### PR TITLE
Added account rotation

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -27,7 +27,7 @@ import geopy
 import geopy.distance
 
 from operator import itemgetter
-from threading import Thread
+from threading import Thread, Event
 from queue import Queue, Empty
 
 from pgoapi import PGoApi
@@ -168,6 +168,10 @@ def search_overseer_thread(args, method, new_location_queue, pause_bit, encrypti
 
     log.info('Search overseer starting')
 
+    # Shuffle account order
+    acc_list = list(args.accounts)
+    random.shuffle(acc_list)
+    worker_reserve = Queue()
     search_items_queue = Queue()
     threadStatus = {}
 
@@ -185,9 +189,31 @@ def search_overseer_thread(args, method, new_location_queue, pause_bit, encrypti
         t.daemon = True
         t.start()
 
-    # Create a search_worker_thread per account
+    num_workers = len(args.accounts)
+    reserve_acc = swap_rate = 0
+    if args.acc_reserve > 0:
+        if args.acc_reserve > 1:  # Specific number of reserves
+            reserve_acc = int(args.acc_reserve)
+        else:  # Proportional reserve
+            reserve_acc = int(math.floor(num_workers * args.acc_reserve))
+
+        if reserve_acc >= num_workers:
+            log.warning('Too many accounts on reserve. Disabling reserve accounts!')
+            reserve_acc = 0
+        else:
+            if reserve_acc < num_workers / 2:
+                log.warning("It's recommended to have more reserve accounts than workers (acc-reserve >= 0.5)")
+
+            num_workers -= reserve_acc
+            # rational: each account should be active for approximately 60 minutes before being swapped out
+            # so calculate the number of scans we can make in this time, and use this as a swap_rate
+            swap_rate = 1 / float((60 * 60) / args.scan_delay)
+
+    log.info('%d workers will be created with %d accounts on reserve. Swap rate: %g', num_workers, reserve_acc, swap_rate)
+
+    # Create search_worker_threads
     log.info('Starting search worker threads')
-    for i, account in enumerate(args.accounts):
+    for i, account in enumerate(acc_list):
         log.debug('Starting search worker thread %d for user %s', i, account['username'])
         workerId = 'Worker {:03}'.format(i)
         threadStatus[workerId] = {
@@ -199,14 +225,19 @@ def search_overseer_thread(args, method, new_location_queue, pause_bit, encrypti
             'skip': 0,
             'user': account['username']
         }
+        worker_sleeper = Event()
+        worker_reserve.put(worker_sleeper)
 
         t = Thread(target=search_worker_thread,
                    name='search-worker-{}'.format(i),
-                   args=(args, account, search_items_queue, pause_bit,
+                   args=(args, account, worker_reserve, swap_rate, i, worker_sleeper, search_items_queue, pause_bit,
                          encryption_lib_path, threadStatus[workerId],
                          db_updates_queue, wh_queue))
         t.daemon = True
         t.start()
+
+    for i in range(num_workers):
+        worker_reserve.get().set()
 
     '''
     For hex scanning, we can generate the full list of scan points well
@@ -410,11 +441,27 @@ def get_sps_location_list(args, current_location, sps_scan_current):
     return retset
 
 
-def search_worker_thread(args, account, search_items_queue, pause_bit, encryption_lib_path, status, dbq, whq):
+def search_worker_thread(args, account, worker_reserve, swap_rate, worker_num, worker_sleeper, search_items_queue, pause_bit, encryption_lib_path, status, dbq, whq):
 
-    stagger_thread(args, account)
+    def sleep_worker(delay=0):
+        if delay:
+            time.sleep(delay)
+
+        worker_sleeper.clear()
+        log.info(worker_reserve.qsize())
+        worker_reserve.put(worker_sleeper)
+        toWake = worker_reserve.get()
+        toWake.set()  # wake our replacement
+        log.info('Worker going to sleep')
+        worker_sleeper.wait()  # wait to be woken
+        log.info('Worker waking up')
+
+    stagger_thread(args, worker_num)
 
     log.debug('Search worker thread starting')
+
+    status['message'] = 'On reserve'
+    worker_sleeper.wait()
 
     # The forever loop for the thread
     while True:
@@ -441,14 +488,11 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
 
                 # If this account has been messing up too hard, let it rest
                 if status['fail'] >= args.max_failures:
-                    end_sleep = now() + (3600 * 2)
                     long_sleep_started = time.strftime('%H:%M:%S')
-                    while now() < end_sleep:
-                        status['message'] = 'Worker {} failed more than {} scans; possibly banned account. Sleeping for 2 hour sleep as of {}'.format(account['username'], args.max_failures, long_sleep_started)
-                        log.error(status['message'])
-                        time.sleep(300)
+                    status['message'] = 'Worker {} failed more than {} scans; possibly banned account. Sleeping for 2 hour sleep as of {}'.format(account['username'], args.max_failures, long_sleep_started)
+                    log.error(status['message'])
+                    sleep_worker(60 * 60 * 2)
                     break  # exit this loop to have the API recreated
-
                 while pause_bit.is_set():
                     status['message'] = 'Scanning paused'
                     time.sleep(2)
@@ -521,6 +565,10 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
                 status['message'] += ', sleeping {}s until {}'.format(args.scan_delay, time.strftime('%H:%M:%S', time.localtime(time.time() + args.scan_delay)))
                 time.sleep(args.scan_delay)
 
+                if swap_rate and random.random() < swap_rate:
+                    status['message'] = 'On reserve'
+                    sleep_worker()
+
         # catch any process exceptions, log them, and continue the thread
         except Exception as e:
             status['message'] = 'Exception in search_worker: {}'.format(e)
@@ -582,10 +630,10 @@ def map_request(api, position, jitter=False):
 
 
 # Delay each thread start time so that logins only occur ~1s
-def stagger_thread(args, account):
-    if args.accounts.index(account) == 0:
+def stagger_thread(args, worker_num):
+    if worker_num == 0:
         return  # No need to delay the first one
-    delay = args.accounts.index(account) + ((random.random() - .5) / 2)
+    delay = worker_num + ((random.random() - .5) / 2)
     log.debug('Delaying thread startup for %.2f seconds', delay)
     time.sleep(delay)
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -54,6 +54,9 @@ def get_args():
                         help='Usernames, one per account.')
     parser.add_argument('-p', '--password', action='append',
                         help='Passwords, either single one for all accounts or one per account.')
+    parser.add_argument('--acc-reserve', type=float, default=0, help='The number (or percent) of accounts \
+                        to keep in reserve. Reserved accounts are regularily rotated in to reduce \
+                        account stress. Defaults to 0 (off)')
     parser.add_argument('-l', '--location', type=parse_unicode,
                         help='Location, can be an address or coordinates')
     parser.add_argument('-j', '--jitter', help='Apply random -9m to +9m jitter to location',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request adds the ability to define a number of 'reserve' accounts. These workers are pooled and not assigned to scan. Randomly (about once every hour), or when a worker detects a possible ban, the scanning worker pulls a replacement out of the pool and retires itself into the pool.

This results in accounts being swapped in and out as the scanner runs.

![image](https://cloud.githubusercontent.com/assets/5599341/17958547/af286396-6a68-11e6-8942-7c4e210fc154.png)
![image](https://cloud.githubusercontent.com/assets/5599341/17958556/bea7d41e-6a68-11e6-8e91-bc709acce473.png)

## Motivation and Context
Workers running continually is a dead giveaway of a scanner. Also, this allows the scanner to more elegantly recover from the loss of an account without a loss of capacity.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

