### PR TITLE
[Documentation] Add Note about Non-Latin Gym Names

### DIFF
--- a/docs/extras/gyminfo.md
+++ b/docs/extras/gyminfo.md
@@ -8,6 +8,13 @@ Gym info parsing adds the gym's name and a list of all the Pokemon currently in 
 ## MySQL Recommended
 Because of the increased data being sent to the database, it is recommended to use MySQL when using this feature.
 
+### Note on Non-Latin Characters in MySQL
+Using out of the box settings, MySQL uses a collation/encoding that does not support non-Latin characters. If gyms in your area are displaying with `????` instead of the correct characters, you need to update your database server's collation and encoding to use UTF8. To correct just the gym names, run:
+```sql
+ALTER TABLE `gymdetails` COLLATE='utf8_general_ci', CONVERT TO CHARSET utf8;
+```
+As gym details are refreshed, the correct characters will appear (to force this, you can empty `gymdetails`). More information regarding MySQL encoding is available [here](http://dev.mysql.com/doc/refman/5.7/en/charset-unicode.html).
+
 ## Enabling Gym Information Parsing
 
 To enable gym parsing, run with the `-gi` argument:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a note to the wiki regarding non-latin characters in the gym name.

## Motivation and Context
MySQL doesn't support non-latin characters by default, so a small tweak needs to be made to allow them to be stored. Ideally, this should be handled by code, but Peewee doesn't support it currently. I'll look into a way to handle it better in the future, but wanted to update the docs in the meantime.

Addresses #1002 

## How Has This Been Tested?
I proofread :smile: 

## Screenshots (if appropriate):

## Types of changes
[x] Documenation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

