### PR TITLE
Add args.optimize_workers: a simple worker minimizer.

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -471,10 +471,10 @@ def start_worker(wh_queue, db_updates_queue, encryption_lib_path, pause_bit, sea
         }
 
         t = Thread(target=search_worker_thread,
-                       name='search-worker-{}'.format(worker_index),
-                       args=(args, account_queue, account_failures, search_items_queue, pause_bit,
-                             encryption_lib_path, threadStatus[workerId],
-                             db_updates_queue, wh_queue))
+                   name='search-worker-{}'.format(worker_index),
+                   args=(args, account_queue, account_failures, search_items_queue, pause_bit,
+                         encryption_lib_path, threadStatus[workerId],
+                         db_updates_queue, wh_queue))
 
         t.daemon = True
         t.start()

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -614,6 +614,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
             status['success'] = 0
             status['noitems'] = 0
             status['skip'] = 0
+            status['starttime'] = 0
 
             while status['stop'] == 1:
                 time.sleep(1)

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -314,7 +314,6 @@ def search_overseer_thread(args, method, new_location_queue, pause_bit, encrypti
     for i in range(0, args.workers):
         start_worker(wh_queue, db_updates_queue, encryption_lib_path, pause_bit, search_items_queue, account_failures, account_queue, threadStatus, args, i)
 
-
     '''
     For hex scanning, we can generate the full list of scan points well
     in advance. When then can queue them all up to be searched as fast
@@ -401,18 +400,23 @@ def search_overseer_thread(args, method, new_location_queue, pause_bit, encrypti
 
                     if args.optimize_workers:
                         if nextitem[2] - now() >= args.scan_delay * 2:
-                            if CCoverseerTime > 0: overseerTime = 0
+                            if overseerTime > 0:
+                                overseerTime = 0
                             overseerTime -= 1
-                        else: overseerTime = 0
+                        else:
+                            overseerTime = 0
                 else:
                     threadStatus['Overseer']['message'] += ' ({}s behind)'.format(now() - nextitem[2])
 
                     if args.optimize_workers:
                         if now() - nextitem[2] >= args.scan_delay * 2:
-                            if overseerTime < 0: overseerTime = 0
+                            if overseerTime < 0:
+                                overseerTime = 0
                             overseerTime += (now() - nextitem[2]) / (args.scan_delay * 2)
-                        elif now() - nextitem[2] <= args.scan_delay: overseerTime -= 1
-                        else: overseerTime = 0
+                        elif now() - nextitem[2] <= args.scan_delay:
+                            overseerTime -= 1
+                        else:
+                            overseerTime = 0
 
                 if args.optimize_workers:
                     if overseerTime >= 60 and account_queue.qsize() > 0:
@@ -463,6 +467,7 @@ def start_worker(wh_queue, db_updates_queue, encryption_lib_path, pause_bit, sea
             'proxy_display': proxy_display,
             'proxy_url': proxy_url,
             'stop': 0,
+            'starttime': 0,
         }
 
         t = Thread(target=search_worker_thread,
@@ -596,6 +601,8 @@ def get_sps_location_list(args, current_location, sps_scan_current):
 def search_worker_thread(args, account_queue, account_failures, search_items_queue, pause_bit, encryption_lib_path, status, dbq, whq):
     log.debug('Search worker thread starting')
 
+    account = []
+
     # The outer forever loop restarts only when the inner one is intentionally exited - which should only be done when the worker is failing too often, and probably banned.
     # This reinitializes the API and grabs a new account from the queue.
     while True:
@@ -646,7 +653,8 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
             while True:
                 if status['stop'] == 1:
                     break
-                else: status['message'] = 'Running...'
+                else:
+                    status['message'] = 'Running...'
 
                 # If this account has been messing up too hard, let it rest
                 if status['fail'] >= args.max_failures:

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -54,6 +54,8 @@ def get_args():
                         help='Passwords, either single one for all accounts or one per account.')
     parser.add_argument('-w', '--workers', type=int,
                         help='Number of search worker threads to start. Defaults to the number of accounts specified.')
+    parser.add_argument('-ow', '--optimize-workers', help='Automatically optimize the number of search worker threads.',
+                        action='store_true', default=False)
     parser.add_argument('-asi', '--account-search-interval', type=int, default=0,
                         help='Seconds for accounts to search before switching to a new account. 0 to disable.')
     parser.add_argument('-ari', '--account-rest-interval', type=int, default=7200,


### PR DESCRIPTION
Introducing a simple, yet effective, worker minimization algorithm.

## Description
Adds, stops or starts workers when required based on scan-delay.

## Motivation and Context
Keeps requests to the server and used accounts at a minimum.
Recycles accounts upon stopping.

## How Has This Been Tested?
Tested and tweaked over the past few days, no accounts have been banned.
With roughly 5000 spawn points spread over town it keeps around 14 accounts active with 10 second scan-delay, it swings between 12 and 18 workers.
No fails or skips.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)