### PR TITLE
The range for a pokestop and gym is 40 meters, but search and pokemon ranges are 70 meters.

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1246,6 +1246,7 @@ function addRangeCircle (marker, map, type, teamId) {
   var range
   var circleColor
 
+  // handle each type of marker and be explicit about the range circle attributes
   switch (type) {
     case 'search':
       circleColor = '#333333'
@@ -1253,7 +1254,7 @@ function addRangeCircle (marker, map, type, teamId) {
       break
     case 'pokemon':
       circleColor = '#C233F2'
-      range = 70
+      range = 40 // pokemon appear at 40m and then you can move away. still have to be 40m close to see it though, so ignore the further disappear distance
       break
     case 'pokestop':
       circleColor = '#3EB0FF'

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1240,20 +1240,36 @@ function addRangeCircle (marker, map, type, teamId) {
   var targetmap = null
   var circleCenter = new google.maps.LatLng(marker.position.lat(), marker.position.lng())
   var gymColors = ['#999999', '#0051CF', '#FF260E', '#FECC23'] // 'Uncontested', 'Mystic', 'Valor', 'Instinct']
-  var circleColor = '#cccccc'
   var teamColor = gymColors[0]
   if (teamId) teamColor = gymColors[teamId]
 
-  if (type === 'search') circleColor = '#333333'
-  if (type === 'pokemon') circleColor = '#C233F2'
-  if (type === 'pokestop') circleColor = '#3EB0FF'
-  if (type === 'gym') circleColor = teamColor
+  var range
+  var circleColor
+
+  switch (type) {
+    case 'search':
+      circleColor = '#333333'
+      range = 70
+      break
+    case 'pokemon':
+      circleColor = '#C233F2'
+      range = 70
+      break
+    case 'pokestop':
+      circleColor = '#3EB0FF'
+      range = 40
+      break
+    case 'gym':
+      circleColor = teamColor
+      range = 40
+      break
+  }
 
   if (map) targetmap = map
 
   var rangeCircleOpts = {
     map: targetmap,
-    radius: 40,    // 40 meters
+    radius: range, // meters
     strokeWeight: 1,
     strokeColor: circleColor,
     strokeOpacity: 0.9,

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -957,9 +957,6 @@ function createSearchMarker () {
     zIndex: google.maps.Marker.MAX_ZINDEX + 1
   })
 
-  if (!searchMarker.rangeCircle && isRangeActive(map)) {
-    searchMarker.rangeCircle = addRangeCircle(searchMarker, map, 'search')
-  }
   var oldLocation = null
   google.maps.event.addListener(searchMarker, 'dragstart', function () {
     oldLocation = searchMarker.getPosition()
@@ -970,9 +967,6 @@ function createSearchMarker () {
     changeSearchLocation(newLocation.lat(), newLocation.lng())
       .done(function () {
         oldLocation = null
-        if (searchMarker.rangeCircle && Store.get('showRanges')) {
-          searchMarker.rangeCircle.setCenter(newLocation)
-        }
       })
       .fail(function () {
         if (oldLocation) {
@@ -1248,10 +1242,6 @@ function addRangeCircle (marker, map, type, teamId) {
 
   // handle each type of marker and be explicit about the range circle attributes
   switch (type) {
-    case 'search':
-      circleColor = '#333333'
-      range = 70
-      break
     case 'pokemon':
       circleColor = '#C233F2'
       range = 40 // pokemon appear at 40m and then you can move away. still have to be 40m close to see it though, so ignore the further disappear distance
@@ -1946,7 +1936,6 @@ function changeLocation (lat, lng) {
   changeSearchLocation(lat, lng).done(function () {
     map.setCenter(loc)
     searchMarker.setPosition(loc)
-    if (searchMarker.rangeCircle) searchMarker.rangeCircle.setCenter(loc)
   })
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix the range circle radius numbers.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[#753](https://github.com/PokemonGoMap/PokemonGo-Map/pull/753) added range circles for the markers, but set them all to 40 meters. Pokemon and search markers should be 70 meters while pokestops are gyms are correct at 40 meters.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local

## Screenshots (if appropriate):
![image](https://cloud.githubusercontent.com/assets/14065681/18025763/403e4a8a-6bf9-11e6-8e23-44a686ea5cb1.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.