### PR TITLE
Improved docker documentation

### DIFF
--- a/docs/advanced-install/docker.md
+++ b/docs/advanced-install/docker.md
@@ -143,41 +143,14 @@ docker run --name db --net=pogonw -v /path/to/mysql/:/var/lib/mysql -e MYSQL_ROO
 The launched MySQL server will have a single user called `root` and its password will be `yourpassword`. However, there is no database/schema that we can use as the server will be empty on the first run, so we've gotta create one for PokemonGo-Map. This will be done by executing a MySQL command in the server. In order to connect to the server, execute this command:
 
 ```
-docker run -it --net=pogonw --rm mysql sh -c 'exec mysql -hdb -P3306 -uroot -pyourpassword'
+docker exec -i db mysql -pyourpassword -e 'CREATE DATABASE pogodb'
 ```
 
-In the above, `-h` indicates the host name, which is the `db` container. `-p` indicates the port which `3306` is the MySQL default, `-u` is the `root` user and `-p` was the password we created previously. This will put you in the MySQL command line interface:
+That will do the trick. If you want to make sure the database was created, execute the following command and check if `pogodb` is listed:
 
 ```
-mysql: [Warning] Using a password on the command line interface can be insecure.
-Welcome to the MySQL monitor.  Commands end with ; or \g.
-Your MySQL connection id is 243
-Server version: 5.6.32 MySQL Community Server (GPL)
-
-Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
-
-Oracle is a registered trademark of Oracle Corporation and/or its
-affiliates. Other names may be trademarks of their respective
-owners.
-
-Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
-
-mysql>
+docker exec -i db mysql -pyourpassword -e 'SHOW DATABASES'
 ```
-
-Now we need to create a database in the server, execute:
-
-```
-CREATE DATABASE pogodb;
-```
-
-Which should output:
-
-```
-Query OK, 1 row affected (0.01 sec)
-```
-
-Once you get that done, simply type `quit` and press enter to exit the MySQL CLI.
 
 ### Relaunching the database
 

--- a/docs/advanced-install/docker.md
+++ b/docs/advanced-install/docker.md
@@ -1,12 +1,13 @@
-# Docker
+# About Docker
 
 Docker is a great way to run "containerized" applications easily and without installing tons of stuff into your computer. 
 
-If you are not familiar with Python, pip or the other stuff that is good to know before launching a PokemonGo-Map server, Docker is probably the easiest approach for you.
+If you are not familiar or don't feel confortable with Python, pip or any of the other the other stuff involved in launching a PokemonGo-Map server, Docker is probably the easiest approach for you.
 
 ## Prerequisites
 
