### PR TITLE
Fix Pokémon Typo

### DIFF
--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Pokemon Go Map - Statistics</title>
+    <title>Pokémon Go Map - Statistics</title>
 
     <!-- Fav- & Apple-Touch-Icons -->
     <!-- Favicon -->


### PR DESCRIPTION
## Description
Title of the Statistics had a minor typo

## Motivation and Context
OCD

## How Has This Been Tested?
on my live map

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Fix the typo in the Title of the stats page