### PR TITLE
Make  all locations window in full stat respect selected duration period

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -106,7 +106,11 @@ class Pogom(Flask):
                     break
 
         if request.args.get('appearances', 'false') == 'true':
-            d['appearances'] = Pokemon.get_appearances(request.args.get('pokemonid'), request.args.get('last', type=float))
+            for duration in self.get_valid_stat_input()["duration"]["items"].values():
+                if duration["selected"] == "SELECTED":
+                    d['appearances'] = Pokemon.get_appearances(request.args.get('pokemonid'),
+                                                               request.args.get('last', type=float), duration["value"])
+                    break
 
         if request.args.get('spawnpoints', 'false') == 'true':
             d['spawnpoints'] = Pokemon.get_spawnpoints(swLat, swLng, neLat, neLng)

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -101,7 +101,7 @@ class Pogom(Flask):
 
         selected_duration = None
 
-        # statistic period for which appearances and seen pokemons are queried
+        # for stats and changed nest points etc, limit pokemon queried
         for duration in self.get_valid_stat_input()["duration"]["items"].values():
             if duration["selected"] == "SELECTED":
                 selected_duration = duration["value"]

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -101,6 +101,7 @@ class Pogom(Flask):
 
         selected_duration = None
 
+        # statistic period for which appearances and seen pokemons are queried
         for duration in self.get_valid_stat_input()["duration"]["items"].values():
             if duration["selected"] == "SELECTED":
                 selected_duration = duration["value"]

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -99,18 +99,18 @@ class Pogom(Flask):
             d['scanned'] = ScannedLocation.get_recent(swLat, swLng, neLat,
                                                       neLng)
 
+        selected_duration = None
+
+        for duration in self.get_valid_stat_input()["duration"]["items"].values():
+            if duration["selected"] == "SELECTED":
+                selected_duration = duration["value"]
+
         if request.args.get('seen', 'false') == 'true':
-            for duration in self.get_valid_stat_input()["duration"]["items"].values():
-                if duration["selected"] == "SELECTED":
-                    d['seen'] = Pokemon.get_seen(duration["value"])
-                    break
+            d['seen'] = Pokemon.get_seen(selected_duration)
 
         if request.args.get('appearances', 'false') == 'true':
-            for duration in self.get_valid_stat_input()["duration"]["items"].values():
-                if duration["selected"] == "SELECTED":
-                    d['appearances'] = Pokemon.get_appearances(request.args.get('pokemonid'),
-                                                               request.args.get('last', type=float), duration["value"])
-                    break
+            d['appearances'] = Pokemon.get_appearances(request.args.get('pokemonid'),
+                                                       request.args.get('last', type=float), selected_duration)
 
         if request.args.get('spawnpoints', 'false') == 'true':
             d['spawnpoints'] = Pokemon.get_spawnpoints(swLat, swLng, neLat, neLng)

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -104,6 +104,7 @@ class Pogom(Flask):
         for duration in self.get_valid_stat_input()["duration"]["items"].values():
             if duration["selected"] == "SELECTED":
                 selected_duration = duration["value"]
+                break
 
         if request.args.get('seen', 'false') == 'true':
             d['seen'] = Pokemon.get_seen(selected_duration)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -195,11 +195,14 @@ class Pokemon(BaseModel):
         return {'pokemon': pokemons, 'total': total}
 
     @classmethod
-    def get_appearances(cls, pokemon_id, last_appearance):
+    def get_appearances(cls, pokemon_id, last_appearance, timediff):
+        if timediff:
+            timediff = datetime.utcnow() - timediff
         query = (Pokemon
                  .select()
                  .where((Pokemon.pokemon_id == pokemon_id) &
-                        (Pokemon.disappear_time > datetime.utcfromtimestamp(last_appearance / 1000.0))
+                        (Pokemon.disappear_time > datetime.utcfromtimestamp(last_appearance / 1000.0)) &
+                        (Pokemon.disappear_time > timediff)
                         )
                  .order_by(Pokemon.disappear_time.asc())
                  .dicts()

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -197,7 +197,7 @@ class Pokemon(BaseModel):
     @classmethod
     def get_appearances(cls, pokemon_id, last_appearance, timediff):
         '''
-        :param pokemon_id: id of pokemon that should be
+        :param pokemon_id: id of pokemon that we need appearances for
         :param last_appearance: time of last appearance of pokemon after which we are getting appearances
         :param timediff: limiting period of the selection
         :return: list of  pokemon  appearances over a selected period

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -196,6 +196,7 @@ class Pokemon(BaseModel):
 
     @classmethod
     def get_appearances(cls, pokemon_id, last_appearance, timediff):
+        # period during which appearances are displayed
         if timediff:
             timediff = datetime.utcnow() - timediff
         query = (Pokemon

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -196,7 +196,12 @@ class Pokemon(BaseModel):
 
     @classmethod
     def get_appearances(cls, pokemon_id, last_appearance, timediff):
-        # period during which appearances are displayed
+        '''
+        :param pokemon_id: id of pokemon that should be
+        :param last_appearance: time of last appearance of pokemon after which we are getting appearances
+        :param timediff: limiting period of the selection
+        :return: list of  pokemon  appearances over a selected period
+        '''
         if timediff:
             timediff = datetime.utcnow() - timediff
         query = (Pokemon

--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -208,7 +208,8 @@ function loadDetails () {
       'scanned': false,
       'appearances': true,
       'pokemonid': pokemonid,
-      'last': lastappearance
+      'last': lastappearance,
+      'duration': document.getElementById('duration').options[document.getElementById('duration').selectedIndex].value
     },
     dataType: 'json',
     beforeSend: function () {

--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -15,7 +15,7 @@ function loadRawData () {
       'gyms': false,
       'scanned': false,
       'seen': true,
-      'duration': document.getElementById('duration').options[document.getElementById('duration').selectedIndex].value
+      'duration': $('#duration').val()
     },
     dataType: 'json',
     beforeSend: function () {
@@ -209,7 +209,7 @@ function loadDetails () {
       'appearances': true,
       'pokemonid': pokemonid,
       'last': lastappearance,
-      'duration': document.getElementById('duration').options[document.getElementById('duration').selectedIndex].value
+      'duration': $('#duration').val()
     },
     dataType: 'json',
     beforeSend: function () {


### PR DESCRIPTION
Make  all locations window in full stat respect selection duration periodMake  all locations window in full stat respect selection duration period
When opening all location it will show only pokemons from the selected in options period.


## Motivation and Context
Since a lot of nest changed recently it would be good to be able to see data only from selected period, not from all time since it will contain no longer actual spawn data.

## How Has This Been Tested?
on my local pc.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

