### PR TITLE
Add support for multiple proxy servers.

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -206,11 +206,12 @@ def search_overseer_thread(args, method, new_location_queue, pause_bit, encrypti
             'user': account['username']
         }
 
+        proxy = args.proxy[i % len(args.proxy)] if args.proxy is not None else None
         t = Thread(target=search_worker_thread,
                    name='search-worker-{}'.format(i),
                    args=(args, account, search_items_queue, pause_bit,
                          encryption_lib_path, threadStatus[workerId],
-                         db_updates_queue, wh_queue))
+                         db_updates_queue, wh_queue, proxy))
         t.daemon = True
         t.start()
 
@@ -416,7 +417,8 @@ def get_sps_location_list(args, current_location, sps_scan_current):
     return retset
 
 
-def search_worker_thread(args, account, search_items_queue, pause_bit, encryption_lib_path, status, dbq, whq):
+def search_worker_thread(args, account, search_items_queue, pause_bit, encryption_lib_path, status, dbq, whq, proxy):
+    log.info("Proxy: {}".format(proxy))
 
     stagger_thread(args, account)
 
@@ -437,8 +439,8 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
             else:
                 api = PGoApi()
 
-            if args.proxy:
-                api.set_proxy({'http': args.proxy, 'https': args.proxy})
+            if proxy:
+                api.set_proxy({'http': proxy, 'https': proxy})
 
             api.activate_signature(encryption_lib_path)
 
@@ -498,7 +500,7 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
                 api.set_position(*step_location)
 
                 # Ok, let's get started -- check our login status
-                check_login(args, account, api, step_location)
+                check_login(args, account, api, step_location, proxy)
 
                 # Make the actual request (finally!)
                 response_dict = map_request(api, step_location, args.jitter)
@@ -586,7 +588,7 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
             time.sleep(args.scan_delay)
 
 
-def check_login(args, account, api, position):
+def check_login(args, account, api, position, proxy):
 
     # Logged in? Enough time left? Cool!
     if api._auth_provider and api._auth_provider._ticket_expire:
@@ -600,8 +602,8 @@ def check_login(args, account, api, position):
     api.set_position(position[0], position[1], position[2])
     while i < args.login_retries:
         try:
-            if args.proxy:
-                api.set_authentication(provider=account['auth_service'], username=account['username'], password=account['password'], proxy_config={'http': args.proxy, 'https': args.proxy})
+            if proxy:
+                api.set_authentication(provider=account['auth_service'], username=account['username'], password=account['password'], proxy_config={'http': proxy, 'https': proxy})
             else:
                 api.set_authentication(provider=account['auth_service'], username=account['username'], password=account['password'])
             break

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -130,7 +130,8 @@ def get_args():
     parser.add_argument('-pd', '--purge-data',
                         help='Clear pokemon from database this many hours after they disappear \
                         (0 to disable)', type=int, default=0)
-    parser.add_argument('-px', '--proxy', help='Proxy url (e.g. socks5://127.0.0.1:9050)')
+    parser.add_argument('-px', '--proxy', help='Proxy url (e.g. socks5://127.0.0.1:9050). Might have multiple values.',
+                        action='append')
     parser.add_argument('--db-type', help='Type of database to be used (default: sqlite)',
                         default='sqlite')
     parser.add_argument('--db-name', help='Name of the database to be used')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
User will be able to specify multiple proxy servers.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I have 2 motivation for this change:
1. When map works under one IP server side is able to identify that "this accounts is used in map, not on real device".
2. For now many Tor IP gets banned and sometimes map may stop working because of it. To resume map we need to restart Tor proxy and map. With this change only threads using banned IP will be paused and other may continue work.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with docker with 10 and 1 proxy servers values in config.ini

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.