### PR TITLE
Fix alphabetical order in full stats

### DIFF
--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -114,10 +114,10 @@ function processSeen (seen) {
       return a['pokemon_id'] - b['pokemon_id']
     } else if (sort.options[sort.selectedIndex].value === 'name') {
       if (a['pokemon_name'].toLowerCase() < b['pokemon_name'].toLowerCase()) {
-        return 1
+        return -1
       }
       if (a['pokemon_name'].toLowerCase() > b['pokemon_name'].toLowerCase()) {
-        return -1
+        return 1
       }
       return 0
     } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When sorting by name on the full stats page, Ascending and Descending are reversed (at least the way I think of ascending/descending).  I changed it.
## Description
<!--- Describe your changes in detail -->
Modified statistics.js to properly alphabetize ascending/descending.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Sort by name has ascending and descending reversed.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I made the change on my system (Windows 7) and it sorts the correct way.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

