### PR TITLE
4 decimals in Percentage

### DIFF
--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -131,7 +131,7 @@ function processSeen (seen) {
 
   for (i = seen.pokemon.length - 1; i >= 0; i--) {
     var item = seen.pokemon[i]
-    var percentage = (item['count'] / total * 100).toFixed(2)
+    var percentage = (item['count'] / total * 100).toFixed(4)
     var lastSeen = new Date(item['disappear_time'])
     lastSeen = lastSeen.getHours() + ':' +
     ('0' + lastSeen.getMinutes()).slice(-2) + ':' +


### PR DESCRIPTION

## Description
Adding 4 decimals to percentage number in overall statistics

## Motivation and Context
When having a large dataset many of the Pokémon will appear with very low percentage.
with going up from 2 to 4, we can now see a more specific percentage than before

## How Has This Been Tested?
tested on my live and dev map. working fine for me and other users on my live map

## Screenshots (if appropriate):
![capture](https://cloud.githubusercontent.com/assets/21323545/18075363/a8cf3f6e-6ea6-11e6-92ce-c9d7173a9eaa.PNG)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

