### PR TITLE
stats.js: Pokémons -> Pokémon

### DIFF
--- a/static/js/stats.js
+++ b/static/js/stats.js
@@ -1,5 +1,5 @@
 function countMarkers () { // eslint-disable-line no-unused-vars
-  document.getElementById('stats-pkmn-label').innerHTML = 'Pokémons'
+  document.getElementById('stats-pkmn-label').innerHTML = 'Pokémon'
   document.getElementById('stats-gym-label').innerHTML = 'Gyms'
   document.getElementById('stats-pkstop-label').innerHTML = 'PokéStops'
 


### PR DESCRIPTION
Long definition not needed (very minor fix)

Fixing "Pokémons" to "Pokémon" in the stats sidebar. ;)