### PR TITLE
A little change to config.ini.example

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -21,7 +21,7 @@
 #step-limit:            # default 12
 #gym-info:              # enables detailed gym info collection (default false)
 #min-seconds-left:      # time that must be left on a spawn before considering it too late and skipping it (default 0)
-#status-name:           # enables writing status updates to the database - if you use multiple processes, each needs a unique value
+#status-name:           # you MUST add a status-name or /status will not show any data - if you use multiple processes, each needs a unique value
 
 # Misc
 #gmaps-key:             # your Google Maps API key


### PR DESCRIPTION
Changed the way #status-name is worded

## Description
When you have multiple accounts in a single process, if you only input -spp, /status screen will not show any workers, so this little change  avoids that.

A better change could be if you input -spp in a process, that process automatically have --status-name Workers, but I'm not that good at coding :(

## Motivation and Context
I had a problem where I had a single process, with -spp but not -sn thinking it wasn't necesary and /status had no data about my workers.

## How Has This Been Tested?
I tested it and worked for me :smile: 

## Types of changes
- [ :heavy_multiplication_x: ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ :heavy_multiplication_x: ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ :heavy_multiplication_x:  ] I have updated the documentation accordingly.