### PR TITLE
Specify a different config file - rebase

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -48,7 +48,7 @@ def get_args():
     # fuck PEP8
     configpath = os.path.join(os.path.dirname(__file__), '../config/config.ini')
     parser = configargparse.ArgParser(default_config_files=[configpath], auto_env_var_prefix='POGOMAP_')
-    parser.add_argument('-configfile', is_config_file=True,
+    parser.add_argument('-cn', is_config_file=True,
                         help='Config file path. e.g. "config/config.ini"')
     parser.add_argument('-a', '--auth-service', type=str.lower, action='append',
                         help='Auth Services, either one for all accounts or one per account: ptc or google. Defaults all to ptc.')

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -48,8 +48,8 @@ def get_args():
     # fuck PEP8
     configpath = os.path.join(os.path.dirname(__file__), '../config/config.ini')
     parser = configargparse.ArgParser(default_config_files=[configpath], auto_env_var_prefix='POGOMAP_')
-    parser.add_argument('-cn', is_config_file=True,
-                        help='Config file path. e.g. "config/config.ini"')
+    parser.add_argument('-cf', is_config_file=True,
+                        help='Config file path. e.g. "config/config.ini" or "config/AnotherConfig.ini"')
     parser.add_argument('-a', '--auth-service', type=str.lower, action='append',
                         help='Auth Services, either one for all accounts or one per account: ptc or google. Defaults all to ptc.')
     parser.add_argument('-u', '--username', action='append',

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -48,6 +48,8 @@ def get_args():
     # fuck PEP8
     configpath = os.path.join(os.path.dirname(__file__), '../config/config.ini')
     parser = configargparse.ArgParser(default_config_files=[configpath], auto_env_var_prefix='POGOMAP_')
+    parser.add_argument('-configfile', is_config_file=True,
+                        help='Config file path. e.g. "config/config.ini"')
     parser.add_argument('-a', '--auth-service', type=str.lower, action='append',
                         help='Auth Services, either one for all accounts or one per account: ptc or google. Defaults all to ptc.')
     parser.add_argument('-u', '--username', action='append',

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1136,7 +1136,7 @@ function pokestopLabel (expireTime, latitude, longitude) {
         Location: ${latitude.toFixed(6)}, ${longitude.toFixed(7)}
       </div>
       <div>
-        <a href='https://www.google.com/maps/dir/My+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
+        <a href='https://www.google.com/maps/dir/Current+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
       </div>`
   }
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1052,7 +1052,7 @@ function pokemonLabel (name, rarity, types, disappearTime, id, latitude, longitu
       <a href='javascript:excludePokemon(${id})'>Exclude</a>&nbsp;&nbsp
       <a href='javascript:notifyAboutPokemon(${id})'>Notify</a>&nbsp;&nbsp
       <a href='javascript:removePokemonMarker("${encounterId}")'>Remove</a>&nbsp;&nbsp
-      <a href='https://www.google.com/maps/dir/Current+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
+      <a href='https://www.google.com/maps/dir/My+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
     </div>`
   return contentstring
 }
@@ -1072,7 +1072,7 @@ function gymLabel (teamName, teamId, gymPoints, latitude, longitude) {
             Location: ${latitude.toFixed(6)}, ${longitude.toFixed(7)}
           </div>
           <div>
-            <a href='https://www.google.com/maps/dir/Current+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
+            <a href='https://www.google.com/maps/dir/My+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
           </div>
         </center>
       </div>`
@@ -1099,7 +1099,7 @@ function gymLabel (teamName, teamId, gymPoints, latitude, longitude) {
             Location: ${latitude.toFixed(6)}, ${longitude.toFixed(7)}
           </div>
           <div>
-            <a href='https://www.google.com/maps/dir/Current+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
+            <a href='https://www.google.com/maps/dir/My+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
           </div>
         </center>
       </div>`
@@ -1125,7 +1125,7 @@ function pokestopLabel (expireTime, latitude, longitude) {
         Location: ${latitude.toFixed(6)}, ${longitude.toFixed(7)}
       </div>
       <div>
-        <a href='https://www.google.com/maps/dir/Current+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
+        <a href='https://www.google.com/maps/dir/My+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
       </div>`
   } else {
     str = `
@@ -1136,7 +1136,7 @@ function pokestopLabel (expireTime, latitude, longitude) {
         Location: ${latitude.toFixed(6)}, ${longitude.toFixed(7)}
       </div>
       <div>
-        <a href='https://www.google.com/maps/dir/Current+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
+        <a href='https://www.google.com/maps/dir/My+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
       </div>`
   }
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1052,7 +1052,7 @@ function pokemonLabel (name, rarity, types, disappearTime, id, latitude, longitu
       <a href='javascript:excludePokemon(${id})'>Exclude</a>&nbsp;&nbsp
       <a href='javascript:notifyAboutPokemon(${id})'>Notify</a>&nbsp;&nbsp
       <a href='javascript:removePokemonMarker("${encounterId}")'>Remove</a>&nbsp;&nbsp
-      <a href='https://www.google.com/maps/dir/My+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
+      <a href='https://www.google.com/maps/dir/Current+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
     </div>`
   return contentstring
 }
@@ -1072,7 +1072,7 @@ function gymLabel (teamName, teamId, gymPoints, latitude, longitude) {
             Location: ${latitude.toFixed(6)}, ${longitude.toFixed(7)}
           </div>
           <div>
-            <a href='https://www.google.com/maps/dir/My+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
+            <a href='https://www.google.com/maps/dir/Current+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
           </div>
         </center>
       </div>`
@@ -1099,7 +1099,7 @@ function gymLabel (teamName, teamId, gymPoints, latitude, longitude) {
             Location: ${latitude.toFixed(6)}, ${longitude.toFixed(7)}
           </div>
           <div>
-            <a href='https://www.google.com/maps/dir/My+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
+            <a href='https://www.google.com/maps/dir/Current+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
           </div>
         </center>
       </div>`
@@ -1125,7 +1125,7 @@ function pokestopLabel (expireTime, latitude, longitude) {
         Location: ${latitude.toFixed(6)}, ${longitude.toFixed(7)}
       </div>
       <div>
-        <a href='https://www.google.com/maps/dir/My+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
+        <a href='https://www.google.com/maps/dir/Current+Location/${latitude},${longitude}?hl=en' target='_blank' title='View in Maps'>Get directions</a>
       </div>`
   } else {
     str = `


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added command line option to specify a different config file

## Motivation and Context
It's easier to manage usernames/passwords in a config file versus -a auth -u username -p password at run time.

## How Has This Been Tested?
On my own map

## Documentation for the Wiki before merging:
```
usage: runserver.py [-h] [-cf CONFIG] [-a AUTH_SERVICE] [-u USERNAME]
                    [-p PASSWORD] [-l LOCATION] [-j] [-st STEP_LIMIT]
                    [-sd SCAN_DELAY] [-ld LOGIN_DELAY] [-lr LOGIN_RETRIES]
                    [-sr SCAN_RETRIES] [-dc] [-H HOST] [-P PORT] [-L LOCALE]
                    [-c] [-d] [-m MOCK] [-ns] [-os] [-nsc] [-fl] -k GMAPS_KEY
                    [--spawnpoints-only] [-C] [-D DB] [-cd] [-np] [-ng] [-nk]
                    [-ss [SPAWNPOINT_SCANNING]] [--dump-spawnpoints]
                    [-pd PURGE_DATA] [-px PROXY] [--db-type DB_TYPE]
                    [--db-name DB_NAME] [--db-user DB_USER]
                    [--db-pass DB_PASS] [--db-host DB_HOST]
                    [--db-port DB_PORT]
                    [--db-max_connections DB_MAX_CONNECTIONS]
                    [--db-threads DB_THREADS] [-wh [WEBHOOKS [WEBHOOKS ...]]]
                    [--webhook-updates-only] [--wh-threads WH_THREADS]
                    [--ssl-certificate SSL_CERTIFICATE]
                    [--ssl-privatekey SSL_PRIVATEKEY] [-ps] [-el ENCRYPT_LIB]

Args that start with '--' (eg. -a) can also be set in a config file
(./PokemonGo-Mappogom/config/config.ini or specified via -cf). The
recognized syntax for setting (key, value) pairs is based on the INI and YAML
formats (e.g. key=value or foo=TRUE). For full documentation of the
differences from the standards please refer to the ConfigArgParse
documentation. If an arg is specified in more than one place, then commandline
values override config file values which override defaults.

optional arguments:
  -h, --help            show this help message and exit
  -cf CONFIG
                       Config file path. e.g. "config/config.ini" or "config/AnotherConfig.ini"
  -a AUTH_SERVICE, --auth-service AUTH_SERVICE
                        Auth Services, either one for all accounts or one per
                        account. ptc or google. Defaults all to ptc.
  -u USERNAME, --username USERNAME
                        Usernames, one per account.
  -p PASSWORD, --password PASSWORD
                        Passwords, either single one for all accounts or one
                        per account.
  -l LOCATION, --location LOCATION
                        Location, can be an address or coordinates
  -j, --jitter          Apply random -9m to +9m jitter to location
  -st STEP_LIMIT, --step-limit STEP_LIMIT
                        Steps
  -sd SCAN_DELAY, --scan-delay SCAN_DELAY
                        Time delay between requests in scan threads
  -ld LOGIN_DELAY, --login-delay LOGIN_DELAY
                        Time delay between each login attempt
  -lr LOGIN_RETRIES, --login-retries LOGIN_RETRIES
                        Number of logins attempts before refreshing a thread
  -sr SCAN_RETRIES, --scan-retries SCAN_RETRIES
                        Number of retries for a given scan cell
  -dc, --display-in-console
                        Display Found Pokemon in Console
  -H HOST, --host HOST  Set web server listening host
  -P PORT, --port PORT  Set web server listening port
  -L LOCALE, --locale LOCALE
                        Locale for Pokemon names (default: en, check
                        static/dist/locales for more)
  -c, --china           Coordinates transformer for China
  -d, --debug           Debug Mode
  -m MOCK, --mock MOCK  Mock mode - point to a fpgo endpoint instead of using
                        the real PogoApi, ec: http://127.0.0.1:9090
  -ns, --no-server      No-Server Mode. Starts the searcher but not the
                        Webserver.
  -os, --only-server    Server-Only Mode. Starts only the Webserver without
                        the searcher.
  -nsc, --no-search-control
                        Disables search control
  -fl, --fixed-location
                        Hides the search bar for use in shared maps.
  -k GMAPS_KEY, --gmaps-key GMAPS_KEY
                        Google Maps Javascript API Key
  --spawnpoints-only    Only scan locations with spawnpoints in them.
  -C, --cors            Enable CORS on web server
  -D DB, --db DB        Database filename
  -cd, --clear-db       Deletes the existing database before starting the
                        Webserver.
  -np, --no-pokemon     Disables Pokemon from the map (including parsing them
                        into local db)
  -ng, --no-gyms        Disables Gyms from the map (including parsing them
                        into local db)
  -nk, --no-pokestops   Disables PokeStops from the map (including parsing
                        them into local db)
  -ss [SPAWNPOINT_SCANNING], --spawnpoint-scanning [SPAWNPOINT_SCANNING]
                        Use spawnpoint scanning (instead of hex grid)
  --dump-spawnpoints    dump the spawnpoints from the db to json (only for use
                        with -ss)
  -pd PURGE_DATA, --purge-data PURGE_DATA
                        Clear pokemon from database this many hours after they
                        disappear (0 to disable)
  -px PROXY, --proxy PROXY
                        Proxy url (e.g. socks5://127.0.0.1:9050)
  --db-type DB_TYPE     Type of database to be used (default: sqlite)
  --db-name DB_NAME     Name of the database to be used
  --db-user DB_USER     Username for the database
  --db-pass DB_PASS     Password for the database
  --db-host DB_HOST     IP or hostname for the database
  --db-port DB_PORT     Port for the database
  --db-max_connections DB_MAX_CONNECTIONS
                        Max connections (per thread) for the database
  --db-threads DB_THREADS
                        Number of db threads; increase if the db queue falls
                        behind
  -wh [WEBHOOKS [WEBHOOKS ...]], --webhook [WEBHOOKS [WEBHOOKS ...]]
                        Define URL(s) to POST webhook information to
  --webhook-updates-only
                        Only send updates (pokémon & lured pokéstops)
  --wh-threads WH_THREADS
                        Number of webhook threads; increase if the webhook
                        queue falls behind
  --ssl-certificate SSL_CERTIFICATE
                        Path to SSL certificate file
  --ssl-privatekey SSL_PRIVATEKEY
                        Path to SSL private key file
  -ps, --print-status   Show a status screen instead of log messages. Can
                        switch between status and logs by pressing enter.
  -el ENCRYPT_LIB, --encrypt-lib ENCRYPT_LIB
                        Path to encrypt lib to be used instead of the shipped
                        ones
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

Ability to specify a different config file other than config.ini

e.g. python runserver.py -os -cf"config/MyConfig.ini"