### PR TITLE
Move "full stats" to the top

### DIFF
--- a/templates/map.html
+++ b/templates/map.html
@@ -230,10 +230,11 @@
       <nav id="stats">
         <div class="switch-container">
           <div class="switch-container">
+            <div><center><a href="stats">Full Stats</a></center></div>
+          </div>
             <center><h1 id="stats-pkmn-label">Loading...</h1></center>
           </div>
           <div id="pokemonList" style="color: black;"></div>
-          <div><a href="stats">Full Stats</a></div>
           <div class="switch-container">
             <center><h1 id="stats-gym-label"></h1></center>
           </div>

--- a/templates/map.html
+++ b/templates/map.html
@@ -231,7 +231,6 @@
         <div class="switch-container">
           <div class="switch-container">
             <div><center><a href="stats">Full Stats</a></center></div>
-          </div>
             <center><h1 id="stats-pkmn-label">Loading...</h1></center>
           </div>
           <div id="pokemonList" style="color: black;"></div>


### PR DESCRIPTION
## Description
Move the "Full Stats" link on the #Stats window to the top and center it

## Motivation and Context
Easier and faster reachability if viewing a lot of pokemon

## How Has This Been Tested?
Tested and in use on live map for a long time

## Screenshots (if appropriate):
![capture](https://cloud.githubusercontent.com/assets/21323545/18189657/594a8070-70ef-11e6-94df-7a317c1e06b7.PNG)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Move the "Full Stats" link under Stats to the top, and center it for easier and faster access