### PR TITLE
Allow only <username>,<password>  or only <username> in -ac CSV

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -204,7 +204,7 @@ def get_args():
                     csv_input.append('<ptc/gmail>,<username>,<password>')
 
                     # If the number of fields is differend this is not a CSV
-                    if num_fields != line.count(',') + 1: 
+                    if num_fields != line.count(',') + 1:
                         print(sys.argv[0] + ": Error parsing CSV file on line " + str(num) + ". Your file started with the following input, '" + csv_input[num_fields] + "' but now you gave us '" + csv_input[line.count(',') + 1] + "'.")
                         sys.exit(1)
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -225,8 +225,8 @@ def get_args():
 
                     # If the number of fields is three then assume this is "ptc,username,password". As requested..
                     if num_fields == 3:
-                        # If field length is not longer then 0 something is wrong!
-                        if len(fields[0]) > 0:
+                        # If field 0 is not ptc or gmail something is wrong!
+                        if fields[0].lower() == 'ptc' or fields[0].lower() == 'gmail':
                             args.auth_service.append(fields[0])
                         else:
                             field_error = True
@@ -245,7 +245,7 @@ def get_args():
 
                         # If something is wrong display error.
                         if field_error:
-                            print(sys.argv[0] + ": Error parsing CSV file on line " + str(num) + ". Lines must be in the format '<method>,<username>,<password>', '<username>,<password>', '<username>'.")
+                            print(sys.argv[0] + ": Error parsing CSV file on line " + str(num) + ". Lines must be in the format '<ptc/gmail>,<username>,<password>', '<username>,<password>', '<username>'.")
                             sys.exit(1)
 
         errors = []

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -189,62 +189,62 @@ def get_args():
             with open(args.accountcsv, 'r') as f:
                 for num, line in enumerate(f, 1):
 
-		    fields = []
+                    fields = []
 
-		    num_fields = line.count(',') + 1
-		    field_error = False
-		    line = line.strip()
+                    num_fields = line.count(',') + 1
+                    field_error = False
+                    line = line.strip()
 
                     # Ignore blank lines and comment lines
                     if len(line) == 0 or line.startswith('#'):
                         continue
 
                     # If number of fields is more than 1 split the line into fields and strip them
-		    if num_fields > 1:
-		        fields = line.split(",")
-			fields = map(str.strip, fields)
+                    if num_fields > 1:
+                        fields = line.split(",")
+                        fields = map(str.strip, fields)
 
-		    # If the number of fields is one then assume this is "username". As requested..
-		    if num_fields == 1:
-			#Empty lines are already ignored.
-			args.username.append(line)
+                    # If the number of fields is one then assume this is "username". As requested..
+                    if num_fields == 1:
+                        #Empty lines are already ignored.
+                        args.username.append(line)
 
-		    # If the number of fields is two then assume this is "username,password". As requested..
-		    if num_fields == 2:
-			# If field length is not longer then 0 something is wrong!
-			if len(fields[0]) > 0:
-			    args.username.append(fields[0])
-			else:
-			    field_error = True
+                    # If the number of fields is two then assume this is "username,password". As requested..
+                    if num_fields == 2:
+                        # If field length is not longer then 0 something is wrong!
+                        if len(fields[0]) > 0:
+                            args.username.append(fields[0])
+                        else:
+                            field_error = True
 
                         # If field length is not longer then 0 something is wrong!
-			if len(fields[1]) > 0:
-			    args.password.append(fields[1])
-			else:
-			    field_error = True
+                        if len(fields[1]) > 0:
+                            args.password.append(fields[1])
+                        else:
+                            field_error = True
 
-		    # If the number of fields is three then assume this is "ptc,username,password". As requested..
-		    if num_fields == 3:
+                    # If the number of fields is three then assume this is "ptc,username,password". As requested..
+                    if num_fields == 3:
                         # If field length is not longer then 0 something is wrong!
-			if len(fields[0]) > 0:
+                        if len(fields[0]) > 0:
                             args.auth_service.append(fields[0])
-			else:
-			    field_error = True
+                        else:
+                            field_error = True
 
                         # If field length is not longer then 0 something is wrong!
-			if len(fields[1]) > 0:
+                        if len(fields[1]) > 0:
                             args.username.append(fields[1])
-			else:
-			    field_error = True
+                        else:
+                            field_error = True
 
                         # If field length is not longer then 0 something is wrong!
-			if len(fields[2]) > 0:
+                        if len(fields[2]) > 0:
                             args.password.append(fields[2])
-			else:
-			    field_error = True
+                        else:
+                            field_error = True
 
-			# If something is wrong display error.
-			if field_error:
+                        # If something is wrong display error.
+                        if field_error:
                             print(sys.argv[0] + ": Error parsing CSV file on line " + str(num) + ". Lines must be in the format '<method>,<username>,<password>', '<username>,<password>', '<username>'.")
                             sys.exit(1)
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -217,7 +217,7 @@ def get_args():
 
 
 
-                    field_error =  ''
+                    field_error = ''
                     line = line.strip()
 
                     # Ignore blank lines and comment lines
@@ -270,7 +270,7 @@ def get_args():
 
                     # If something is wrong display error.
                     if field_error != '':
