### PR TITLE
Read usernames and passwords from file

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -15,7 +15,6 @@ from . import config
 
 log = logging.getLogger(__name__)
 
-
 def parse_unicode(bytestring):
     decoded_string = bytestring.decode(sys.getfilesystemencoding())
     return decoded_string
@@ -44,6 +43,8 @@ def memoize(function):
 @memoize
 def get_args():
     # fuck PEP8
+    accountsFile = None
+    accountFileLines = None
     configpath = os.path.join(os.path.dirname(__file__), '../config/config.ini')
     parser = configargparse.ArgParser(default_config_files=[configpath], auto_env_var_prefix='POGOMAP_')
     parser.add_argument('-a', '--auth-service', type=str.lower, action='append',
@@ -182,17 +183,29 @@ def get_args():
         num_passwords = 0
 
         if (args.username is None):
+            
             errors.append('Missing `username` either as -u/--username or in config')
         else:
             num_usernames = len(args.username)
 
         if (args.location is None):
             errors.append('Missing `location` either as -l/--location or in config')
+        
+        if num_usernames == 1 and args.username[0].startswith('file:'):
+            accountsFile = args.username[0][5:]
+        
+        if accountsFile:
+            try:
+                with open(accountsFile,"r") as myfile:
+                    accountFileLines = myfile.readlines()
+            except Exception as  e:
+                errors.append("Error reading accountFileLines from file: {}".format(e))
 
-        if (args.password is None):
-            errors.append('Missing `password` either as -p/--password or in config')
-        else:
-            num_passwords = len(args.password)
+        if not accountsFile:
+            if (args.password is None):
+                errors.append('Missing `password` either as -p/--password or in config')
+            else:
+                num_passwords = len(args.password)
 
         if (args.step_limit is None):
             errors.append('Missing `step_limit` either as -st/--step-limit or in config')
@@ -208,23 +221,31 @@ def get_args():
             if num_auths > 1 and num_usernames != num_auths:
                 errors.append('The number of provided auth ({}) must match the username count ({})'.format(num_auths, num_usernames))
 
+
         if len(errors) > 0:
             parser.print_usage()
             print(sys.argv[0] + ": errors: \n - " + "\n - ".join(errors))
             sys.exit(1)
 
-        # Fill the pass/auth if set to a single value
-        if num_passwords == 1:
-            args.password = [args.password[0]] * num_usernames
-        if num_auths == 1:
-            args.auth_service = [args.auth_service[0]] * num_usernames
+        if not accountsFile:
+            # Fill the pass/auth if set to a single value
+            if num_passwords == 1:
+                args.password = [args.password[0]] * num_usernames
+            if num_auths == 1:
+                args.auth_service = [args.auth_service[0]] * num_usernames
 
         # Make our accounts list
         args.accounts = []
 
-        # Make the accounts list
-        for i, username in enumerate(args.username):
-            args.accounts.append({'username': username, 'password': args.password[i], 'auth_service': args.auth_service[i]})
+        if accountsFile:
+            credentials = [x.strip().split(',') for x in accountFileLines]
+            for item in credentials:
+                args.accounts.append({'username': item[1], 'password': item[2], 'auth_service': item[0]})
+
+        else:
+            # Make the accounts list
+            for i, username in enumerate(args.username):
+                args.accounts.append({'username': username, 'password': args.password[i], 'auth_service': args.auth_service[i]})
 
     return args
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -15,6 +15,7 @@ from . import config
 
 log = logging.getLogger(__name__)
 
+
 def parse_unicode(bytestring):
     decoded_string = bytestring.decode(sys.getfilesystemencoding())
     return decoded_string
@@ -183,23 +184,22 @@ def get_args():
         num_passwords = 0
 
         if (args.username is None):
-            
             errors.append('Missing `username` either as -u/--username or in config')
         else:
             num_usernames = len(args.username)
 
         if (args.location is None):
             errors.append('Missing `location` either as -l/--location or in config')
-        
+
         if num_usernames == 1 and args.username[0].startswith('file:'):
             accountsFile = args.username[0][5:]
-        
+
         if accountsFile:
             try:
-                with open(accountsFile,"r") as myfile:
+                with open(accountsFile, "r") as myfile:
                     accountFileLines = myfile.readlines()
-            except Exception as  e:
-                errors.append("Error reading accountFileLines from file: {}".format(e))
+            except Exception as e:
+                errors.append("Error reading credentials from file: {}".format(e))
 
         if not accountsFile:
             if (args.password is None):
@@ -220,7 +220,6 @@ def get_args():
                 errors.append('The number of provided passwords ({}) must match the username count ({})'.format(num_passwords, num_usernames))
             if num_auths > 1 and num_usernames != num_auths:
                 errors.append('The number of provided auth ({}) must match the username count ({})'.format(num_auths, num_usernames))
-
 
         if len(errors) > 0:
             parser.print_usage()


### PR DESCRIPTION
## Description
Provide a means for reading login credentials from file. It works like this: let the username field begin with 'file:' and it will use the rest of that field as the path to your credentials file. The works both as python runserver.py -u file:somepath/accounts.csv as well as from config.ini. The path can be absolute or relative (to runserver.py).

## Motivation and Context
It is the belief of the author that this is a feature that has been requested and that will be welcomed

## How Has This Been Tested?
Tested with powershell on windows 7. Not tested with unix/linux, it would be nice if someone could test that part. Mostly how the dashes in filename paths work. But I assume that the user can form the filename path to such a string that it works on any system.

## Screenshots (if appropriate):
![readfromfile](https://cloud.githubusercontent.com/assets/5911982/18227275/c5e969ec-7227-11e6-8602-4e31b178f2e8.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
Will update the documentation in a timely manner 

when it is needed and topical.