### PR TITLE
Fix statistics page home link to work with sites running in subdirectories

### DIFF
--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -41,7 +41,7 @@
         <!-- Header -->
         <header id="header">
             <a href="#nav">Options</a>
-            <h1><a href="#">Pokémon Go Map</a></h1>
+            <h1><a href="./">Pokémon Go Map</a></h1>
         </header>
         <nav id="nav">
             {% for name, item in valid_input.items() %}

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -41,7 +41,7 @@
         <!-- Header -->
         <header id="header">
             <a href="#nav">Options</a>
-            <h1><a href="..">Pokémon Go Map</a></h1>
+            <h1><a href="#">Pokémon Go Map</a></h1>
         </header>
         <nav id="nav">
             {% for name, item in valid_input.items() %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR correct a minor issue where the "Pokemon Go Map" header link on the statistics page redirects to the site root, as opposed to the current sub-directory.
## Description
<!--- Describe your changes in detail -->
Statistics.html line 44, characters 45 and 46 where changed from '..' to './'
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required so that sites running in sub-directories will correctly redirect to map homepage. 
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/PokemonGoMap/PokemonGo-Map/issues/1015
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I clicked on the link and as expected was redirected to the site homepage.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
