### PR TITLE
Read accounts from CSV file with -ac/--accountcsv parameter

### DIFF
--- a/docs/extras/multi-account.md
+++ b/docs/extras/multi-account.md
@@ -46,3 +46,15 @@ auth-service: [ptc, ptc, google]
 username: [thunderfox01, thunderfox02, thunderfox03@gmail.com]
 password: [password01, password02, password03]
 ```
+
+## Using CSV file:
+
+To use multiple accounts from a CSV file, you create a CSV file with the auth method, username and password on each line. Additional fields after the password are ignored.
+
+CSV File Example:
+```
+ptc,thunderfox01,password01
+ptc,thunderfox02,password02,other,information
+```
+
+Example: `python runserver.py -ac accounts.csv`

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -207,7 +207,7 @@ def get_args():
         if (args.step_limit is None):
             errors.append('Missing `step_limit` either as -st/--step-limit or in config')
 
-        if args.auth_service is None:
+        if len(args.auth_service) is None:
             args.auth_service = ['ptc']
         else:
             num_auths = len(args.auth_service)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This allows a CSV file containing accounts to be specified, instead of **or in addition to** multiple -a/-u/-p parameters

Each line must contain the auth type, username and password.  Additional fields after that are ignored and can be left there.

eg:
```
ptc,username1,password1,00.00,00.00,dovahkiin1
ptc,username2,password1,00.00,00.00,dovahkiin2
```

## Motivation and Context
Adding hundreds of accounts from the command line is painful.  CSV files are painless.  Many already have their accounts in CSV files in the correct format.

## How Has This Been Tested?
Tested various valid and invalid combinations of csv files and command line account parameters.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.

