### PR TITLE
Send webhook for unique events

### DIFF
--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -3,7 +3,12 @@
 
 import logging
 import requests
+import calendar
+import time
 from .utils import get_args
+from threading import Thread, Event
+from queue import Queue
+from datetime import datetime, timedelta
 
 log = logging.getLogger(__name__)
 
@@ -28,6 +33,38 @@ def send_to_webhook(message_type, message):
         except requests.exceptions.RequestException as e:
             log.debug(e)
 
+def wh_overseer(args, whq):
+    wh_unique_queue = Queue()
+    unique_pokemon = {}
+    cleanup_time = int(round(time.time() * 1000)) + 300000
+
+    for i in range(args.wh_threads):
+        log.debug('Starting wh-updater worker thread %d', i)
+        t = Thread(target=wh_updater, name='wh-updater-{}'.format(i), args=(args, wh_unique_queue))
+        t.daemon = True
+        t.start()
+
+    # The forever loop
+    while True:
+        try:
+            # Loop the queue
+            while True:
+                whtype, message = whq.get()
+                if whtype == 'pokemon':
+                    pokemon_key = (message['encounter_id'], message['spawnpoint_id'])
+                    if pokemon_key not in unique_pokemon:
+                        unique_pokemon[pokemon_key] = message['disappear_time']
+                        wh_unique_queue.put((whtype, message))
+                else:
+                    wh_unique_queue.put((whtype, message))
+
+                # delete expired keys every 5 minutes with 1 minute grace period
+                if int(round(time.time() * 1000)) > cleanup_time:
+                    cleanup_time = int(round(time.time() * 1000)) + 300000
+                    unique_pokemon = {k: v for k, v in unique_pokemon.iteritems() if time.gmtime(v) > (datetime.utcnow() - timedelta(minutes=1)).timetuple()}
+
+        except Exception as e:
+            log.exception('Exception in wh_overseer: %s', e)
 
 def wh_updater(args, q):
     # The forever loop

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -3,10 +3,9 @@
 
 import logging
 import requests
-import calendar
 import time
 from .utils import get_args
-from threading import Thread, Event
+from threading import Thread
 from queue import Queue
 from datetime import datetime, timedelta
 
@@ -32,6 +31,7 @@ def send_to_webhook(message_type, message):
             log.debug('Response timeout on webhook endpoint %s', w)
         except requests.exceptions.RequestException as e:
             log.debug(e)
+
 
 def wh_overseer(args, whq):
     wh_unique_queue = Queue()
@@ -65,6 +65,7 @@ def wh_overseer(args, whq):
 
         except Exception as e:
             log.exception('Exception in wh_overseer: %s', e)
+
 
 def wh_updater(args, q):
     # The forever loop

--- a/runserver.py
+++ b/runserver.py
@@ -25,7 +25,7 @@ from pogom.utils import get_args, get_encryption_lib_path
 
 from pogom.search import search_overseer_thread
 from pogom.models import init_database, create_tables, drop_tables, Pokemon, db_updater, clean_db_loop
-from pogom.webhook import wh_updater
+from pogom.webhook import wh_overseer
 
 # Currently supported pgoapi
 pgoapi_version = "1.1.7"

--- a/runserver.py
+++ b/runserver.py
@@ -188,12 +188,11 @@ def main():
     # WH Updates
     wh_updates_queue = Queue()
 
-    # Thread to process webhook updates
-    for i in range(args.wh_threads):
-        log.debug('Starting wh-updater worker thread %d', i)
-        t = Thread(target=wh_updater, name='wh-updater-{}'.format(i), args=(args, wh_updates_queue))
-        t.daemon = True
-        t.start()
+    # Thread to oversee webhook updates
+    log.debug('Starting wh-overseer worker thread')
+    t = Thread(target=wh_overseer, name='wh-overseer', args=(args, wh_updates_queue))
+    t.daemon = True
+    t.start()
 
     if not args.only_server:
         # Gather the pokemons!


### PR DESCRIPTION
## Description

Created a webhook-overseer thread to send webhooks for unique events only. For pokemon this means unique encounter id + spawnpoint id, for pokestops unique pokestop id + last modified, for gyms unique gym id + last modified.
## How Has This Been Tested?

Ran on my computer with latest pull from develop on 2016-09-01 18:00 PST
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