-			type_error = 'empty!'
+                        type_error = 'empty!'
                         if field_error == 'method':
                             type_error = 'not ptc or gmail instead we got \'' + fields[0] + '\'!'
                         print(sys.argv[0] + ": Error parsing CSV file on line " + str(num) + ". We found " + str(num_fields) + " fields, so your input should have looked like '" + csv_input + "'\nBut you gave us '" + line + "', your " + field_error + " was " + type_error)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -206,7 +206,7 @@ def get_args():
 
                     # If the number of fields is one then assume this is "username". As requested..
                     if num_fields == 1:
-                        #Empty lines are already ignored.
+                        # Empty lines are already ignored.
                         args.username.append(line)
 
                     # If the number of fields is two then assume this is "username,password". As requested..
@@ -247,7 +247,6 @@ def get_args():
                         if field_error:
                             print(sys.argv[0] + ": Error parsing CSV file on line " + str(num) + ". Lines must be in the format '<method>,<username>,<password>', '<username>,<password>', '<username>'.")
                             sys.exit(1)
-
 
         errors = []
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -205,7 +205,7 @@ def get_args():
                     if num_fields == 3:
                         csv_input = '<ptc/gmail>,<username>,<password>'
 
-                    if num_fields != prev_num_fields :
+                    if num_fields != prev_num_fields:
                         if prev_num_fields == 1:
                             prev_csv_input = '<username>'
                         if prev_num_fields == 2:
@@ -214,8 +214,6 @@ def get_args():
                             prev_csv_input = '<ptc/gmail>,<username>,<password>'
                         print(sys.argv[0] + ": Error parsing CSV file on line " + str(num) + ". Your file started with the following input, '" + prev_csv_input + "' but now you gave us '" + csv_input + "'.")
                         sys.exit(1)
-
-
 
                     field_error = ''
                     line = line.strip()

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -186,33 +186,26 @@ def get_args():
         # If using a CSV file, add the data where needed into the username,password and auth_service arguments.
         # CSV file should have lines like "ptc,username,password", "username,password" or "username".
         if args.accountcsv is not None:
+            # Giving num_fields something it would usually not get
             num_fields = -1
             with open(args.accountcsv, 'r') as f:
                 for num, line in enumerate(f, 1):
 
                     fields = []
+
+                    # First time around populate num_fields with current field count.
                     if num_fields < 0:
-                        prev_num_fields = line.count(',') + 1
-                    else:
-                        prev_num_fields = num_fields
+                        num_fields = line.count(',') + 1
 
-                    num_fields = line.count(',') + 1
+                    csv_input = []
+                    csv_input.append('')
+                    csv_input.append('<username>')
+                    csv_input.append('<username>,<password>')
+                    csv_input.append('<ptc/gmail>,<username>,<password>')
 
-                    if num_fields == 1:
-                        csv_input = '<username>'
-                    if num_fields == 2:
-                        csv_input = '<username>,<password>'
-                    if num_fields == 3:
-                        csv_input = '<ptc/gmail>,<username>,<password>'
-
-                    if num_fields != prev_num_fields:
-                        if prev_num_fields == 1:
-                            prev_csv_input = '<username>'
-                        if prev_num_fields == 2:
-                            prev_csv_input = '<username>,<password>'
-                        if prev_num_fields == 3:
-                            prev_csv_input = '<ptc/gmail>,<username>,<password>'
-                        print(sys.argv[0] + ": Error parsing CSV file on line " + str(num) + ". Your file started with the following input, '" + prev_csv_input + "' but now you gave us '" + csv_input + "'.")
+                    # If the number of fields is differend this is not a CSV
+                    if num_fields != line.count(',') + 1: 
+                        print(sys.argv[0] + ": Error parsing CSV file on line " + str(num) + ". Your file started with the following input, '" + csv_input[num_fields] + "' but now you gave us '" + csv_input[line.count(',') + 1] + "'.")
                         sys.exit(1)
 
                     field_error = ''
@@ -271,7 +264,7 @@ def get_args():
                         type_error = 'empty!'
                         if field_error == 'method':
                             type_error = 'not ptc or gmail instead we got \'' + fields[0] + '\'!'
-                        print(sys.argv[0] + ": Error parsing CSV file on line " + str(num) + ". We found " + str(num_fields) + " fields, so your input should have looked like '" + csv_input + "'\nBut you gave us '" + line + "', your " + field_error + " was " + type_error)
+                        print(sys.argv[0] + ": Error parsing CSV file on line " + str(num) + ". We found " + str(num_fields) + " fields, so your input should have looked like '" + csv_input[num_fields] + "'\nBut you gave us '" + line + "', your " + field_error + " was " + type_error)
                         sys.exit(1)
 
         errors = []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
As long as auth-service has been defined once (or defaults to PTC) this allows for only specifying username and password in CSV.

Also allows for only specifying 'username' in CSV if password is specified once. (either in config.ini or -p)


Also slightly changed error handling to account for 2/3 fields and optimized code.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
1. When using only PTC accounts this would not need to be specified in the CSV.
2. When using same password for all accounts this allows for only specifying a list of usernames and specify password only once (in config.ini or with -p ).


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