-To get started, [install Docker by following their instructions](https://www.docker.com/products/docker).
+* [Docker](https://www.docker.com/products/docker)
+* Google Maps API Key
 
 ## Introduction
 
@@ -24,7 +25,7 @@ In order to start the map, you've got to run your docker container with a few ar
 docker run --rm pokemap/pokemongo-map -h
 ```
 
-To be able to access the map in your machine via browser, you've got to bind a port on you host to the one wich will be used by the map (default is 5000). The following docker run command is an example of to launch a container with a very basic setup of the map, following the instructions above:
+To be able to access the map in your machine via browser, you've got to bind a port on your host machine to the one wich will be exposed by the container (default is 5000). The following docker run command is an example of to launch a container with a very basic setup of the map, following the instructions above:
 
 ```
 docker run -d --name pogomap -p 5000:5000 \
@@ -45,7 +46,7 @@ Press `ctrl-c` when you're done.
 
 ### Stopping the server
 
-In the step above we launched our server in a container named 'pogomap'. Therefore, to stop it as simple as:
+In the step above we launched our server in a container named `pogomap`. Therefore, to stop it as simple as running:
 
 ```
 docker stop pogomap
@@ -59,11 +60,11 @@ docker rm pogomap
 
 ### Local access
 
-Given that we have bound port 5000 in your machine to port 5000 in the container, which the server is listening to, to access the server from your machine you just got to access 'http://localhost:5000' in you preferred browser.
+Given that we have bound port 5000 in your machine to port 5000 in the container, which the server is listening to, in order to access the server from your machine you just got to access `http://localhost:5000` in your preferred browser.
 
 ### External access
 
-If external access is necessary, there are plenty of ways to expose you server to the web. In this guide we are going to approach this using a [ngrok](https://ngrok.com/) container, which will create a secure introspected tunnel to your server. This is also very simple to do. Simply run the following command:
+If external access is necessary, there are plenty of ways to expose you server to the web. In this guide we are going to approach this using a [ngrok](https://ngrok.com/) container, which will create a secure introspected tunnel to your server. This is also very simple to do with Docker. Simply run the following command:
 
 ```
 docker run -d --name ngrok --link pogomap \
@@ -90,7 +91,7 @@ Open that URL in your browser and you're ready to rock!
 
 ## Updating Versions
 
-In order to update your PokemonGo-Map docker image, you should stop/remove all the current running containers (refer to Stopping the server), pull the latest docker image version, and restart everything. To pull the latest image, use the following command:
+In order to update your PokemonGo-Map docker image, you should stop/remove all the containers running with the current (outdated) version (refer to "Stopping the server"), pull the latest docker image version, and restart everything. To pull the latest image, use the following command:
 
 ```
 docker pull pokemap/pokemongo-map
@@ -115,11 +116,11 @@ If you want to run pokemongo-map on a service that doesn't support arguments lik
 
 ## Advanced Docker Setup
 
-In this session, we are going to approach a docker setup that allows data persistence. To do so, we are going to use the docker image for [MySQL](https://hub.docker.com/_/mysql/) as our database, and have our server(s) connect to it. This could be done by linking docker containers. However, linking is considered a [legacy feature](https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/#/legacy-container-links), so we are going to use the docker network approach.
+In this session, we are going to approach a docker setup that allows data persistence. To do so, we are going to use the docker image for [MySQL](https://hub.docker.com/_/mysql/) as our database, and have our server(s) connect to it. This could be done by linking docker containers. However, linking is considered a [legacy feature](https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/#/legacy-container-links), so we are going to use the docker network approach. We are also going to refer to a few commands that were used in the "Simple Docker Setup" session, which has more in-depth explanation about such commands, in case you need those.
 
 ### Creating the Docker Network
 
-The first step is very simple, we are going to use the following command to create a docker network called 'pogonw':
+The first step is very simple, we are going to use the following command to create a docker network called `pogonw`:
 
 ``` 
 docker network create pogonw
@@ -127,25 +128,25 @@ docker network create pogonw
 
 ### Launching the database
 
-Now that we have the network, we gotta launch the database into it. As noted in the introduction, docker containers are disposable. Sharing a directory in you machine with the docker container will allow the MySQL server to use such directory to store its data, and ensure it will remain there after the container stops. You can create this directory wherever you like. In this example we going to create a dir called /path/to/mysql/ just for the sake of it.
+Now that we have the network, we've gotta launch the database into it. As noted in the introduction, docker containers are disposable. Sharing a directory in you machine with the docker container will allow the MySQL server to use such directory to store its data, which ensures the data will remain there after the container stops. You can create this directory wherever you like. In this example we going to create a dir called `/path/to/mysql/` just for the sake of it.
 
 ```
 mkdir /path/to/mysql/
 ```
 
-After the directory is created, we can lauch the MySQL container. Use the following command to launch a container named 'db' into our previously created network, sharing the directory we just created:
+After the directory is created, we can lauch the MySQL container. Use the following command to launch a container named `db` into our previously created network, sharing the directory we just created:
 
 ```
 docker run --name db --net=pogonw -v /path/to/mysql/:/var/lib/mysql -e MYSQL_ROOT_PASSWORD=yourpassword  -d mysql:5.6.32
 ```
 
-The launched MySQL server will have a single user called 'root' and its password will be 'yourpassword'. However, there is no database/schema that we can use as the server will be empty on the first run, so we've got to create it. In order to connect to the server, and execute a MySQL command, execute this command:
+The launched MySQL server will have a single user called `root` and its password will be `yourpassword`. However, there is no database/schema that we can use as the server will be empty on the first run, so we've gotta create one for PokemonGo-Map. This will be done by executing a MySQL command in the server. In order to connect to the server, execute this command:
 
 ```
 docker run -it --net=pogonw --rm mysql sh -c 'exec mysql -hdb -P3306 -uroot -pyourpassword'
 ```
 
-In the above, `-h` indicates the host name, which is the 'db' container, `-p` is 3306 which is the MySQL default port, `-u` is the default root user and `-p` was the password we provided. This will put you in the MySQL command line interface:
+In the above, `-h` indicates the host name, which is the `db` container. `-p` indicates the port which `3306` is the MySQL default, `-u` is the `root` user and `-p` was the password we created previously. This will put you in the MySQL command line interface:
 
 ```
 mysql: [Warning] Using a password on the command line interface can be insecure.
@@ -164,7 +165,7 @@ Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
 mysql>
 ```
 
-Now we need to create a database in the server:
+Now we need to create a database in the server, execute:
 
 ```
 CREATE DATABASE pogodb;
@@ -178,9 +179,13 @@ Query OK, 1 row affected (0.01 sec)
 
 Once you get that done, simply type `quit` and press enter to exit the MySQL CLI.
 
+### Relaunching the database
+
+If the `db` container is not running, simply execute the same command that was used before to launch the container and the MySQL server will be up and running with all the previously stored data. You won't have to execute any MySQL command to create the database.
+
 ### Launching the PokemonGo-map server
 
-Now that we have a persistent database up and running, we need to launch our PokemonGo-map server. To do so, we are going to use a slightly modified version of the docker run command from the "Simple Docker Setup" session. This time we need to launch our server inside the network and pass the database infos to it. Here's an example:
+Now that we have a persistent database up and running, we need to launch our PokemonGo-map server. To do so, we are going to use a slightly modified version of the docker run command from the "Simple Docker Setup" session. This time we need to launch our server inside the created network and pass the necessary database infos to it. Here's an example:
 
 ```
 docker run -d --name pogomap --net=pogonw -p 5000:5000 \
@@ -197,17 +202,19 @@ docker run -d --name pogomap --net=pogonw -p 5000:5000 \
     --db-pass yourpassword 
 ```
 
-Just like before, in order to check the server's logs we can use 
+This will launch a container named `pogomap`. Just like before, in order to check the server's logs we can use: 
 
 ```
 docker logs -f pogomap
 ```
 
-If everything is fine, it should be up and running.
+If you want more detailed logs, add the `--verbose` flag to the end of the docker run command.
+
+If everything is fine, the server should be up and running now.
 
 ### Launching workers
 
-If you would like to launch a different worker to scan a different area, but sharing the same db, it is just as easy. We can use the docker run command from above, changing the container's name, and the necessary account and coordinate infos. For example:
+If you would like to launch a different worker sharing the same db, to scan a different area for example, it is just as easy. We can use the docker run command from above, changing the container's name, and the necessary account and coordinate infos. For example:
 
 ```
 docker run -d --name pogomap2 --net=pogonw \
@@ -227,11 +234,11 @@ docker run -d --name pogomap2 --net=pogonw \
 
 The difference here being: we are launching with the `-ns` flag, which means that this container will only run the searcher and not the webserver (front-end), because we can use the webserver from the first container. That also means we can get rid of `-p 5000:5000`, as we dont need to bind that port anymore. 
 
-If for some reason you would like this container to launch the webserver as well, simply remove the `-ns` flag and add back the `-p`, with a different pairing as 5000 will be already taken in the host, such as -p 5001:5000.
+If for some reason you would like this container to launch the webserver as well, simply remove the `-ns` flag and add back the `-p`, with a different pairing as your local port 5000 will be already taken, such as `-p 5001:5000`.
 
 ### External Access
 
-Just like before, we can use ngrok to provide external access to the webserver. The only thing we need to change in the command from the previous session is the link flag, instead we need to launch ngrok in our network:
+Just like before, we can use ngrok to provide external access to the webserver. The only thing we need to change in the command from the previous session is the `--link` flag, instead we need to launch ngrok in our network:
 
 ```
 docker run -d --name ngrok --net=pogonw \
@@ -247,7 +254,7 @@ docker run --rm --net=pogonw \
     sh -c "curl -s http://ngrok:4040/api/tunnels | grep -o 'https\?:\/\/[a-zA-Z0-9\.]\+'"
 ```
 
-### Inspecting the network
+### Inspecting the containers
 
 If at any moment you would like to check what containers are running, you can execute:
 
@@ -255,7 +262,7 @@ If at any moment you would like to check what containers are running, you can ex
 docker ps -a
 ```
 
-If you would like more detailed information about the network, such as its subnet, gateway or the ips that were assigned to the containers, you can execute:
+If you would like more detailed information about the network, such as its subnet and gateway or even the ips that were assigned to each running container, you can execute:
 
 ```
 docker network inspect pogonw

--- a/docs/advanced-install/docker.md
+++ b/docs/advanced-install/docker.md
@@ -1,4 +1,4 @@
-# About Docker
+# Docker
 
 Docker is a great way to run "containerized" applications easily and without installing tons of stuff into your computer. 
 

--- a/docs/advanced-install/docker.md
+++ b/docs/advanced-install/docker.md
@@ -1,35 +1,69 @@
 # Docker
 
-Docker is a great way to run "containerized" applications easily and without installing tons of stuff into your computer.
+Docker is a great way to run "containerized" applications easily and without installing tons of stuff into your computer. 
 
-## Prerequisits
+If you are not familiar with Python, pip or the other stuff that is good to know before launching a PokemonGo-Map server, Docker is probably the easiest approach for you.
+
+## Prerequisites
 
 To get started, [install Docker by following their instructions](https://www.docker.com/products/docker).
 
-## First Install
+## Introduction
 
-For your first install, there's only a few steps. Let's get to it!
+The quickest way to get PokemonGo-Map up and running with docker is quite simple. However, given the disposable nature of docker containers, and the fact that the default database for PokemonGo-Map is SQLite, your data won't be persistent. In case the container is stopped or crashes, all the collected data will be lost.
 
-### Start the Map 
+If that doesn't bother you, and you just want to give PokemonGo-Map a go, keep on reading. If you prefer a persistent setup, skip to "Advanced Docker Setup"
 
-You'll need to change the command line params. If you don't know what they are, you can run `docker run --rm pokemap/pokemongo-map -h` and you'll get the full help text. The command below examples out a very basic setup.
+## Simple Docker Setup
+
+### Starting the server 
+
+In order to start the map, you've got to run your docker container with a few arguments, such as authentication type, account, password, desired location and steps. If you don't know which arguments are necessary, you can use the following command to get help:
 
 ```
-docker run -d --name pogomap \
+docker run --rm pokemap/pokemongo-map -h
+```
+
+To be able to access the map in your machine via browser, you've got to bind a port on you host to the one wich will be used by the map (default is 5000). The following docker run command is an example of to launch a container with a very basic setup of the map, following the instructions above:
+
+```
+docker run -d --name pogomap -p 5000:5000 \
   pokemap/pokemongo-map \
-    -a ptc -u your -p login \
-    -k 'google-maps-key' \
-    -l 'coords' \
+    -a ptc -u username -p password \
+    -k 'your-google-maps-key' \
+    -l 'lat, lon' \
     -st 5
 ```
 
-If you've like to see that the application is outputting (console logs) you can run `docker logs -f pogomap` and just type `ctrl-c` when you're done watching.
+If you would like to see what the server's output (console logs) you can run 
 
-### Start an SSL Tunnel
+```
+docker logs -f pogomap
+``` 
 
-At this point, the map is running, but you can't get to it. Also, you'll probably want to access this from places other than `localhost`. Finally, if you want location services to work, you'll need SSL.
+Press `ctrl-c` when you're done.
 
-We'll use [ngrok](https://ngrok.com/) to make a secure tunnel to solve all of those issues!
+### Stopping the server
+
+In the step above we launched our server in a container named 'pogomap'. Therefore, to stop it as simple as:
+
+```
+docker stop pogomap
+```
+
+After stopping a named container, if you would like to launch a new one re-using such name, you have to remove it first, or else it will not be allowed:
+
+```
+docker rm pogomap
+```
+
+### Local access
+
+Given that we have bound port 5000 in your machine to port 5000 in the container, which the server is listening to, to access the server from your machine you just got to access 'http://localhost:5000' in you preferred browser.
+
+### External access
+
+If external access is necessary, there are plenty of ways to expose you server to the web. In this guide we are going to approach this using a [ngrok](https://ngrok.com/) container, which will create a secure introspected tunnel to your server. This is also very simple to do. Simply run the following command:
 
 ```
 docker run -d --name ngrok --link pogomap \
@@ -37,9 +71,7 @@ docker run -d --name ngrok --link pogomap \
     ngrok http pogomap:5000
 ```
 
-### Discover ngrok URL
-
-Now that ngrok tunnel is running, let's see what domain you've been assigned. You can run this command to grab it from the ngrok instance
+After the container is launched, we need to discover what domain you've been assigned. The following command can be used to obtain the domain:
 
 ```
 docker run --rm --link ngrok \
@@ -47,27 +79,24 @@ docker run --rm --link ngrok \
     sh -c "curl -s http://ngrok:4040/api/tunnels | grep -o 'https\?:\/\/[a-zA-Z0-9\.]\+'"
 ```
 
-That should return something like:
+That should output something like:
 
 ```
 http://random-string-here.ngrok.io
 https://random-string-here.ngrok.io
 ```
 
-Open that up and you're ready to rock!
+Open that URL in your browser and you're ready to rock!
 
 ## Updating Versions
 
-When you update, you remove all the current containers, pull the latest version, and restart everything.
-
-Run:
+In order to update your docker images, you should stop/remove all the current running containers (refer to Stopping the server), pull the latest docker image version, and restart everything. To pull the latest image, use the following command:
 
 ```
-docker rm -f pogomap ngrok
 docker pull pokemap/pokemongo-map
 ```
 
-Then redo the steps from "First Install" and you'll be on the latest version!
+If you are running a ngrok container, you've got to stop it as well. To start the server after updating your image, simply use the same commands that were used before, and the containers will be launched with the latest version.
 
 ## Running on docker cloud 
 
@@ -83,3 +112,175 @@ If you want to run pokemongo-map on a service that doesn't support arguments lik
     -e "GMAPS_KEY=SUPERSECRET" \
     ashex/pokemongo-map
 ```
+
+## Advanced Docker Setup
+
+In this session, we are going to approach a docker setup that allows data persistence. To do so, we are going to use the docker image for [MySQL](https://hub.docker.com/_/mysql/) as our database, and have our server(s) connect to it. This could be done by linking docker containers. However, linking is considered a [legacy feature](https://docs.docker.com/engine/userguide/networking/default_network/dockerlinks/#/legacy-container-links), so we are going to use the docker network approach.
+
+### Creating the Docker Network
+
+The first step is very simple, we are going to use the following command to create a docker network called 'pogonw':
+
+``` 
+docker network create pogonw
+```
+
+### Launching the database
+
+Now that we have the network, we gotta launch the database into it. As noted in the introduction, docker containers are disposable. Sharing a directory in you machine with the docker container will allow the MySQL server to use such directory to store its data, and ensure it will remain there after the container stops. You can create this directory wherever you like. In this example we going to create a dir called /path/to/mysql/ just for the sake of it.
+
+```
+mkdir /path/to/mysql/
+```
+
+After the directory is created, we can lauch the MySQL container. Use the following command to launch a container named 'db' into our previously created network, sharing the directory we just created:
+
+```
+docker run --name db --net=pogonw -v /path/to/mysql/:/var/lib/mysql -e MYSQL_ROOT_PASSWORD=yourpassword  -d mysql:5.6.32
+```
+
+The launched MySQL server will have a single user called 'root' and its password will be 'yourpassword'. However, there is no database/schema that we can use as the server will be empty on the first run, so we've got to create it. In order to connect to the server, and execute a MySQL command, execute this command:
+
+```
+docker run -it --net=pogonw --rm mysql sh -c 'exec mysql -hdb -P3306 -uroot -pyourpassword'
+```
+
+In the above, -h indicates the host name, which is the 'db' container, -p is 3306 which is the MySQL default port, -u is the default root user and -p was the password we provided. This will put you in the MySQL command line interface:
+
+```
+mysql: [Warning] Using a password on the command line interface can be insecure.
+Welcome to the MySQL monitor.  Commands end with ; or \g.
+Your MySQL connection id is 243
+Server version: 5.6.32 MySQL Community Server (GPL)
+
+Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
+
+Oracle is a registered trademark of Oracle Corporation and/or its
+affiliates. Other names may be trademarks of their respective
+owners.
+
+Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+
+mysql>
+```
+
+Now we need to create a database in the server:
+
+```
+CREATE DATABASE pogodb;
+```
+
+Which should output:
+
+```
+Query OK, 1 row affected (0.01 sec)
+```
+
+Once you get that done, simply type `quit` and press enter to exit the MySQL CLI.
+
+### Launching the PokemonGo-map server
+
+Now that we have a persistent database up and running, we need to launch our PokemonGo-map server. To do so, we are going to use a slightly modified version of the docker run command from the "Simple Docker Setup" session. This time we need to launch our server inside the network and pass the database infos to it. Here's an example:
+
+```
+docker run -d --name pogomap --net=pogonw -p 5000:5000 \
+  pokemap/pokemongo-map \
+    -a ptc -u username -p password \
+    -k 'your-google-maps-key' \
+    -l 'lat, lon' \
+    -st 5 \
+    --db-type mysql \
+    --db-host db \
+    --db-port 3306 \
+    --db-name pogodb \
+    --db-user root \
+    --db-pass pogomap 
+```
+
+Just like before, in order to check the server's logs we can use 
+
+```
+docker logs -f pogomap
+```
+
+If everything is fine, it should be up and running.
+
+### Launching workers
+
+If you would like to launch a different worker to scan a different area, but sharing the same db, it is just as easy. We can use the docker run command from above, changing the container's name, and the necessary account and coordinate infos. For example:
+
+```
+docker run -d --name pogomap2 --net=pogonw \
+  pokemap/pokemongo-map \
+    -a ptc -u username2 -p password2 \
+    -k 'your-google-maps-key' \
+    -l 'newlat, newlon' \
+    -st 5 \
+    --db-type mysql \
+    --db-host db \
+    --db-port 3306 \
+    --db-name pogodb \
+    --db-user root \
+    --db-pass pogomap 
+    -ns
+```
+
+The difference here being: we are launching with the -ns flag, which means that this container will only run the searcher and not the webserver (front-end), because we can use the webserver from the first container. That also means we can get rid of the -p 5000:5000, as we dont need to expose that port anymore. 
+
+If for some reason you would like this container to launch the webserver as well, simply remove the -ns flag and add back the -p, with a different pairing as 5000 will be already taken in the host, such as -p 5001:5000.
+
+### External Access
+
+Just like before, we can use ngrok to provide external access to the webserver. The only thing we need to change in the command from the previous session is the link flag, instead we need to launch ngrok in our network:
+
+```
+docker run -d --name ngrok --net=pogonw \
+  wernight/ngrok \
+    ngrok http pogomap:5000
+```
+
+To obtain the assigned domain from ngrok, we also need to execute the previous command in our network instead of using links:
+
+```
+docker run --rm --net=pogonw \
+  appropriate/curl \
+    sh -c "curl -s http://ngrok:4040/api/tunnels | grep -o 'https\?:\/\/[a-zA-Z0-9\.]\+'"
+```
+
+### Inspecting the network
+
+If at any moment you would like to check what containers are running, you can execute:
+
+```
+docker ps -a
+```
+
+If you would like more detailed information about the network, such as its subnet, gateway or the ips that were assigned to the containers, you can execute:
+
+```
+docker network inspect pogonw
+```
+
+### Setting up notifications
+
+If you have a docker image for a notification webhook that you want to be called by the server/workers, such as [PokeAlarm](https://github.com/kvangent/PokeAlarm), you can launch such container in the 'pogonw' network and give it a name such as 'hook'. This guide won't cover how to do that, but once such container is configured and running, you can stop your server/workers and relaunch them with the added flags: `-wh`, `--wh-threads` and `--webhook-updates-only`. For example, if the hook was listening to port 4000, and we wanted 3 threads to post updates only to the hook:
+
+```
+docker run -d --name pogomap --net=pogonw -p 5000:5000 \
+  pokemap/pokemongo-map \
+    -a ptc -u username -p password \
+    -k 'your-google-maps-key' \
+    -l 'lat, lon' \
+    -st 5 \
+    --db-type mysql \
+    --db-host db \
+    --db-port 3306 \
+    --db-name pogodb \
+    --db-user root \
+    --db-pass pogomap \
+    -wh 'http://hook:4000' \ 
+    --wh-threads 3 \
+    --webhook-updates-only
+```
+
+

--- a/docs/advanced-install/docker.md
+++ b/docs/advanced-install/docker.md
@@ -35,7 +35,7 @@ docker run -d --name pogomap -p 5000:5000 \
     -st 5
 ```
 
-If you would like to see what the server's output (console logs) you can run 
+If you would like to see what are the server's outputs (console logs), you can run:
 
 ```
 docker logs -f pogomap
@@ -71,7 +71,7 @@ docker run -d --name ngrok --link pogomap \
     ngrok http pogomap:5000
 ```
 
-After the container is launched, we need to discover what domain you've been assigned. The following command can be used to obtain the domain:
+After the ngrok container is launched, we need to discover what domain you've been assigned. The following command can be used to obtain the domain:
 
 ```
 docker run --rm --link ngrok \
@@ -90,7 +90,7 @@ Open that URL in your browser and you're ready to rock!
 
 ## Updating Versions
 
-In order to update your docker images, you should stop/remove all the current running containers (refer to Stopping the server), pull the latest docker image version, and restart everything. To pull the latest image, use the following command:
+In order to update your PokemonGo-Map docker image, you should stop/remove all the current running containers (refer to Stopping the server), pull the latest docker image version, and restart everything. To pull the latest image, use the following command:
 
 ```
 docker pull pokemap/pokemongo-map
@@ -145,7 +145,7 @@ The launched MySQL server will have a single user called 'root' and its password
 docker run -it --net=pogonw --rm mysql sh -c 'exec mysql -hdb -P3306 -uroot -pyourpassword'
 ```
 
-In the above, -h indicates the host name, which is the 'db' container, -p is 3306 which is the MySQL default port, -u is the default root user and -p was the password we provided. This will put you in the MySQL command line interface:
+In the above, `-h` indicates the host name, which is the 'db' container, `-p` is 3306 which is the MySQL default port, `-u` is the default root user and `-p` was the password we provided. This will put you in the MySQL command line interface:
 
 ```
 mysql: [Warning] Using a password on the command line interface can be insecure.
@@ -225,9 +225,9 @@ docker run -d --name pogomap2 --net=pogonw \
     -ns
 ```
 
-The difference here being: we are launching with the -ns flag, which means that this container will only run the searcher and not the webserver (front-end), because we can use the webserver from the first container. That also means we can get rid of the -p 5000:5000, as we dont need to expose that port anymore. 
+The difference here being: we are launching with the `-ns` flag, which means that this container will only run the searcher and not the webserver (front-end), because we can use the webserver from the first container. That also means we can get rid of `-p 5000:5000`, as we dont need to bind that port anymore. 
 
-If for some reason you would like this container to launch the webserver as well, simply remove the -ns flag and add back the -p, with a different pairing as 5000 will be already taken in the host, such as -p 5001:5000.
+If for some reason you would like this container to launch the webserver as well, simply remove the `-ns` flag and add back the `-p`, with a different pairing as 5000 will be already taken in the host, such as -p 5001:5000.
 
 ### External Access
 
@@ -282,5 +282,3 @@ docker run -d --name pogomap --net=pogonw -p 5000:5000 \
     --wh-threads 3 \
     --webhook-updates-only
 ```
-
-

--- a/docs/advanced-install/docker.md
+++ b/docs/advanced-install/docker.md
@@ -194,7 +194,7 @@ docker run -d --name pogomap --net=pogonw -p 5000:5000 \
     --db-port 3306 \
     --db-name pogodb \
     --db-user root \
-    --db-pass pogomap 
+    --db-pass yourpassword 
 ```
 
 Just like before, in order to check the server's logs we can use 
@@ -221,7 +221,7 @@ docker run -d --name pogomap2 --net=pogonw \
     --db-port 3306 \
     --db-name pogodb \
     --db-user root \
-    --db-pass pogomap 
+    --db-pass yourpassword 
     -ns
 ```
 
@@ -277,7 +277,7 @@ docker run -d --name pogomap --net=pogonw -p 5000:5000 \
     --db-port 3306 \
     --db-name pogodb \
     --db-user root \
-    --db-pass pogomap \
+    --db-pass yourpassword \
     -wh 'http://hook:4000' \ 
     --wh-threads 3 \
     --webhook-updates-only


### PR DESCRIPTION
## Description

Provides more in-depth instructions on how to run PokemonGo-Map as a docker container and how to persist its data

## Motivation and Context

A few things caught my attention from the beginning when reading the docs a couple nights ago. The documentation does not inform the reader at any point that the data collected by a PokemonGo-Map container is not persistent, and that it will be wiped as soon as the container stops. It also didn't provide any information or instructions on how to circumvent such problem. If I hadn't had previous knowledge about docker, I would have wasted lots of processing hours when running my containers.

## How Has This Been Tested?

Locally on sublime, online on github's preview

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

