### PR TITLE
Decommission faulty accounts 2

### DIFF
--- a/docs/extras/multi-account.md
+++ b/docs/extras/multi-account.md
@@ -1,11 +1,15 @@
-# Using Multiple Accounts
+# Adding Accounts
 
-PokemonGo-Map supports using multiple accounts to run a worker with multiple threads.
-
+PokemonGo-Map stores your accounts for use in its database. 
+Before you start you will need to load the database with your accounts.
 
 ## Using Command Line Arguments:
 
-To use multiple accounts when running from the command line, you must specify multiple -u and -p values.
+To add an account use the -u -p and -a when you launch runserver.py
+
+Example: `python runserver.py -u thunderfox01 -p abracadabra` 
+
+To add multiple accounts when running from the command line, you must specify multiple -u and -p values.
 
 Example: `python runserver.py -u thunderfox01 -u thunderfox02 -p thunderfox01 -p thunderfox02`
 
@@ -46,3 +50,9 @@ auth-service: [ptc, ptc, google]
 username: [thunderfox01, thunderfox02, thunderfox03@gmail.com]
 password: [password01, password02, password03]
 ```
+## Using multiple accounts
+
+PokemonGo-Map supports using multiple accounts to run a worker with multiple threads.
+to specify the number of accounts use the -na flag
+
+Example: `python runserver.py -na 3`

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -584,6 +584,7 @@ class PoGoAccount(BaseModel):
                 use_account(account['username'], account['session'])
             if i == count - 1:
                 break
+
         return accounts
 
     @staticmethod
@@ -643,7 +644,7 @@ def update_use_account(username):
 def remove_accounts():
     if args.remove_user is not None:
         for user in args.remove_user:
-            log.info('Removing {} from the db'.format(username))
+            log.info('Removing {} from the db'.format(user))
             PoGoAccount.delete().where(PoGoAccount.username == user).execute()
 
 
@@ -1029,7 +1030,6 @@ def clean_db_loop(args):
                      .where((PoGoAccount.time_deactivated < (datetime.utcnow() - timedelta(minutes=120))) &
                             (PoGoAccount.active == 0)))
             query.execute()
-
             
             # Reset usage on idle accounts
             query = (PoGoAccount

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -583,8 +583,7 @@ def insert_accounts():
         log.info("Checking " + account['username'])
         try:
             query = PoGoAccount.create(username=account['username'], password=account['password'], auth_service=account['auth_service'])
-            query.execute()
-            log.info("added" + account['username'])
+            log.info("Added " + account['username'])
         except:
             log.info(account['username'] + " already exists reseting password and status")
             query = PoGoAccount.update(password=account['password'], auth_service=account['auth_service'], active=True).where(PoGoAccount.username == account['username'])

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -569,6 +569,15 @@ class PoGoAccount(BaseModel):
                 break
 
         return accounts
+    @staticmethod
+    def valid_session(username,session):
+        query = (PoGoAccount
+                .select()
+                .where(PoGoAccount.username == username)
+                .dicts())
+        for account in query:
+            return account['session'] == session
+        
 
 def insert_accounts():
     for account in args.accounts:

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -586,13 +586,13 @@ class PoGoAccount(BaseModel):
             if i == count - 1:
                 break
         return accounts
-		
+
     @staticmethod
-    def valid_session(username,session):
+    def valid_session(username, session):
         query = (PoGoAccount
-                .select()
-                .where(PoGoAccount.username == username)
-                .dicts())
+                 .select()
+                 .where(PoGoAccount.username == username)
+                 .dicts())
         for account in query:
             return account['session'] == session
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -548,8 +548,8 @@ class PoGoAccount(BaseModel):
     def get_active_unused(count, use):
         query = (PoGoAccount
                  .select()
-                 .where((PoGoAccount.active == True) &
-                        (PoGoAccount.in_use == False))
+                 .where((PoGoAccount.active == 1) &
+                        (PoGoAccount.in_use == 0))
                  .dicts())
 
         accounts = []

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 import logging
 import calendar
@@ -588,7 +589,6 @@ class PoGoAccount(BaseModel):
                 use_account(account['username'], account['session'])
             if i == count - 1:
                 break
-
         return accounts
 
     @staticmethod
@@ -600,10 +600,7 @@ class PoGoAccount(BaseModel):
         for account in query:
             if not account['in_use']:  # If the account is not set to in_use recreate the session
                 log.info('usage was reset refreshing session')
-                query = (PoGoAccount
-                         .update(in_use=True, session=current_session)
-                         .where(PoGoAccount.username == username)
-                         .execute())
+                PoGoAccount.update(in_use=True, session=current_session).where(PoGoAccount.username == username).execute()
             return account['session'] == current_session
 
 
@@ -611,50 +608,41 @@ def insert_accounts():
     for account in args.accounts:
         log.info("Checking " + account['username'])
         try:
-            query = PoGoAccount.create(username=account['username'], password=account['password'], auth_service=account['auth_service'])
+            PoGoAccount.create(username=account['username'], password=account['password'], auth_service=account['auth_service'])
             log.info("Added " + account['username'])
         except:
             done = False
             while not done:
                 try:
                     log.info(account['username'] + " already exists reseting password and status")
-                    query = PoGoAccount.update(password=account['password'], auth_service=account['auth_service'], active=True).where(PoGoAccount.username == account['username'])
-                    query.execute()
+                    PoGoAccount.update(password=account['password'], auth_service=account['auth_service'], active=True).where(PoGoAccount.username == account['username']).execute()
                     done = True
                 except:
                     log.info("Issue updating accounts, trying again")
-    
+
 
 def deactivate_account(faulty_account):
     log.info("Deactivating " + faulty_account)
-    query = PoGoAccount.update(active=False, in_use=False, time_deactivated=datetime.utcnow()).where(PoGoAccount.username == faulty_account)
-    query.execute()
+    PoGoAccount.update(active = False, in_use=False, time_deactivated=datetime.utcnow()).where(PoGoAccount.username == faulty_account).execute()
 
 
-def update_use_account(account):
-    query = (PoGoAccount
-             .update(in_use=True, last_scan_time=datetime.utcnow())
-             .where(PoGoAccount.username == account)
-             .execute()
-             )
+def update_use_account(username):
+    PoGoAccount.update(in_use = True, last_scan_time=datetime.utcnow()).where(PoGoAccount.username == username).execute()
 
-
+	
 def remove_accounts():
     if args.remove_user is not None:
-        for account in args.remove_user:
-            log.info("Removing " + account + " from the db.")
-            query = (PoGoAccount.delete().where(PoGoAccount.username == account))
-            query.execute()
+        for user in args.remove_user:
+            log.info("Removing " + user + " from the db.")
+            PoGoAccount.delete().where(PoGoAccount.username == user).execute()
 
 
-def use_account(account, newSession):
-    query = PoGoAccount.update(in_use=True, session=newSession).where(PoGoAccount.username == account)
-    query.execute()
+def use_account(username, new_session):
+    PoGoAccount.update(in_use=True, session=new_session).where(PoGoAccount.username == username).execute()
 
 
 def reset_account_use():
-    query = PoGoAccount.update(in_use=False)
-    query.execute()
+    PoGoAccount.update(in_use=False).execute()
 
 
 def hex_bounds(center, steps):

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta
 from base64 import b64encode
 
 from . import config
-from .utils import get_pokemon_name, get_pokemon_rarity, get_pokemon_types, get_args, generate_session
+from .utils import get_pokemon_name, get_pokemon_rarity, get_pokemon_types, get_args, generate_session, calculate_speed_sleep
 from .transform import transform_from_wgs_to_gcj, get_new_coords
 from .customLog import printPokemon
 
@@ -537,6 +537,7 @@ class GymDetails(BaseModel):
 
 
 class PoGoAccount(BaseModel):
+    location = [x.strip() for x in args.location.split(',')]
     username = CharField(primary_key=True)
     password = CharField()
     auth_service = CharField()
@@ -544,6 +545,54 @@ class PoGoAccount(BaseModel):
     in_use = BooleanField(default=False)
     session = CharField(index=True, default=generate_session())
     time_deactivated = DateTimeField(default=datetime.utcnow())
+    last_scan_time = DateTimeField(default=datetime.utcnow())
+    last_latitude = CharField(default=location[0])
+    last_longitude = CharField(default=location[1])
+
+    @staticmethod
+    def get_speed_sleep(location, username, args):
+        query = (PoGoAccount
+                 .select()
+                 .where(PoGoAccount.username == username)
+                 .dicts()
+                 )
+
+        for i, current_account in enumerate(query):
+            distance, speed, sleep = calculate_speed_sleep(location,(current_account['last_latitude'],current_account['last_longitude']),current_account['last_scan_time'], args)
+        unit = "m"
+        if distance >= 1000:
+            unit = "km"
+            distance = distance / 1000            
+        speed = speed * 3600.0 / 1000.0 # convert speed to km/h       
+        message = 'Traveled {:.1f}{} at {:.1f}km/h'.format(distance, unit, speed)
+        new_account = {}
+        if sleep > 0:
+            message = "{:.1f}km/h is too fast, we are waiting {} seconds to stay under {}km/h".format(speed,sleep,args.speed_limit)
+            new_accounts = PoGoAccount.get_active_unused(float("inf"), False)
+            old_sleep = sleep
+            for test_account in new_accounts:
+                new_distance, new_speed, new_sleep = calculate_speed_sleep(location,(test_account['last_latitude'], test_account['last_longitude']), test_account['last_scan_time'], args)
+                if sleep > new_sleep:
+                    new_account = test_account
+                    distance = new_distance
+                    sleep = new_sleep
+                if sleep == new_sleep:
+                    if distance > new_distance:
+                        new_account = test_account
+                        distance = new_distance
+                    
+        if new_account:
+            reset_account_use(current_account['username'])
+            log.info("{} will take {} seconds to arive at the next scan.".format(username,old_sleep))
+            if sleep == 0:
+                log.info("We found an in range unused account that can scan now.")
+            else:
+                log.info = "We found {} is closer, it will take {} seconds to arive.".format(new_account['username'],sleep)
+            new_account.update({'session': generate_session()})
+            use_account(new_account['username'], new_account['session'])
+            return sleep, new_account
+        log.info(message)
+        return sleep, current_account
 
     @staticmethod
     def get_num_accounts():
@@ -574,11 +623,9 @@ class PoGoAccount(BaseModel):
             accounts.append(account)
             if use:
                 accounts[i].update({'session': generate_session()})
-                log.info("seting " + account['username'] + " to in use.")
                 use_account(account['username'], account['session'])
             if i == count - 1:
                 break
-
         return accounts
 
     @staticmethod
@@ -604,9 +651,16 @@ def insert_accounts():
             query = PoGoAccount.create(username=account['username'], password=account['password'], auth_service=account['auth_service'])
             log.info("Added " + account['username'])
         except:
-            log.info(account['username'] + " already exists reseting password and status")
-            query = PoGoAccount.update(password=account['password'], auth_service=account['auth_service'], active=True).where(PoGoAccount.username == account['username'])
-            query.execute()
+            done = False
+            while not done:
+                try:
+                    log.info(account['username'] + " already exists reseting password and status")
+                    query = PoGoAccount.update(password=account['password'], auth_service=account['auth_service'], active=True).where(PoGoAccount.username == account['username'])
+                    query.execute()
+                    done = True
+                except:
+                    log.info("Issue updating accounts, trying again")
+
 
 
 def deactivate_account(faulty_account):
@@ -617,20 +671,45 @@ def deactivate_account(faulty_account):
 
 def remove_accounts():
     if args.remove_user is not None:
-        for account in args.remove_user:
-            log.info("Removing " + account + " from the db.")
-            query = (PoGoAccount.delete().where(PoGoAccount.username == account))
-            query.execute()
+        for username in args.remove_user:
+            log.info('Removing {} from the db'.format(username))
+            query = (PoGoAccount
+                     .delete()
+                     .where(PoGoAccount.username == account)
+                     .execute()
+                     )
 
 
-def use_account(account, newSession):
-    query = PoGoAccount.update(in_use=True, session=newSession).where(PoGoAccount.username == account)
-    query.execute()
+def use_account(username, new_session):
+    log.info('setting {} to in use'.format(username))
+    query = (PoGoAccount
+             .update(in_use=True, session=new_session)
+             .where(PoGoAccount.username == username)
+             .execute()
+             )
 
 
-def reset_account_use():
-    query = PoGoAccount.update(in_use=False)
-    query.execute()
+def update_use_account(account, latitude, longitude):
+    query = (PoGoAccount
+             .update(in_use=True, last_scan_time=datetime.utcnow(),last_latitude=latitude, last_longitude=longitude)
+             .where(PoGoAccount.username == account)
+             .execute()
+             )
+
+
+def reset_account_use(username):
+    if username == '*':
+        query = (PoGoAccount
+                 .update(in_use=False, session=generate_session())
+                 .execute()
+                 )
+    else:
+        log.info('setting {} back to available'.format(username))
+        query = (PoGoAccount
+                 .update(in_use=False, session=generate_session())
+                 .where(PoGoAccount.username == username)
+                 .execute()
+                 )
 
 
 def hex_bounds(center, steps):
@@ -976,6 +1055,14 @@ def clean_db_loop(args):
                             (PoGoAccount.active == 0)))
             query.execute()
 
+            
+            # Reset usage on idle accounts
+            query = (PoGoAccount
+                     .update(in_use=False)
+                     .where((PoGoAccount.last_scan_time < (datetime.utcnow() - timedelta(minutes=3))) &
+                            (PoGoAccount.active == 1)))
+            query.execute()
+
             # If desired, clear old pokemon spawns
             if args.purge_data > 0:
                 query = (Pokemon
@@ -984,9 +1071,9 @@ def clean_db_loop(args):
                                 (datetime.utcnow() - timedelta(hours=args.purge_data)))))
 
             log.info('Regular database cleaning complete')
-            time.sleep(60)
         except Exception as e:
-            log.exception('Exception in clean_db_loop: %s', e)
+            log.exception('Exception in clean_db_loop: {}'.format(e))
+        time.sleep(60)
 
 
 def bulk_upsert(cls, data):

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1003,9 +1003,8 @@ def clean_db_loop(args):
             # Reactivate account after two hour sleep
             query = (PoGoAccount
                      .update(active=True)
-                     .where((PoGoAccount.time_deactivated <
-                            (datetime.utcnow() - timedelta(minutes=120))) &
-                            PoGoAccount.active == False))
+                     .where((PoGoAccount.time_deactivated < (datetime.utcnow() - timedelta(minutes=120))) &
+                            (PoGoAccount.active == False)))
             query.execute()
 
             # If desired, clear old pokemon spawns

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1038,6 +1038,13 @@ def clean_db_loop(args):
                             (PoGoAccount.active == 1)))
             query.execute()
 
+            # Reset usage on idle accounts
+            query = (PoGoAccount
+                     .update(in_use=False)
+                     .where((PoGoAccount.last_scan_time < (datetime.utcnow() - timedelta(minutes=3))) &
+                            (PoGoAccount.active == 1)))
+            query.execute()
+
             # If desired, clear old pokemon spawns
             if args.purge_data > 0:
                 query = (Pokemon

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -586,6 +586,15 @@ class PoGoAccount(BaseModel):
             if i == count - 1:
                 break
         return accounts
+		
+    @staticmethod
+    def valid_session(username,session):
+        query = (PoGoAccount
+                .select()
+                .where(PoGoAccount.username == username)
+                .dicts())
+        for account in query:
+            return account['session'] == session
 
     @staticmethod
     def valid_session(username, current_session):

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -567,7 +567,7 @@ class PoGoAccount(BaseModel):
 def insert_accounts():
     print(len(args.username))
     print(args.username)
-    for count in range(0, len(args.username)-1):
+    for count in range(len(args.username)):
         newuser = args.username[count]
         if len(args.password)>1:
             newpass = args.password[count]

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -565,14 +565,25 @@ class PoGoAccount(BaseModel):
         return accounts
 
 def insert_accounts():
-    for account in args.accounts:
-        log.info("Provessing "+account['username'])
+    print(len(args.username))
+    print(args.username)
+    for count in range(0, len(args.username)-1):
+        newuser = args.username[count]
+        if len(args.password)>1:
+            newpass = args.password[count]
+        else:
+            newpass = args.password[0]
+        if len(args.auth_service)>1:
+            newauth = args.auth_service[count]
+        else:
+            newauth = args.auth_service[0]
+        log.info("Checking "+args.username[count])
         try:
-            query = PoGoAccount.create(username=account['username'],password=account['password'],auth_service=account['auth_service'])
+            query = PoGoAccount.create(username=newuser,password=newpass,auth_service=newauth)
             query.execute()
         except:
-            log.info(account['username']+" already exists reseting password and status")
-            query = PoGoAccount.update(password=account['password'],auth_service=account['auth_service'],active=True).where(PoGoAccount.username==account['username'])
+            log.info(args.username[count]+" already exists reseting password and status")
+            query = PoGoAccount.update(password=newpass,auth_service=newauth,active=True).where(PoGoAccount.username==newuser)
             query.execute()
         else:
             log.info("added" +account['username'])

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -957,6 +957,12 @@ def clean_db_loop(args):
                      .where(Pokestop.lure_expiration < datetime.utcnow()))
             query.execute()
 
+            # Remove active modifier from expired lured pokestops
+            query = (Pokestop
+                     .update(lure_expiration=None)
+                     .where(Pokestop.lure_expiration < datetime.utcnow()))
+            query.execute()
+
             # Reactivate account after two hour sleep
             query = (PoGoAccount
                      .update(active=True)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -545,7 +545,7 @@ class PoGoAccount(BaseModel):
     session = CharField(index=True, default=generate_session())
     time_deactivated = DateTimeField(default=datetime.utcnow())
     last_scan_time = DateTimeField(default=datetime.utcnow())
-    proxy = BooleanField(default=False)
+    proxy = CharField(default='')
 
     @staticmethod
     def update_proxy(username, new_proxy):

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1000,6 +1000,13 @@ def clean_db_loop(args):
                             (PoGoAccount.active == 1)))
             query.execute()
 
+            # Reactivate account after two hour sleep
+            query = (PoGoAccount
+                     .update(active=True, in_use=False)
+                     .where((PoGoAccount.last_modified <
+                            (datetime.utcnow() - timedelta(minutes=120)))))
+            query.execute()
+
             # If desired, clear old pokemon spawns
             if args.purge_data > 0:
                 query = (Pokemon

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -582,18 +582,19 @@ class PoGoAccount(BaseModel):
         return accounts
 
     @staticmethod
-    def valid_session(username, session):
+    def valid_session(username, current_session):
         query = (PoGoAccount
                  .select()
                  .where(PoGoAccount.username == username)
                  .dicts())
         for account in query:
             if not account['in_use']:  # If the account is not set to in_use recreate the session
+                log.info('usage was reset refreshing session')
                 query = (PoGoAccount
-                         .update(in_use=True, session=newSession)
-                         .where(PoGoAccount.username == account)
+                         .update(in_use=True, session=current_session)
+                         .where(PoGoAccount.username == username)
                          .execute())
-            return account['session'] == session
+            return account['session'] == current_session
 
 
 def insert_accounts():

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -446,7 +446,6 @@ class ScannedLocation(BaseModel):
                         (ScannedLocation.longitude >= swLng) &
                         (ScannedLocation.latitude <= neLat) &
                         (ScannedLocation.longitude <= neLng))
-                 .order_by(ScannedLocation.last_modified.asc())
                  .dicts())
 
         return list(query)
@@ -543,65 +542,65 @@ class PoGoAccount(BaseModel):
     auth_service = CharField()
     active = BooleanField(default=True)
     in_use = BooleanField(default=False)
-    session = CharField(index=True,default=generate_session())
+    session = CharField(index=True, default=generate_session())
 
     @staticmethod
     def get_active_unused(count, use):
         query = (PoGoAccount
-                .select()
-                .where((PoGoAccount.active == True) &
-                      (PoGoAccount.in_use == False))
-                .dicts())
-                 
+                 .select()
+                 .where((PoGoAccount.active == True) &
+                        (PoGoAccount.in_use == False))
+                 .dicts())
 
         accounts = []
         while len(query) == 0:
             log.info("no available accounts, please add more")
             time.sleep(180)
-            
+
         for i, account in enumerate(query):
             accounts.append(account)
             if use:
                 accounts[i].update({'session': generate_session()})
                 log.info("seting " + account['username'] + " to in use.")
-                use_account(account['username'],account['session'])    
-            if i == count-1:
+                use_account(account['username'], account['session'])
+            if i == count - 1:
                 break
 
         return accounts
+
     @staticmethod
-    def valid_session(username,session):
+    def valid_session(username, session):
         query = (PoGoAccount
-                .select()
-                .where(PoGoAccount.username == username)
-                .dicts())
+                 .select()
+                 .where(PoGoAccount.username == username)
+                 .dicts())
         for account in query:
             return account['session'] == session
-        
+
 
 def insert_accounts():
     for account in args.accounts:
-        log.info("Checking "+account['username'])
+        log.info("Checking " + account['username'])
         try:
-            query = PoGoAccount.create(username=account['username'],password=account['password'],auth_service=account['auth_service'])
+            query = PoGoAccount.create(username=account['username'], password=account['password'], auth_service=account['auth_service'])
             query.execute()
             log.info("added" + account['username'])
         except:
             log.info(account['username'] + " already exists reseting password and status")
-            query = PoGoAccount.update(password=account['password'],auth_service=account['auth_service'],active=True).where(PoGoAccount.username==account['username'])
+            query = PoGoAccount.update(password=account['password'], auth_service=account['auth_service'], active=True).where(PoGoAccount.username == account['username'])
             query.execute()
-            
-        
+
+
 def deactivate_account(faulty_account):
     log.info("Deactivating " + faulty_account)
-    query = PoGoAccount.update(active = False,in_use=False).where(PoGoAccount.username == faulty_account)
+    query = PoGoAccount.update(active=False, in_use=False).where(PoGoAccount.username == faulty_account)
     query.execute()
-               
+
 
 def remove_accounts():
-    if args.remove_user != None:
+    if args.remove_user is not None:
         for account in args.remove_user:
-            log.info("Removing "+account+" from the db.")
+            log.info("Removing " + account + " from the db.")
             query = (PoGoAccount.delete().where(PoGoAccount.username == account))
             query.execute()
 
@@ -609,6 +608,7 @@ def remove_accounts():
 def use_account(account, newSession):
     query = PoGoAccount.update(in_use=True, session=newSession).where(PoGoAccount.username == account)
     query.execute()
+
 
 def reset_account_use():
     query = PoGoAccount.update(in_use=False)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -594,11 +594,6 @@ class PoGoAccount(BaseModel):
                  .where(PoGoAccount.username == username)
                  .dicts())
         for account in query:
-            if not account['in_use']  # If the account is not set to in_use recreate the session
-                query = (PoGoAccount
-                         .update(in_use=True, session=newSession)
-                         .where(PoGoAccount.username == account)
-                         .execute())
             return account['session'] == session
 
     @staticmethod

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -588,6 +588,11 @@ class PoGoAccount(BaseModel):
                  .where(PoGoAccount.username == username)
                  .dicts())
         for account in query:
+            if not account['in_use']  # If the account is not set to in_use recreate the session
+                query = (PoGoAccount
+                         .update(in_use=True, session=newSession)
+                         .where(PoGoAccount.username == account)
+                         .execute())
             return account['session'] == session
 
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -543,7 +543,7 @@ class PoGoAccount(BaseModel):
     active = BooleanField(default=True)
     in_use = BooleanField(default=False)
     session = CharField(index=True, default=generate_session())
-    time_deactivated = DateTimeField(default=datetime.utcnow)
+    time_deactivated = DateTimeField(default=datetime.utcnow())
 
     @staticmethod
     def get_active_unused(count, use):
@@ -950,9 +950,8 @@ def clean_db_loop(args):
             # Reactivate account after two hour sleep
             query = (PoGoAccount
                      .update(active=True)
-                     .where((PoGoAccount.time_deactivated <
-                            (datetime.utcnow() - timedelta(minutes=120))) &
-                            PoGoAccount.active == False))
+                     .where((PoGoAccount.time_deactivated < (datetime.utcnow() - timedelta(minutes=120))) &
+                            (PoGoAccount.active == False)))
             query.execute()
 
             # If desired, clear old pokemon spawns

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -554,6 +554,10 @@ class PoGoAccount(BaseModel):
                  
 
         accounts = []
+        while len(query) == 0:
+            log.info("no available accounts, please add more")
+            time.sleep(180)
+            
         for i, account in enumerate(query):
             accounts.append(account)
             if use:
@@ -565,28 +569,17 @@ class PoGoAccount(BaseModel):
         return accounts
 
 def insert_accounts():
-    print(len(args.username))
-    print(args.username)
-    for count in range(len(args.username)):
-        newuser = args.username[count]
-        if len(args.password)>1:
-            newpass = args.password[count]
-        else:
-            newpass = args.password[0]
-        if len(args.auth_service)>1:
-            newauth = args.auth_service[count]
-        else:
-            newauth = args.auth_service[0]
-        log.info("Checking "+args.username[count])
+    for account in args.accounts:
+        log.info("Checking "+account['username'])
         try:
-            query = PoGoAccount.create(username=newuser,password=newpass,auth_service=newauth)
+            query = PoGoAccount.create(username=account['username'],password=account['password'],auth_service=account['auth_service'])
             query.execute()
+            log.info("added" + account['username'])
         except:
-            log.info(args.username[count]+" already exists reseting password and status")
-            query = PoGoAccount.update(password=newpass,auth_service=newauth,active=True).where(PoGoAccount.username==newuser)
+            log.info(account['username'] + " already exists reseting password and status")
+            query = PoGoAccount.update(password=account['password'],auth_service=account['auth_service'],active=True).where(PoGoAccount.username==account['username'])
             query.execute()
-        else:
-            log.info("added" +account['username'])
+            
         
 def deactivate_account(faulty_account):
     log.info("Deactivating " + faulty_account)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -543,7 +543,7 @@ class PoGoAccount(BaseModel):
     active = BooleanField(default=True)
     in_use = BooleanField(default=False)
     session = CharField(index=True, default=generate_session())
-    last_modified = DateTimeField(default=datetime.utcnow)
+    time_deactivated = DateTimeField(default=datetime.utcnow)
 
     @staticmethod
     def get_active_unused(count, use):
@@ -595,7 +595,7 @@ def insert_accounts():
 
 def deactivate_account(faulty_account):
     log.info("Deactivating " + faulty_account)
-    query = PoGoAccount.update(active=False, in_use=False, last_modified=datetime.utcnow()).where(PoGoAccount.username == faulty_account)
+    query = PoGoAccount.update(active=False, in_use=False, time_deactivated=datetime.utcnow()).where(PoGoAccount.username == faulty_account)
     query.execute()
 
 
@@ -950,7 +950,7 @@ def clean_db_loop(args):
             # Reactivate account after two hour sleep
             query = (PoGoAccount
                      .update(active=True)
-                     .where((PoGoAccount.last_modified <
+                     .where((PoGoAccount.time_deactivated <
                             (datetime.utcnow() - timedelta(minutes=120))) &
                             PoGoAccount.active == False))
             query.execute()

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -544,6 +544,7 @@ class PoGoAccount(BaseModel):
     in_use = BooleanField(default=False)
     session = CharField(index=True, default=generate_session())
     time_deactivated = DateTimeField(default=datetime.utcnow())
+
     @staticmethod
     def get_num_accounts():
         query = (PoGoAccount
@@ -960,7 +961,7 @@ def clean_db_loop(args):
             query = (PoGoAccount
                      .update(active=True)
                      .where((PoGoAccount.time_deactivated < (datetime.utcnow() - timedelta(minutes=120))) &
-                            (PoGoAccount.active == False)))
+                            (PoGoAccount.active == 0)))
             query.execute()
 
             # If desired, clear old pokemon spawns

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1000,6 +1000,12 @@ def clean_db_loop(args):
                             (PoGoAccount.active == 1)))
             query.execute()
 
+            # Remove active modifier from expired lured pokestops
+            query = (Pokestop
+                     .update(lure_expiration=None)
+                     .where(Pokestop.lure_expiration < datetime.utcnow()))
+            query.execute()
+
             # Reactivate account after two hour sleep
             query = (PoGoAccount
                      .update(active=True)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -588,11 +588,6 @@ class PoGoAccount(BaseModel):
                  .where(PoGoAccount.username == username)
                  .dicts())
         for account in query:
-            if not account['in_use']  # If the account is not set to in_use recreate the session
-                query = (PoGoAccount
-                         .update(in_use=True, session=newSession)
-                         .where(PoGoAccount.username == account)
-                         .execute())
             return account['session'] == session
 
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -547,12 +547,9 @@ class PoGoAccount(BaseModel):
     @staticmethod
     def get_num_accounts():
         query = (PoGoAccount
-                 .select(fn.COUNT(PoGoAccount.username))
-                 .get())
-        print query
-
+                 .select()
+                 .count())
         return query
-        
 
     @staticmethod
     def get_active_unused(count, use):
@@ -566,7 +563,7 @@ class PoGoAccount(BaseModel):
                      .dicts())
 
             if len(query) == 0:
-                if get_num_accounts() == 0:
+                if PoGoAccount.get_num_accounts() == 0:
                     log.info("there are no accounts, please add accounts using -u/--username and -p/--password or in config")
                 else:
                     log.info("no available accounts, please add more")

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -976,6 +976,13 @@ def clean_db_loop(args):
                             (PoGoAccount.active == 0)))
             query.execute()
 
+            # Reset usage on idle accounts
+            query = (PoGoAccount
+                     .update(in_use=False)
+                     .where((PoGoAccount.last_scan_time < (datetime.utcnow() - timedelta(minutes=3))) &
+                            (PoGoAccount.active == 1)))
+            query.execute()
+
             # If desired, clear old pokemon spawns
             if args.purge_data > 0:
                 query = (Pokemon

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1003,7 +1003,7 @@ def clean_db_loop(args):
             # Reactivate account after two hour sleep
             query = (PoGoAccount
                      .update(active=True)
-                     .where((PoGoAccount.last_modified <
+                     .where((PoGoAccount.time_deactivated <
                             (datetime.utcnow() - timedelta(minutes=120))) &
                             PoGoAccount.active == False))
             query.execute()

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta
 from base64 import b64encode
 
 from . import config
-from .utils import get_pokemon_name, get_pokemon_rarity, get_pokemon_types, get_args
+from .utils import get_pokemon_name, get_pokemon_rarity, get_pokemon_types, get_args, generate_session
 from .transform import transform_from_wgs_to_gcj, get_new_coords
 from .customLog import printPokemon
 
@@ -543,6 +543,7 @@ class PoGoAccount(BaseModel):
     auth_service = CharField()
     active = BooleanField(default=True)
     in_use = BooleanField(default=False)
+    session = CharField(index=True,default=generate_session())
 
     @staticmethod
     def get_active_unused(count, use):
@@ -561,8 +562,9 @@ class PoGoAccount(BaseModel):
         for i, account in enumerate(query):
             accounts.append(account)
             if use:
+                accounts[i].update({'session': generate_session()})
                 log.info("seting " + account['username'] + " to in use.")
-                use_account(account['username'])    
+                use_account(account['username'],account['session'])    
             if i == count-1:
                 break
 
@@ -595,8 +597,8 @@ def remove_accounts():
             query.execute()
 
 
-def use_account(account):
-    query = PoGoAccount.update(in_use=True).where(PoGoAccount.username == account)
+def use_account(account, newSession):
+    query = PoGoAccount.update(in_use=True, session=newSession).where(PoGoAccount.username == account)
     query.execute()
 
 def reset_account_use():

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -617,7 +617,6 @@ def insert_accounts():
                     log.info("Issue updating accounts, trying again")
 
 
-
 def deactivate_account(faulty_account):
     log.info("Deactivating " + faulty_account)
     PoGoAccount.update(active = False, in_use=False, time_deactivated=datetime.utcnow()).where(PoGoAccount.username == faulty_account).execute()

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -538,18 +538,18 @@ class GymDetails(BaseModel):
 
 
 class PoGoAccount(BaseModel):
-    Username = CharField(primary_key=True)
-    Password = CharField()
-    Auth_service = CharField()
-    Active = BooleanField(default=True)
-    In_use = BooleanField(default=False)
+    username = CharField(primary_key=True)
+    password = CharField()
+    auth_service = CharField()
+    active = BooleanField(default=True)
+    in_use = BooleanField(default=False)
 
     @staticmethod
     def get_active_unused(count, use):
         query = (PoGoAccount
                 .select()
-                .where((PoGoAccount.Active == True) &
-                      (PoGoAccount.In_use == False))
+                .where((PoGoAccount.active == True) &
+                      (PoGoAccount.in_use == False))
                 .dicts())
                  
 
@@ -557,8 +557,8 @@ class PoGoAccount(BaseModel):
         for i, account in enumerate(query):
             accounts.append(account)
             if use:
-                log.info("seting " + account['Username'] + " to in use.")
-                use_account(account['Username'])    
+                log.info("seting " + account['username'] + " to in use.")
+                use_account(account['username'])    
             if i == count-1:
                 break
 
@@ -568,18 +568,18 @@ def insert_accounts():
     for account in args.accounts:
         log.info("Provessing "+account['username'])
         try:
-            query = PoGoAccount.create(Username=account['username'],Password=account['password'],Auth_service=account['auth_service'])
+            query = PoGoAccount.create(username=account['username'],password=account['password'],auth_service=account['auth_service'])
             query.execute()
         except:
             log.info(account['username']+" already exists reseting password and status")
-            query = PoGoAccount.update(Password=account['password'],Auth_service=account['auth_service'],Active=True).where(PoGoAccount.Username==account['username'])
+            query = PoGoAccount.update(password=account['password'],auth_service=account['auth_service'],active=True).where(PoGoAccount.username==account['username'])
             query.execute()
         else:
             log.info("added" +account['username'])
         
 def deactivate_account(faulty_account):
     log.info("Deactivating " + faulty_account)
-    query = PoGoAccount.update(Active = False,In_use=False).where(PoGoAccount.Username == faulty_account)
+    query = PoGoAccount.update(active = False,in_use=False).where(PoGoAccount.username == faulty_account)
     query.execute()
                
 
@@ -587,16 +587,16 @@ def remove_accounts():
     if args.remove_user != None:
         for account in args.remove_user:
             log.info("Removing "+account+" from the db.")
-            query = (PoGoAccount.delete().where(PoGoAccount.Username == account))
+            query = (PoGoAccount.delete().where(PoGoAccount.username == account))
             query.execute()
 
 
 def use_account(account):
-    query = PoGoAccount.update(In_use=True).where(PoGoAccount.Username == account)
+    query = PoGoAccount.update(in_use=True).where(PoGoAccount.username == account)
     query.execute()
 
 def reset_account_use():
-    query = PoGoAccount.update(In_use=False)
+    query = PoGoAccount.update(in_use=False)
     query.execute()
 
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -949,9 +949,10 @@ def clean_db_loop(args):
 
             # Reactivate account after two hour sleep
             query = (PoGoAccount
-                     .update(active=True, in_use=False)
+                     .update(active=True)
                      .where((PoGoAccount.last_modified <
-                            (datetime.utcnow() - timedelta(minutes=120)))))
+                            (datetime.utcnow() - timedelta(minutes=120))) &
+                            PoGoAccount.active == False))
             query.execute()
 
             # If desired, clear old pokemon spawns

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta
 from base64 import b64encode
 
 from . import config
-from .utils import get_pokemon_name, get_pokemon_rarity, get_pokemon_types, get_args, generate_session, calculate_speed_sleep
+from .utils import get_pokemon_name, get_pokemon_rarity, get_pokemon_types, get_args, generate_session
 from .transform import transform_from_wgs_to_gcj, get_new_coords
 from .customLog import printPokemon
 
@@ -537,7 +537,6 @@ class GymDetails(BaseModel):
 
 
 class PoGoAccount(BaseModel):
-    location = [x.strip() for x in args.location.split(',')]
     username = CharField(primary_key=True)
     password = CharField()
     auth_service = CharField()
@@ -545,54 +544,6 @@ class PoGoAccount(BaseModel):
     in_use = BooleanField(default=False)
     session = CharField(index=True, default=generate_session())
     time_deactivated = DateTimeField(default=datetime.utcnow())
-    last_scan_time = DateTimeField(default=datetime.utcnow())
-    last_latitude = CharField(default=location[0])
-    last_longitude = CharField(default=location[1])
-
-    @staticmethod
-    def get_speed_sleep(location, username, args):
-        query = (PoGoAccount
-                 .select()
-                 .where(PoGoAccount.username == username)
-                 .dicts()
-                 )
-
-        for i, current_account in enumerate(query):
-            distance, speed, sleep = calculate_speed_sleep(location,(current_account['last_latitude'],current_account['last_longitude']),current_account['last_scan_time'], args)
-        unit = "m"
-        if distance >= 1000:
-            unit = "km"
-            distance = distance / 1000            
-        speed = speed * 3600.0 / 1000.0 # convert speed to km/h       
-        message = 'Traveled {:.1f}{} at {:.1f}km/h'.format(distance, unit, speed)
-        new_account = {}
-        if sleep > 0:
-            message = "{:.1f}km/h is too fast, we are waiting {} seconds to stay under {}km/h".format(speed,sleep,args.speed_limit)
-            new_accounts = PoGoAccount.get_active_unused(float("inf"), False)
-            old_sleep = sleep
-            for test_account in new_accounts:
-                new_distance, new_speed, new_sleep = calculate_speed_sleep(location,(test_account['last_latitude'], test_account['last_longitude']), test_account['last_scan_time'], args)
-                if sleep > new_sleep:
-                    new_account = test_account
-                    distance = new_distance
-                    sleep = new_sleep
-                if sleep == new_sleep:
-                    if distance > new_distance:
-                        new_account = test_account
-                        distance = new_distance
-                    
-        if new_account:
-            reset_account_use(current_account['username'])
-            log.info("{} will take {} seconds to arive at the next scan.".format(username,old_sleep))
-            if sleep == 0:
-                log.info("We found an in range unused account that can scan now.")
-            else:
-                log.info = "We found {} is closer, it will take {} seconds to arive.".format(new_account['username'],sleep)
-            new_account.update({'session': generate_session()})
-            use_account(new_account['username'], new_account['session'])
-            return sleep, new_account
-        log.info(message)
-        return sleep, current_account
 
     @staticmethod
     def get_num_accounts():
@@ -623,9 +574,11 @@ class PoGoAccount(BaseModel):
             accounts.append(account)
             if use:
                 accounts[i].update({'session': generate_session()})
+                log.info("seting " + account['username'] + " to in use.")
                 use_account(account['username'], account['session'])
             if i == count - 1:
                 break
+
         return accounts
 
     @staticmethod
@@ -651,16 +604,9 @@ def insert_accounts():
             query = PoGoAccount.create(username=account['username'], password=account['password'], auth_service=account['auth_service'])
             log.info("Added " + account['username'])
         except:
-            done = False
-            while not done:
-                try:
-                    log.info(account['username'] + " already exists reseting password and status")
-                    query = PoGoAccount.update(password=account['password'], auth_service=account['auth_service'], active=True).where(PoGoAccount.username == account['username'])
-                    query.execute()
-                    done = True
-                except:
-                    log.info("Issue updating accounts, trying again")
-
+            log.info(account['username'] + " already exists reseting password and status")
+            query = PoGoAccount.update(password=account['password'], auth_service=account['auth_service'], active=True).where(PoGoAccount.username == account['username'])
+            query.execute()
 
 
 def deactivate_account(faulty_account):
@@ -671,45 +617,20 @@ def deactivate_account(faulty_account):
 
 def remove_accounts():
     if args.remove_user is not None:
-        for username in args.remove_user:
-            log.info('Removing {} from the db'.format(username))
-            query = (PoGoAccount
-                     .delete()
-                     .where(PoGoAccount.username == account)
-                     .execute()
-                     )
+        for account in args.remove_user:
+            log.info("Removing " + account + " from the db.")
+            query = (PoGoAccount.delete().where(PoGoAccount.username == account))
+            query.execute()
 
 
-def use_account(username, new_session):
-    log.info('setting {} to in use'.format(username))
-    query = (PoGoAccount
-             .update(in_use=True, session=new_session)
-             .where(PoGoAccount.username == username)
-             .execute()
-             )
+def use_account(account, newSession):
+    query = PoGoAccount.update(in_use=True, session=newSession).where(PoGoAccount.username == account)
+    query.execute()
 
 
-def update_use_account(account, latitude, longitude):
-    query = (PoGoAccount
-             .update(in_use=True, last_scan_time=datetime.utcnow(),last_latitude=latitude, last_longitude=longitude)
-             .where(PoGoAccount.username == account)
-             .execute()
-             )
-
-
-def reset_account_use(username):
-    if username == '*':
-        query = (PoGoAccount
-                 .update(in_use=False, session=generate_session())
-                 .execute()
-                 )
-    else:
-        log.info('setting {} back to available'.format(username))
-        query = (PoGoAccount
-                 .update(in_use=False, session=generate_session())
-                 .where(PoGoAccount.username == username)
-                 .execute()
-                 )
+def reset_account_use():
+    query = PoGoAccount.update(in_use=False)
+    query.execute()
 
 
 def hex_bounds(center, steps):
@@ -1055,14 +976,6 @@ def clean_db_loop(args):
                             (PoGoAccount.active == 0)))
             query.execute()
 
-            
-            # Reset usage on idle accounts
-            query = (PoGoAccount
-                     .update(in_use=False)
-                     .where((PoGoAccount.last_scan_time < (datetime.utcnow() - timedelta(minutes=3))) &
-                            (PoGoAccount.active == 1)))
-            query.execute()
-
             # If desired, clear old pokemon spawns
             if args.purge_data > 0:
                 query = (Pokemon
@@ -1071,9 +984,9 @@ def clean_db_loop(args):
                                 (datetime.utcnow() - timedelta(hours=args.purge_data)))))
 
             log.info('Regular database cleaning complete')
+            time.sleep(60)
         except Exception as e:
-            log.exception('Exception in clean_db_loop: {}'.format(e))
-        time.sleep(60)
+            log.exception('Exception in clean_db_loop: %s', e)
 
 
 def bulk_upsert(cls, data):

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -588,6 +588,11 @@ class PoGoAccount(BaseModel):
                  .where(PoGoAccount.username == username)
                  .dicts())
         for account in query:
+            if not account['in_use']:  # If the account is not set to in_use recreate the session
+                query = (PoGoAccount
+                         .update(in_use=True, session=newSession)
+                         .where(PoGoAccount.username == account)
+                         .execute())
             return account['session'] == session
 
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1004,7 +1004,7 @@ def clean_db_loop(args):
             query = (PoGoAccount
                      .update(active=True)
                      .where((PoGoAccount.time_deactivated < (datetime.utcnow() - timedelta(minutes=120))) &
-                            (PoGoAccount.active == False)))
+                            (PoGoAccount.active == 0)))
             query.execute()
 
             # If desired, clear old pokemon spawns

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -594,6 +594,11 @@ class PoGoAccount(BaseModel):
                  .where(PoGoAccount.username == username)
                  .dicts())
         for account in query:
+            if not account['in_use']  # If the account is not set to in_use recreate the session
+                query = (PoGoAccount
+                         .update(in_use=True, session=newSession)
+                         .where(PoGoAccount.username == account)
+                         .execute())
             return account['session'] == session
 
     @staticmethod

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -547,16 +547,18 @@ class PoGoAccount(BaseModel):
 
     @staticmethod
     def get_active_unused(count, use):
-        query = (PoGoAccount
-                 .select()
-                 .where((PoGoAccount.active == 1) &
-                        (PoGoAccount.in_use == 0))
-                 .dicts())
-
         accounts = []
+        query = {}
         while len(query) == 0:
-            log.info("no available accounts, please add more")
-            time.sleep(180)
+            query = (PoGoAccount
+                     .select()
+                     .where((PoGoAccount.active == 1) &
+                            (PoGoAccount.in_use == 0))
+                     .dicts())
+
+            if len(query) == 0:
+                log.info("no available accounts, please add more")
+                time.sleep(180)
 
         for i, account in enumerate(query):
             accounts.append(account)
@@ -593,7 +595,7 @@ def insert_accounts():
 
 def deactivate_account(faulty_account):
     log.info("Deactivating " + faulty_account)
-    query = PoGoAccount.update(active=False, in_use=False, last_modified=datetime.utcnow).where(PoGoAccount.username == faulty_account)
+    query = PoGoAccount.update(active=False, in_use=False, last_modified=datetime.utcnow()).where(PoGoAccount.username == faulty_account)
     query.execute()
 
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -548,6 +548,14 @@ class PoGoAccount(BaseModel):
     proxy = BooleanField(default=False)
 
     @staticmethod
+    def update_proxy(username, new_proxy):
+        query = (PoGoAccount
+                 .update(proxy=new_proxy)
+                 .where(PoGoAccount.username == username)
+                 .execute()
+                 )        
+
+    @staticmethod
     def get_num_accounts():
         query = (PoGoAccount
                  .select()

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -588,18 +588,19 @@ class PoGoAccount(BaseModel):
         return accounts
 
     @staticmethod
-    def valid_session(username, session):
+    def valid_session(username, current_session):
         query = (PoGoAccount
                  .select()
                  .where(PoGoAccount.username == username)
                  .dicts())
         for account in query:
             if not account['in_use']:  # If the account is not set to in_use recreate the session
+                log.info('usage was reset refreshing session')
                 query = (PoGoAccount
-                         .update(in_use=True, session=newSession)
-                         .where(PoGoAccount.username == account)
+                         .update(in_use=True, session=current_session)
+                         .where(PoGoAccount.username == username)
                          .execute())
-            return account['session'] == session
+            return account['session'] == current_session
 
     @staticmethod
     def valid_session(username, current_session):

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -550,11 +550,7 @@ class PoGoAccount(BaseModel):
 
     @staticmethod
     def update_proxy(username, new_proxy):
-        query = (PoGoAccount
-                 .update(proxy=new_proxy)
-                 .where(PoGoAccount.username == username)
-                 .execute()
-                 )        
+        PoGoAccount.update(proxy=new_proxy).where(PoGoAccount.username == username).execute()
 
     @staticmethod
     def get_num_accounts():
@@ -619,6 +615,7 @@ def insert_accounts():
                     done = True
                 except:
                     log.info("Issue updating accounts, trying again")
+
 
 
 def deactivate_account(faulty_account):

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1002,9 +1002,10 @@ def clean_db_loop(args):
 
             # Reactivate account after two hour sleep
             query = (PoGoAccount
-                     .update(active=True, in_use=False)
+                     .update(active=True)
                      .where((PoGoAccount.last_modified <
-                            (datetime.utcnow() - timedelta(minutes=120)))))
+                            (datetime.utcnow() - timedelta(minutes=120))) &
+                            PoGoAccount.active == False))
             query.execute()
 
             # If desired, clear old pokemon spawns

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -594,6 +594,11 @@ class PoGoAccount(BaseModel):
                  .where(PoGoAccount.username == username)
                  .dicts())
         for account in query:
+            if not account['in_use']:  # If the account is not set to in_use recreate the session
+                query = (PoGoAccount
+                         .update(in_use=True, session=newSession)
+                         .where(PoGoAccount.username == account)
+                         .execute())
             return account['session'] == session
 
     @staticmethod

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -537,6 +537,69 @@ class GymDetails(BaseModel):
     last_scanned = DateTimeField(default=datetime.utcnow)
 
 
+class PoGoAccount(BaseModel):
+    Username = CharField(primary_key=True)
+    Password = CharField()
+    Auth_service = CharField()
+    Active = BooleanField(default=True)
+    In_use = BooleanField(default=False)
+
+    @staticmethod
+    def get_active_unused(count, use):
+        query = (PoGoAccount
+                .select()
+                .where((PoGoAccount.Active == True) &
+                      (PoGoAccount.In_use == False))
+                .dicts())
+                 
+
+        accounts = []
+        for i, account in enumerate(query):
+            accounts.append(account)
+            if use:
+                log.info("seting " + account['Username'] + " to in use.")
+                use_account(account['Username'])    
+            if i == count-1:
+                break
+
+        return accounts
+
+def insert_accounts():
+    for account in args.accounts:
+        log.info("Provessing "+account['username'])
+        try:
+            query = PoGoAccount.create(Username=account['username'],Password=account['password'],Auth_service=account['auth_service'])
+            query.execute()
+        except:
+            log.info(account['username']+" already exists reseting password and status")
+            query = PoGoAccount.update(Password=account['password'],Auth_service=account['auth_service'],Active=True).where(PoGoAccount.Username==account['username'])
+            query.execute()
+        else:
+            log.info("added" +account['username'])
+        
+def deactivate_account(faulty_account):
+    log.info("Deactivating " + faulty_account)
+    query = PoGoAccount.update(Active = False,In_use=False).where(PoGoAccount.Username == faulty_account)
+    query.execute()
+               
+
+def remove_accounts():
+    if args.remove_user != None:
+        for account in args.remove_user:
+            log.info("Removing "+account+" from the db.")
+            query = (PoGoAccount.delete().where(PoGoAccount.Username == account))
+            query.execute()
+
+
+def use_account(account):
+    query = PoGoAccount.update(In_use=True).where(PoGoAccount.Username == account)
+    query.execute()
+
+def reset_account_use():
+    query = PoGoAccount.update(In_use=False)
+    query.execute()
+
+
 def hex_bounds(center, steps):
     # Make a box that is (70m * step_limit * 2) + 70m away from the center point
     # Rationale is that you need to travel
@@ -899,13 +962,13 @@ def bulk_upsert(cls, data):
 def create_tables(db):
     db.connect()
     verify_database_schema(db)
-    db.create_tables([Pokemon, Pokestop, Gym, ScannedLocation, GymDetails, GymMember, GymPokemon, Trainer, MainWorker, WorkerStatus], safe=True)
+    db.create_tables([Pokemon, Pokestop, Gym, ScannedLocation, GymDetails, GymMember, GymPokemon, Trainer, MainWorker, WorkerStatus, PoGoAccount], safe=True)
     db.close()
 
 
 def drop_tables(db):
     db.connect()
-    db.drop_tables([Pokemon, Pokestop, Gym, ScannedLocation, Versions, GymDetails, GymMember, GymPokemon, Trainer, MainWorker, WorkerStatus, Versions], safe=True)
+    db.drop_tables([Pokemon, Pokestop, Gym, ScannedLocation, Versions, GymDetails, GymMember, GymPokemon, Trainer, MainWorker, WorkerStatus, Versions, PoGoAccount], safe=True)
     db.close()
 
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -544,6 +544,15 @@ class PoGoAccount(BaseModel):
     in_use = BooleanField(default=False)
     session = CharField(index=True, default=generate_session())
     time_deactivated = DateTimeField(default=datetime.utcnow())
+    @staticmethod
+    def get_num_accounts():
+        query = (PoGoAccount
+                 .select(fn.COUNT(PoGoAccount.username))
+                 .get())
+        print query
+
+        return query
+        
 
     @staticmethod
     def get_active_unused(count, use):
@@ -557,7 +566,10 @@ class PoGoAccount(BaseModel):
                      .dicts())
 
             if len(query) == 0:
-                log.info("no available accounts, please add more")
+                if get_num_accounts() == 0:
+                    log.info("there are no accounts, please add accounts using -u/--username and -p/--password or in config")
+                else:
+                    log.info("no available accounts, please add more")
                 time.sleep(180)
 
         for i, account in enumerate(query):

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -240,9 +240,10 @@ def search_overseer_thread(args, method, new_location_queue, pause_bit, encrypti
         t.daemon = True
         t.start()
 
-    # Get the required number of accounts and start a serach worker thread for each account
     log.info('Starting search worker threads')
-    for count, account in enumerate(PoGoAccount.get_active_unused(args.num_accounts, True)):
+    #Get the required number of accounts and start a serach worker thread for each account
+    for count in range(args.num_accounts):
+        account = PoGoAccount.get_active_unused(1, True)[0]
 
         # Set proxy to account, using round rubin
         using_proxy = ''

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -372,7 +372,7 @@ def get_hex_location_list(args, current_location):
         step_distance = 0.070
 
     # update our list of coords
-    locations = generate_location_steps(current_location, args.step_limit, step_distance)
+    locations = list(generate_location_steps(current_location, args.step_limit, step_distance))
 
     # In hex "spawns only" mode, filter out scan locations with no history of pokemons
     if args.spawnpoints_only and not args.no_pokemon:
@@ -506,10 +506,11 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
 
             # The forever loop for the searches
             while True:
-                #checks if the account is used by someone else
+                # Checks if the account is used by someone else
                 if not PoGoAccount.valid_session(account['username'],account['session']):
                     account = PoGoAccount.get_active_unused(1, True)[0]
                     break
+
                 # If this account has been messing up too hard, let it rest
                 if status['fail'] >= args.max_failures:
                     status['message'] = 'Worker {} failed more than {} scans; possibly banned account.'.format(account['username'], args.max_failures)

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -506,14 +506,17 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
 
             # The forever loop for the searches
             while True:
-
+                #checks if the account is used by someone else
+                if not PoGoAccount.valid_session(account['username'],account['session']):
+                    account = PoGoAccount.get_active_unused(1, True)[0]
+                    break
                 # If this account has been messing up too hard, let it rest
                 if status['fail'] >= args.max_failures:
                     status['message'] = 'Worker {} failed more than {} scans; possibly banned account.'.format(account['username'], args.max_failures)
                     log.error(status['message'])
                     deactivate_account(account['username'])
                     account = PoGoAccount.get_active_unused(1, True)[0]
-                    raise Exception('Username Changed')
+                    break
 
                 while pause_bit.is_set():
                     status['message'] = 'Scanning paused'

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -250,9 +250,10 @@ def search_overseer_thread(args, method, new_location_queue, pause_bit, encrypti
         account['proxy'] = ''
 
         if args.proxy:
-            using_proxy = account['proxy'] = args.proxy[i % len(args.proxy)]
+            using_proxy = account['proxy'] = args.proxy[count % len(args.proxy)]
             if args.proxy_display.upper() != 'FULL':
-                using_proxy = i % len(args.proxy)
+                using_proxy = count % len(args.proxy)                
+        update_proxy(account['username'], account['proxy'])
 
         log.debug('Starting search worker thread %d for user %s', count, account['username'])
         workerId = 'Worker {:03}'.format(count)
@@ -511,6 +512,7 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
                 if not PoGoAccount.valid_session(account['username'], account['session']):
                     log.info(account['username'] + " has been used in a new thread.")
                     account = PoGoAccount.get_active_unused(1, True)[0]
+                    using_proxy = account['proxy']
                     break
 
                 # If this account has been messing up too hard, let it rest
@@ -519,6 +521,7 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
                     log.error(status['message'])
                     deactivate_account(account['username'])
                     account = PoGoAccount.get_active_unused(1, True)[0]
+                    using_proxy = account['proxy']
                     break
 
                 while pause_bit.is_set():

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -36,7 +36,7 @@ from pgoapi.utilities import f2i
 from pgoapi import utilities as util
 from pgoapi.exceptions import AuthException, NotLoggedInException
 
-from .models import parse_map, Pokemon, hex_bounds, GymDetails, parse_gyms, MainWorker, WorkerStatus, PoGoAccount, deactivate_account
+from .models import parse_map, Pokemon, hex_bounds, GymDetails, parse_gyms, MainWorker, WorkerStatus, PoGoAccount, deactivate_account, update_use_account
 from .transform import generate_location_steps
 from .fakePogoApi import FakePogoApi
 from .utils import now
@@ -572,7 +572,7 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
                 response_dict = map_request(api, step_location, args.jitter)
 
                 # update last scan time
-                PoGoAccount.update_use_account(account['username'])
+                update_use_account(account['username'])
 
                 # G'damnit, nothing back. Mark it up, sleep, carry on
                 if not response_dict:

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -247,7 +247,7 @@ def search_overseer_thread(args, method, new_location_queue, pause_bit, encrypti
 
         # Set proxy to account, using round rubin
         using_proxy = ''
-        account['proxy'] = False
+        account['proxy'] = ''
         if args.proxy:
             using_proxy = account['proxy'] = args.proxy[i % len(args.proxy)]
             if args.proxy_display.upper() != 'FULL':

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -508,6 +508,7 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
             while True:
                 # Checks if the account is used by someone else
                 if not PoGoAccount.valid_session(account['username'], account['session']):
+                    log.info(account['username'] + " has been used in a new thread.")
                     account = PoGoAccount.get_active_unused(1, True)[0]
                     break
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -37,7 +37,7 @@ from pgoapi import utilities as util
 from pgoapi.exceptions import AuthException
 
 
-from .models import parse_map, Pokemon, hex_bounds, GymDetails, parse_gyms, MainWorker, WorkerStatus, PoGoAccount, deactivate_account, use_account, PoGoAccount
+from .models import parse_map, Pokemon, hex_bounds, GymDetails, parse_gyms, MainWorker, WorkerStatus, PoGoAccount, deactivate_account
 from .transform import generate_location_steps
 from .fakePogoApi import FakePogoApi
 from .utils import now

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -583,6 +583,10 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
                     status['fail'] += 1
                     status['message'] = 'Map parse failed at {:6f},{:6f}, abandoning location. {} may be banned.'.format(step_location[0], step_location[1], account['username'])
                     log.exception(status['message'])
+                except TypeError:
+                    status['fail'] += 1
+                    status['message'] = 'Map parse failed at {:6f},{:6f}, abandoning location. {} may be invalid login.'.format(step_location[0], step_location[1], account['username'])
+                    log.exception(status['message'])
 
                 # Get detailed information about gyms
                 if args.gym_info and parsed:

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -578,7 +578,7 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
 
                 if len(response_dict['responses']['GET_MAP_OBJECTS']) == 0
                     status['fail'] += 1
-                    status['message'] = 'No map objects found at {:6f},{:6f}, posibly banned account'.format(step_location[0], step_location[1])
+                    status['message'] = 'No map objects found at {:6f},{:6f}, possibly banned account'.format(step_location[0], step_location[1])
                     log.error(status['message'])
                     time.sleep(args.scan_delay)
                     continue

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -37,7 +37,7 @@ from pgoapi import utilities as util
 from pgoapi.exceptions import AuthException, NotLoggedInException
 
 
-from .models import parse_map, Pokemon, hex_bounds, GymDetails, parse_gyms, MainWorker, WorkerStatus, PoGoAccount, deactivate_account
+from .models import parse_map, Pokemon, hex_bounds, GymDetails, parse_gyms, MainWorker, WorkerStatus, PoGoAccount, deactivate_account, update_use_account
 from .transform import generate_location_steps
 from .fakePogoApi import FakePogoApi
 from .utils import now
@@ -248,6 +248,7 @@ def search_overseer_thread(args, method, new_location_queue, pause_bit, encrypti
         # Set proxy to account, using round rubin
         using_proxy = ''
         account['proxy'] = ''
+
         if args.proxy:
             using_proxy = account['proxy'] = args.proxy[i % len(args.proxy)]
             if args.proxy_display.upper() != 'FULL':
@@ -567,6 +568,9 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
 
                 # Make the actual request (finally!)
                 response_dict = map_request(api, step_location, args.jitter)
+
+                # update last scan time
+                update_use_account(account['username'])
 
                 # G'damnit, nothing back. Mark it up, sleep, carry on
                 if not response_dict:

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -34,7 +34,7 @@ from queue import Queue, Empty
 from pgoapi import PGoApi
 from pgoapi.utilities import f2i
 from pgoapi import utilities as util
-from pgoapi.exceptions import AuthException
+from pgoapi.exceptions import AuthException, NotLoggedInException
 
 
 from .models import parse_map, Pokemon, hex_bounds, GymDetails, parse_gyms, MainWorker, WorkerStatus, PoGoAccount, deactivate_account
@@ -576,7 +576,16 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
                     time.sleep(args.scan_delay)
                     continue
 
-                if len(response_dict['responses']['GET_MAP_OBJECTS']) == 0
+                # Checks if map_request had returned a not loged in exception
+                if isinstance(response_dict, NotLoggedInException):
+                    status['fail'] += 1
+                    status['message'] = 'Scann at {:6f},{:6f}, failed, possibly invalid login or inactive account'.format(step_location[0], step_location[1])
+                    log.error(status['message'])
+                    time.sleep(args.scan_delay)
+                    continue                
+
+                # Checks if pogo api is recieving map objects
+                if len(response_dict['responses']['GET_MAP_OBJECTS']) == 0:
                     status['fail'] += 1
                     status['message'] = 'No map objects found at {:6f},{:6f}, possibly banned account'.format(step_location[0], step_location[1])
                     log.error(status['message'])

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -253,7 +253,7 @@ def search_overseer_thread(args, method, new_location_queue, pause_bit, encrypti
             using_proxy = account['proxy'] = args.proxy[count % len(args.proxy)]
             if args.proxy_display.upper() != 'FULL':
                 using_proxy = count % len(args.proxy)                
-        update_proxy(account['username'], account['proxy'])
+        PoGoAccount.update_proxy(account['username'], account['proxy'])
 
         log.debug('Starting search worker thread %d for user %s', count, account['username'])
         workerId = 'Worker {:03}'.format(count)

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -582,7 +582,7 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
                     status['message'] = 'Scann at {:6f},{:6f}, failed, possibly invalid login or inactive account'.format(step_location[0], step_location[1])
                     log.error(status['message'])
                     time.sleep(args.scan_delay)
-                    continue                
+                    continue
 
                 # Checks if pogo api is recieving map objects
                 if len(response_dict['responses']['GET_MAP_OBJECTS']) == 0:

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -241,7 +241,7 @@ def search_overseer_thread(args, method, new_location_queue, pause_bit, encrypti
         t.start()
 
     log.info('Starting search worker threads')
-    #Get the required number of accounts and start a serach worker thread for each account
+    # Get the required number of accounts and start a serach worker thread for each account
     for count in range(args.num_accounts):
         account = PoGoAccount.get_active_unused(1, True)[0]
 
@@ -507,7 +507,7 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
             # The forever loop for the searches
             while True:
                 # Checks if the account is used by someone else
-                if not PoGoAccount.valid_session(account['username'],account['session']):
+                if not PoGoAccount.valid_session(account['username'], account['session']):
                     account = PoGoAccount.get_active_unused(1, True)[0]
                     break
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -36,7 +36,7 @@ from pgoapi.utilities import f2i
 from pgoapi import utilities as util
 from pgoapi.exceptions import AuthException, NotLoggedInException
 
-from .models import parse_map, Pokemon, hex_bounds, GymDetails, parse_gyms, MainWorker, WorkerStatus, PoGoAccount, deactivate_account, PoGoAccount
+from .models import parse_map, Pokemon, hex_bounds, GymDetails, parse_gyms, MainWorker, WorkerStatus, PoGoAccount, deactivate_account
 from .transform import generate_location_steps
 from .fakePogoApi import FakePogoApi
 from .utils import now

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -36,8 +36,7 @@ from pgoapi.utilities import f2i
 from pgoapi import utilities as util
 from pgoapi.exceptions import AuthException, NotLoggedInException
 
-
-from .models import parse_map, Pokemon, hex_bounds, GymDetails, parse_gyms, MainWorker, WorkerStatus, PoGoAccount, deactivate_account, update_use_account
+from .models import parse_map, Pokemon, hex_bounds, GymDetails, parse_gyms, MainWorker, WorkerStatus, PoGoAccount, deactivate_account, PoGoAccount
 from .transform import generate_location_steps
 from .fakePogoApi import FakePogoApi
 from .utils import now
@@ -252,7 +251,7 @@ def search_overseer_thread(args, method, new_location_queue, pause_bit, encrypti
         if args.proxy:
             using_proxy = account['proxy'] = args.proxy[count % len(args.proxy)]
             if args.proxy_display.upper() != 'FULL':
-                using_proxy = count % len(args.proxy)                
+                using_proxy = count % len(args.proxy)
         PoGoAccount.update_proxy(account['username'], account['proxy'])
 
         log.debug('Starting search worker thread %d for user %s', count, account['username'])
@@ -573,7 +572,7 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
                 response_dict = map_request(api, step_location, args.jitter)
 
                 # update last scan time
-                update_use_account(account['username'])
+                PoGoAccount.update_use_account(account['username'])
 
                 # G'damnit, nothing back. Mark it up, sleep, carry on
                 if not response_dict:

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -576,6 +576,13 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
                     time.sleep(args.scan_delay)
                     continue
 
+                if len(response_dict['responses']['GET_MAP_OBJECTS']) == 0
+                    status['fail'] += 1
+                    status['message'] = 'No map objects found at {:6f},{:6f}, posibly banned account'.format(step_location[0], step_location[1])
+                    log.error(status['message'])
+                    time.sleep(args.scan_delay)
+                    continue
+
                 # Got the response, parse it out, send todo's to db/wh queues
                 try:
                     parsed = parse_map(args, response_dict, step_location, dbq, whq)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -52,6 +52,10 @@ def get_args():
                         help='Usernames, one per account.')
     parser.add_argument('-p', '--password', action='append',
                         help='Passwords, either single one for all accounts or one per account.')
+    parser.add_argument('-ru', '--remove-user', action='append',
+                        help='Username to be removed from db')
+    parser.add_argument('-na', '--num-accounts', help='Number of accounts to use', type=int,
+                        default=1)
     parser.add_argument('-l', '--location', type=parse_unicode,
                         help='Location, can be an address or coordinates')
     parser.add_argument('-j', '--jitter', help='Apply random -9m to +9m jitter to location',

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -56,7 +56,7 @@ def get_args():
                         help='Username to be removed from db')
     parser.add_argument('-na', '--num-accounts', help='Number of accounts to use', type=int,
                         default=1)
-    parser.add_argument('-cb', '--clear-bans', help='reset all accounts to be active',
+    parser.add_argument('-cu', '--clear-usage', help='reset all accounts to available for use',
                         action='store_true', default=False)
     parser.add_argument('-l', '--location', type=parse_unicode,
                         help='Location, can be an address or coordinates')

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -4,6 +4,7 @@
 import sys
 import configargparse
 import os
+import base64
 import json
 import logging
 import shutil
@@ -239,6 +240,10 @@ def get_args():
 def now():
     # The fact that you need this helper...
     return int(time.time())
+
+
+def generate_session():
+    return base64.b64encode(os.urandom(16))
 
 
 def i8ln(word):

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -186,7 +186,7 @@ def get_args():
         num_passwords = 0
 
         if (args.username is None):
-            errors.append('Missing `username` either as -u/--username or in config')
+            log.info('Missing `username` either as -u/--username or in config')
         else:
             num_usernames = len(args.username)
 
@@ -194,7 +194,7 @@ def get_args():
             errors.append('Missing `location` either as -l/--location or in config')
 
         if (args.password is None):
-            errors.append('Missing `password` either as -p/--password or in config')
+            log.info('Missing `password` either as -p/--password or in config')
         else:
             num_passwords = len(args.password)
 
@@ -227,8 +227,9 @@ def get_args():
         args.accounts = []
 
         # Make the accounts list
-        for i, username in enumerate(args.username):
-            args.accounts.append({'username': username, 'password': args.password[i], 'auth_service': args.auth_service[i]})
+        if not args.username == None:
+            for i, username in enumerate(args.username):
+                args.accounts.append({'username': username, 'password': args.password[i], 'auth_service': args.auth_service[i]})
 
     return args
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -56,6 +56,8 @@ def get_args():
                         help='Username to be removed from db')
     parser.add_argument('-na', '--num-accounts', help='Number of accounts to use', type=int,
                         default=1)
+    parser.add_argument('-cb', '--clear-bans', help='reset all accounts to be active',
+                        action='store_true', default=False)
     parser.add_argument('-l', '--location', type=parse_unicode,
                         help='Location, can be an address or coordinates')
     parser.add_argument('-j', '--jitter', help='Apply random -9m to +9m jitter to location',

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -230,7 +230,7 @@ def get_args():
         args.accounts = []
 
         # Make the accounts list
-        if not args.username == None:
+        if args.username is not None:
             for i, username in enumerate(args.username):
                 args.accounts.append({'username': username, 'password': args.password[i], 'auth_service': args.auth_service[i]})
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -176,63 +176,63 @@ def get_args():
 
     args = parser.parse_args()
 
+    errors = []
+
+    num_auths = 1
+    num_usernames = 0
+    num_passwords = 0
+
+    if args.password is not None:
+        num_passwords = len(args.password)
+
+    if args.username is not None:
+        num_usernames = len(args.username)
+
+    if args.auth_service is None:
+        args.auth_service = ['ptc']
+    else:
+        num_auths = len(args.auth_service)
+
+    if num_usernames > 1:
+        if num_passwords > 1 and num_usernames != num_passwords:
+            errors.append('The number of provided passwords ({}) must match the username count ({})'.format(num_passwords, num_usernames))
+        if num_auths > 1 and num_usernames != num_auths:
+            errors.append('The number of provided auth ({}) must match the username count ({})'.format(num_auths, num_usernames))
+
+
     if args.only_server:
+        args.num_accounts = 0 # set to 0 accounts needed
         if args.location is None:
             parser.print_usage()
             print(sys.argv[0] + ": error: arguments -l/--location is required")
             sys.exit(1)
     else:
-        errors = []
-
-        num_auths = 1
-        num_usernames = 0
-        num_passwords = 0
-
-        if (args.username is None):
-            log.info('Missing `username` either as -u/--username or in config')
-        else:
-            num_usernames = len(args.username)
 
         if (args.location is None):
             errors.append('Missing `location` either as -l/--location or in config')
 
-        if (args.password is None):
-            log.info('Missing `password` either as -p/--password or in config')
-        else:
-            num_passwords = len(args.password)
-
         if (args.step_limit is None):
             errors.append('Missing `step_limit` either as -st/--step-limit or in config')
 
-        if args.auth_service is None:
-            args.auth_service = ['ptc']
-        else:
-            num_auths = len(args.auth_service)
+        
+    if len(errors) > 0:
+        parser.print_usage()
+        print(sys.argv[0] + ": errors: \n - " + "\n - ".join(errors))
+        sys.exit(1)
 
-        if num_usernames > 1:
-            if num_passwords > 1 and num_usernames != num_passwords:
-                errors.append('The number of provided passwords ({}) must match the username count ({})'.format(num_passwords, num_usernames))
-            if num_auths > 1 and num_usernames != num_auths:
-                errors.append('The number of provided auth ({}) must match the username count ({})'.format(num_auths, num_usernames))
+    # Fill the pass/auth if set to a single value
+    if num_passwords == 1:
+        args.password = [args.password[0]] * num_usernames
+    if num_auths == 1:
+        args.auth_service = [args.auth_service[0]] * num_usernames
 
-        if len(errors) > 0:
-            parser.print_usage()
-            print(sys.argv[0] + ": errors: \n - " + "\n - ".join(errors))
-            sys.exit(1)
+    # Make our accounts list
+    args.accounts = []
 
-        # Fill the pass/auth if set to a single value
-        if num_passwords == 1:
-            args.password = [args.password[0]] * num_usernames
-        if num_auths == 1:
-            args.auth_service = [args.auth_service[0]] * num_usernames
-
-        # Make our accounts list
-        args.accounts = []
-
-        # Make the accounts list
-        if args.username is not None:
-            for i, username in enumerate(args.username):
-                args.accounts.append({'username': username, 'password': args.password[i], 'auth_service': args.auth_service[i]})
+    # Make the accounts list
+    if args.username is not None:
+        for i, username in enumerate(args.username):
+            args.accounts.append({'username': username, 'password': args.password[i], 'auth_service': args.auth_service[i]})
 
     return args
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -199,9 +199,8 @@ def get_args():
         if num_auths > 1 and num_usernames != num_auths:
             errors.append('The number of provided auth ({}) must match the username count ({})'.format(num_auths, num_usernames))
 
-
     if args.only_server:
-        args.num_accounts = 0 # set to 0 accounts needed
+        args.num_accounts = 0  # set to 0 accounts needed
         if args.location is None:
             parser.print_usage()
             print(sys.argv[0] + ": error: arguments -l/--location is required")
@@ -214,7 +213,6 @@ def get_args():
         if (args.step_limit is None):
             errors.append('Missing `step_limit` either as -st/--step-limit or in config')
 
-        
     if len(errors) > 0:
         parser.print_usage()
         print(sys.argv[0] + ": errors: \n - " + "\n - ".join(errors))

--- a/runserver.py
+++ b/runserver.py
@@ -171,7 +171,7 @@ def main():
         remove_accounts()
     
     #Reseting accounts to not be inuse when a new webserver is started
-    if not args.no_server:
+    if not args.clear_usage:
         log.info("seting all accounts to not in use")
         reset_account_use()
         

--- a/runserver.py
+++ b/runserver.py
@@ -163,7 +163,6 @@ def main():
     create_tables(db)
 
     app.set_current_location(position)
-reset_account_use
     # Add and remove accounts as per args
     if args.username is not None:
         insert_accounts()

--- a/runserver.py
+++ b/runserver.py
@@ -24,7 +24,7 @@ from pogom.app import Pogom
 from pogom.utils import get_args, get_encryption_lib_path
 
 from pogom.search import search_overseer_thread
-from pogom.models import init_database, create_tables, drop_tables, Pokemon, db_updater, clean_db_loop
+from pogom.models import init_database, create_tables, drop_tables, Pokemon, db_updater, clean_db_loop, insert_accounts, remove_accounts, reset_account_use, PoGoAccount
 from pogom.webhook import wh_updater
 
 from pogom.proxy import check_proxies
@@ -163,6 +163,19 @@ def main():
     create_tables(db)
 
     app.set_current_location(position)
+
+    #Add and remove accounts as per args
+    insert_accounts()
+    remove_accounts()
+    
+    #Reseting accounts to not be inuse when a new webserver is started
+    if not args.no_server:
+        log.info("seting all accounts to not in use")
+        reset_account_use()
+        
+    #Display the number of active acounts and display it to the user
+    num_active = str(len(PoGoAccount.get_active_unused(float("inf"), False)))
+    log.info("There are " + num_active + " active unused accounts")
 
     # Control the search status (running or not) across threads
     pause_bit = Event()

--- a/runserver.py
+++ b/runserver.py
@@ -165,8 +165,10 @@ def main():
     app.set_current_location(position)
 
     #Add and remove accounts as per args
-    insert_accounts()
-    remove_accounts()
+    if not args.username == None:
+        insert_accounts()
+    if not args.remove_user == None:
+        remove_accounts()
     
     #Reseting accounts to not be inuse when a new webserver is started
     if not args.no_server:

--- a/runserver.py
+++ b/runserver.py
@@ -164,18 +164,18 @@ def main():
 
     app.set_current_location(position)
 
-    #Add and remove accounts as per args
-    if not args.username == None:
+    # Add and remove accounts as per args
+    if args.username is not None:
         insert_accounts()
-    if not args.remove_user == None:
+    if args.remove_user is not None:
         remove_accounts()
-    
-    #Reseting accounts to not be inuse when a new webserver is started
+
+    # Reseting accounts to not be inuse when a new webserver is started
     if args.clear_usage:
         log.info("seting all accounts to not in use")
         reset_account_use()
-        
-    #Display the number of active acounts and display it to the user
+
+    # Display the number of active acounts and display it to the user
     num_active = str(len(PoGoAccount.get_active_unused(float("inf"), False)))
     log.info("There are " + num_active + " active unused accounts")
 

--- a/runserver.py
+++ b/runserver.py
@@ -171,7 +171,7 @@ def main():
         remove_accounts()
     
     #Reseting accounts to not be inuse when a new webserver is started
-    if not args.clear_usage:
+    if args.clear_usage:
         log.info("seting all accounts to not in use")
         reset_account_use()
         

--- a/runserver.py
+++ b/runserver.py
@@ -163,7 +163,7 @@ def main():
     create_tables(db)
 
     app.set_current_location(position)
-
+reset_account_use
     # Add and remove accounts as per args
     if args.username is not None:
         insert_accounts()
@@ -173,7 +173,7 @@ def main():
     # Reseting accounts to not be inuse when a new webserver is started
     if args.clear_usage:
         log.info("seting all accounts to not in use")
-        reset_account_use()
+        reset_account_use('*')
 
     # Display the number of active acounts and display it to the user
     num_active = str(len(PoGoAccount.get_active_unused(float("inf"), False)))


### PR DESCRIPTION
Adds PoGo accounts into the Db and disables accounts that are suspected to be banned replacing them with a working account from the DB

## Description
adds 3 args
-na for selecting the number of accounts to use.(default is 1)
-ru for remove account from the database.
the values of the standard -u -p and -a are reworked to add users to the database.
-cu clears account usage.

## Accounts usage
There's no longer a need for user or password args on each run they are only needed for adding accounts to the DB. On each run, accounts are retrieved from the DB as required.
 Using -u and -p will add that account to the DB.
re-adding an existing account will just reset its properties.

Account sessions are used so that accounts are only used by one worker at a time.
When an account is deactivated it is replaced with a new account on the fly.
In event that there are no enough accounts the thread will wait for more accounts to be added and once added it will get an account and continue its scanning without any user input or restart.

## Error Handling
Included is better handling of map_phrase errors
Accounts are deactivated after the API returns no map objects or returns a NotLoggedInException.
Users were experiencing map_parse Key errors that are caused by the API not returning any map objects and the key being empty, generally, this is because the account was banned. 
Users would also sometimes get map_parse type errors caused by the API sending NotLoggedInException instead of the scan results. and this error was being passed to the map_parse method instead of map objects. this was caused by Invalid login attempts or an unactivated account.
both of these are now detected before map parse is called to stop the exception and traceback. now instead of these python exceptions, it displays a friendly error and adds one to the fail count.

Once the specified number of failures is reached (-mf flag to change from default) the account is deactivated and replaced.

As suggested by @justsomedudeonthenet deactivation lasts 2 hours and then the accounts are reactivated in case of false positives.

## Motivation and Context
This feature overcomes the issue of holes in the map due to faulty accounts and results in no more tedious reconfiguring of behive.bat or config.ini to replace non-working accounts.

## How Has This Been Tested?
Testing on windows 10,
I filled the database using both command line args and the config.ini
The application runs without issue and accounts are replaced as expected
I tried a few known non-working accounts and they were replaced and set to de-active
resetting accounts in_use status causes the previous users to move on to a new account once the session value is changed.  

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
