### PR TITLE
Jitter by Default, Except on Spawnpoint Scanning

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -501,7 +501,7 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
                 check_login(args, account, api, step_location)
 
                 # Make the actual request (finally!)
-                response_dict = map_request(api, step_location, args.jitter)
+                response_dict = map_request(api, step_location, args.spawnpoint_scanning)
 
                 # G'damnit, nothing back. Mark it up, sleep, carry on
                 if not response_dict:
@@ -617,9 +617,9 @@ def check_login(args, account, api, position):
     time.sleep(args.scan_delay)
 
 
-def map_request(api, position, jitter=False):
+def map_request(api, position, noJitter=False):
     # create scan_location to send to the api based off of position, because tuples aren't mutable
-    if jitter:
+    if not noJitter:
         # jitter it, just a little bit.
         scan_location = jitterLocation(position)
         log.debug('Jittered to: %f/%f/%f', scan_location[0], scan_location[1], scan_location[2])

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -56,8 +56,8 @@ def get_args():
                         help='Passwords, either single one for all accounts or one per account.')
     parser.add_argument('-l', '--location', type=parse_unicode,
                         help='Location, can be an address or coordinates')
-    parser.add_argument('-j', '--jitter', help='Apply random -9m to +9m jitter to location',
-                        action='store_true', default=False)
+    parser.add_argument('-j', '--jitter', help='[DEPRECATED] Apply random -9m to +9m jitter to location',
+                        action='store_true', default=True)
     parser.add_argument('-st', '--step-limit', help='Steps', type=int,
                         default=12)
     parser.add_argument('-sd', '--scan-delay',
@@ -164,6 +164,9 @@ def get_args():
     parser.set_defaults(DEBUG=False)
 
     args = parser.parse_args()
+
+    if args.jitter:
+        log.warn('--jitter is default and will be deprecated in a future release.')
 
     if args.only_server:
         if args.location is None:


### PR DESCRIPTION
Turn on `--jitter` by default, except with `-ss`

## Description

Jitter all search requests by default, except with spawnpoint scanning.

`--jitter` is kept as a variable, but prints a warning when used, it doesn't actually do anything.

## Motivation and Context

`--jitter` has been optional and working for a week now.

## How Has This Been Tested?

With and without spawnpoint scanning.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.

Changes to the documentation will take place when `--jitter` is removed from the arguments.