### PR TITLE
Fix for some cases of 0,0,0 returns

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -491,14 +491,17 @@ def search_worker_thread(args, account, search_items_queue, pause_bit, encryptio
                     # No sleep here; we've not done anything worth sleeping for. Plus we clearly need to catch up!
                     continue
 
-                status['message'] = 'Searching at {:6f},{:6f}'.format(step_location[0], step_location[1])
-                log.info(status['message'])
-
                 # Let the api know where we intend to be for this loop
+                # doing this before check_login so it does not also have to be done there
+                # when the auth token is refreshed
                 api.set_position(*step_location)
 
                 # Ok, let's get started -- check our login status
                 check_login(args, account, api, step_location)
+
+                # putting this message after the check_login so the messages aren't out of order
+                status['message'] = 'Searching at {:6f},{:6f}'.format(step_location[0], step_location[1])
+                log.info(status['message'])
 
                 # Make the actual request (finally!)
                 response_dict = map_request(api, step_location, args.jitter)
@@ -597,7 +600,6 @@ def check_login(args, account, api, position):
 
     # Try to login (a few times, but don't get stuck here)
     i = 0
-    api.set_position(position[0], position[1], position[2])
     while i < args.login_retries:
         try:
             if args.proxy:
@@ -614,7 +616,7 @@ def check_login(args, account, api, position):
                 time.sleep(args.login_delay)
 
     log.debug('Login for account %s successful', account['username'])
-    time.sleep(args.scan_delay)
+    time.sleep(20)
 
 
 def map_request(api, position, jitter=False):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
With High scan delays, and single threads, an auth token refresh could result in significant gaps in the scan data. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fix sets a specific delay after the auth token is refreshed and removes a extra set_location call that occurred only for auth token refreshes. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have only tested this on my system. I was able to clear all the cases of 0,0,0 on auth refresh though I was still seeing very rarely 0,0,0 after the first token again. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

Some users reporting 0,0,0 returns on subsequent auth token refreshes
after the first.