### PR TITLE
Add hybrid option to map styles

### DIFF
--- a/static/data/mapstyle.json
+++ b/static/data/mapstyle.json
@@ -1,6 +1,7 @@
 {
   "roadmap": "Roadmap",
   "satellite": "Satellite",
+  "hybrid": "Hybrid",
   "nolabels_style": "No Labels",
   "dark_style": "Dark",
   "style_light2": "Light2",

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -865,6 +865,7 @@ function initMap () { // eslint-disable-line no-unused-vars
       mapTypeIds: [
         google.maps.MapTypeId.ROADMAP,
         google.maps.MapTypeId.SATELLITE,
+        google.maps.MapTypeId.HYBRID,
         'nolabels_style',
         'dark_style',
         'style_light2',

--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -274,6 +274,7 @@ function initMap () {
       mapTypeIds: [
         google.maps.MapTypeId.ROADMAP,
         google.maps.MapTypeId.SATELLITE,
+        google.maps.MapTypeId.HYBRID,
         'nolabels_style',
         'dark_style',
         'style_light2',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Simply adds one of the google default map style options to the map styles list.

## Motivation and Context
Hybrid map is awesome for navigating and determining exactly where an off road pokemon is.  It's basically satellite view with street and POI labels.

## How Has This Been Tested?
Ran on my server.

## Screenshots (if appropriate):
![hybrid](https://cloud.githubusercontent.com/assets/20652372/18234508/34bbcde8-72d6-11e6-8e44-099ad8bf4546.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

