### PR TITLE
Wider nav panel for smaller screens

### DIFF
--- a/static/sass/layout/_nav.scss
+++ b/static/sass/layout/_nav.scss
@@ -16,7 +16,7 @@
     top: 3.50em;
     left: 0;
     visibility: hidden;
-    width: 18em;
+    width: 20.50em;
     z-index: 500;
     h3 {
       font-size: 18px;

--- a/static/sass/layout/_nav.scss
+++ b/static/sass/layout/_nav.scss
@@ -1,7 +1,7 @@
 /* Nav */
 
   #nav {
-    @include vendor('transform', 'translateX(-18em)');
+    @include vendor('transform', 'translateX(-20.50em)');
     @include vendor('transition', ('transform #{_duration(nav)} ease', 'box-shadow #{_duration(nav)} ease', 'visibility #{_duration(nav)}'));
     -webkit-overflow-scrolling: touch;
     background: #F8F8F8;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changed with of nav panel from 18em to 20.50em - just that :)

## Motivation and Context
After changed title of location panel to "Location & Search Settings" - on smaller screens (like 1280x768) and mobile it was wrapped and takes too much space on screen - bigger scroll area...

## How Has This Been Tested?
On my chrome browser and android mobile phone

## Screenshots (if appropriate):
Before:
![18em](https://cloud.githubusercontent.com/assets/20594810/18321693/6417c9ec-752f-11e6-8641-43df3e0c8018.png)


After:
![20 05em](https://cloud.githubusercontent.com/assets/20594810/18321699/67d33df0-752f-11e6-8bc8-c5c8efc02ba2.png)


On mobile:
![img_20160907_190515](https://cloud.githubusercontent.com/assets/20594810/18321703/6a41807e-752f-11e6-986c-0848015b8594.jpg)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

