### PR TITLE
Fix math domain error in the spawnpoint clustering script

### DIFF
--- a/Tools/Spawnpoint-Clustering/utils.py
+++ b/Tools/Spawnpoint-Clustering/utils.py
@@ -11,7 +11,12 @@ def distance(pos1, pos2):
     lat2 = radians(pos2[0])
     lon2 = radians(pos2[1])
     
-    return acos(sin(lat1)*sin(lat2) + cos(lat1)*cos(lat2) * cos(lon2-lon1)) * R
+    a = sin(lat1)*sin(lat2) + cos(lat1)*cos(lat2) * cos(lon2-lon1)
+    
+    if a > 1:
+        return 0.0
+    
+    return acos(a) * R
     
 def intermediate_point(pos1, pos2, f):
     if pos1 == pos2:
@@ -22,7 +27,12 @@ def intermediate_point(pos1, pos2, f):
     lat2 = radians(pos2[0])
     lon2 = radians(pos2[1])
     
-    delta = acos(sin(lat1)*sin(lat2) + cos(lat1)*cos(lat2) * cos(lon2-lon1))
+    a = sin(lat1)*sin(lat2) + cos(lat1)*cos(lat2) * cos(lon2-lon1)
+    
+    if a > 1: # too close
+        return pos1 if f < 0.5 else pos2
+    
+    delta = acos(a)
     
     if delta == 0: # too close
         return pos1 if f < 0.5 else pos2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds a check to prevent us from calculating `acos` of something greater than 1.

## Motivation and Context
Fixes an issue that can very occasionally occur when we're calculating the distance between points `a` and `b` and `a != b`, but `radians(a) == radians(b)` due to floating point accuracy problems.

## How Has This Been Tested?
User @Obihoernchen in #990 tested it and it fixes the issue.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.