### PR TITLE
fix seen pokemons to return distinct results

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -175,6 +175,7 @@ class Pokemon(BaseModel):
                          Pokemon.longitude,
                          pokemon_count_query.c.count)
                  .join(pokemon_count_query, on=(Pokemon.pokemon_id == pokemon_count_query.c.pokemon_id))
+                 .distinct()
                  .where(Pokemon.disappear_time == pokemon_count_query.c.lastappeared)
                  .dicts()
                  )


### PR DESCRIPTION
## Description
Make a stats page return proper unique results and dont have duplicates that lead to jumping number on stat page

## Motivation and Context
Fixes this -> https://github.com/PokemonGoMap/PokemonGo-Map/issues/940


## How Has This Been Tested?
on my local pc

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

