### PR TITLE
Decrease Number of Upserted Rows

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -839,7 +839,13 @@ def clean_db_loop(args):
 def bulk_upsert(cls, data):
     num_rows = len(data.values())
     i = 0
-    step = 50
+
+    if args.db_type == 'mysql':
+        step = 120
+    else:
+        # SQLite has a default max number of parameters of 999,
+        # so we need to limit how many rows we insert for it.
+        step = 50
 
     while i < num_rows:
         log.debug('Inserting items %d to %d', i, min(i + step, num_rows))

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -839,7 +839,7 @@ def clean_db_loop(args):
 def bulk_upsert(cls, data):
     num_rows = len(data.values())
     i = 0
-    step = 120
+    step = 50
 
     while i < num_rows:
         log.debug('Inserting items %d to %d', i, min(i + step, num_rows))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
[SQLite has a default max of 999 variables in a command](https://www.sqlite.org/c3ref/c_limit_attached.html#sqlitelimitvariablenumber), going over that limit causes errors. The "widest" table in the database is `gympokemon` with 17 columns. 999/17 = 58.76 - so only 58 parameterized `gympokemon` records can be inserted at once. Rounding down to add some margin of safety, I've updated the "step" size of `bulk_upsert` to 50 rows at a time.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[Comment on #666](https://github.com/PokemonGoMap/PokemonGo-Map/pull/666#issuecomment-243953614) where user is hitting this issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

