### PR TITLE
element.matches polyfill for app.js

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -2,6 +2,20 @@
   'use strict'
 
   // Methods/polyfills.
+  if (!Element.prototype.matches) {
+    Element.prototype.matches =
+      Element.prototype.matchesSelector ||
+      Element.prototype.mozMatchesSelector ||
+      Element.prototype.msMatchesSelector ||
+      Element.prototype.oMatchesSelector ||
+      Element.prototype.webkitMatchesSelector ||
+        function (s) {
+          var matches = (this.document || this.ownerDocument).querySelectorAll(s)
+          var i = matches.length
+          while (--i >= 0 && matches.item(i) !== this) {}
+          return i > -1
+        }
+  }
 
   // addEventsListener
   var addEventsListener = function (o, t, e) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds a element.matches polyfill to app.js 
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required for browsers that do not support element.matches, which app.js uses.

For example, when clicking anywhere, Microsoft Edge throws the exception:

SCRIPT438: Object doesn't support property or method 'matches'
app.min.js (5,1660)

which is line..

Line: 127
if (event.target.matches('a[href="#nav"]')) {

This error prevents the Nav and Stats from closing, except by clicking directly on the button.

<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/PokemonGoMap/PokemonGo-Map/issues/1212
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
tested on windows ff/chrome/edge android/ff/chrome and ios/safari and the matches function normally.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

