### PR TITLE
Fix missing spawns when exporting

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -279,7 +279,7 @@ class Pokemon(BaseModel):
             # todo: this DOES NOT ACCOUNT for pokemons that appear sooner and live longer, but you'll _always_ have at least 15 minutes, so it works well enough
             location['time'] = (location['time'] + 2700) % 3600
 
-        #remove dublicates because when a spawn falls into more than 1 hex location it is listed multiple times
+        # remove dublicates because when a spawn falls into more than 1 hex location it is listed multiple times
         noDupes = []
         [noDupes.append(i) for i in filtered if not noDupes.count(i)]
         return noDupes

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -510,11 +510,11 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue):
                 # Correct misterious time_till_hidden value by removing extra bit in front of the Int32 that indicates this is a long spawn
                 # 2147483647 is the maximum value of an Int32 and can be read since this is read as a Int64
                 if time_till_hidden > 2147483647:
-                     time_till_hidden = time_till_hidden - 2147483647
+                    time_till_hidden = time_till_hidden - 2147483647
 
                 d_t = datetime.utcfromtimestamp(
                     (p['last_modified_timestamp_ms'] +
-                    time_till_hidden) / 1000.0)
+                     time_till_hidden) / 1000.0)
 
                 printPokemon(p['pokemon_data']['pokemon_id'], p['latitude'],
                              p['longitude'], d_t)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -263,14 +263,13 @@ class Pokemon(BaseModel):
         s = list(query.dicts())
 
         # Filter to spawns which actually fall in the hex locations
-        # This loop is about as non-pythonic as you can get, I bet.
-        # Oh well.
+        # Don't remove spawns from s when inside a hex location yet to avoid skipping spawns inside the for loop
         filtered = []
         hex_locations = list(generate_location_steps(center, steps, 0.07))
         for hl in hex_locations:
-            for idx, sp in enumerate(s):
+            for sp in s:
                 if geopy.distance.distance(hl, (sp['lat'], sp['lng'])).meters <= 70:
-                    filtered.append(s.pop(idx))
+                    filtered.append(sp)
 
         # at this point, 'time' is DISAPPEARANCE time, we're going to morph it to APPEARANCE time
         for location in filtered:
@@ -280,7 +279,10 @@ class Pokemon(BaseModel):
             # todo: this DOES NOT ACCOUNT for pokemons that appear sooner and live longer, but you'll _always_ have at least 15 minutes, so it works well enough
             location['time'] = (location['time'] + 2700) % 3600
 
-        return filtered
+        #remove dublicates because when a spawn falls into more than 1 hex location it is listed multiple times
+        noDupes = []
+        [noDupes.append(i) for i in filtered if not noDupes.count(i)]
+        return noDupes
 
 
 class Pokestop(BaseModel):

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -505,15 +505,16 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue):
     for cell in cells:
         if config['parse_pokemon']:
             for p in cell.get('wild_pokemons', []):
-                # time_till_hidden_ms was overflowing causing a negative integer.
-                # It was also returning a value above 3.6M ms.
-                if 0 < p['time_till_hidden_ms'] < 3600000:
-                    d_t = datetime.utcfromtimestamp(
-                        (p['last_modified_timestamp_ms'] +
-                         p['time_till_hidden_ms']) / 1000.0)
-                else:
-                    # Set a value of 15 minutes because currently its unknown but larger than 15.
-                    d_t = datetime.utcfromtimestamp((p['last_modified_timestamp_ms'] + 900000) / 1000.0)
+
+                time_till_hidden = p['time_till_hidden_ms']
+                # Correct misterious time_till_hidden value by removing extra bit in front of the Int32 that indicates this is a long spawn
+                # 2147483647 is the maximum value of an Int32 and can be read since this is read as a Int64
+                if time_till_hidden > 2147483647:
+                     time_till_hidden = time_till_hidden - 2147483647
+
+                d_t = datetime.utcfromtimestamp(
+                    (p['last_modified_timestamp_ms'] +
+                    time_till_hidden) / 1000.0)
 
                 printPokemon(p['pokemon_data']['pokemon_id'], p['latitude'],
                              p['longitude'], d_t)


### PR DESCRIPTION
Fix for reported issue #939
~~Fix for calculating the remaining time when time_tile_hidden was very large.~~ #855

## Description
Since the search refactor #901 exporting spawn points into a json file was exporting far less spawn points on the database than before this PR.
As example a previous build exported 186 spawns where the current build exports 134.
This fix finds 180 spawns again, not exactly the same as before, but this is probably more accurate.
The problem was caused by deleting entries from a list while still in a for loop that loops thru that same list.
This results in skipping items and ultimately missing spawns.

## Motivation and Context
If you didn't exported a spawn point file yet you don't want to miss a lot of spawn points.
Thats the whole idea of this project.

## How Has This Been Tested?
Exported spawns on the same database with the same location and amount of steps with different builds. And before and after this patch.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.