### PR TITLE
Wrap "expire lures on Pstops during db cleanup" with a "do we parse Pstops" check

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -886,10 +886,11 @@ def clean_db_loop(args):
             query.execute()
 
             # Remove active modifier from expired lured pokestops
-            query = (Pokestop
-                     .update(lure_expiration=None)
-                     .where(Pokestop.lure_expiration < datetime.utcnow()))
-            query.execute()
+            if config['parse_pokestops']:
+                query = (Pokestop
+                         .update(lure_expiration=None)
+                         .where(Pokestop.lure_expiration < datetime.utcnow()))
+                query.execute()
 
             # If desired, clear old pokemon spawns
             if args.purge_data > 0:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If we don't parse pokestops, then we don't need to expire old lures. Simple as that.

## Motivation and Context
Why it bothers me? I have a huge db of pokestops (and gyms) and sadly this query runs too many times and produces no meaningful results, because they all are already lure-expired...

## How Has This Been Tested?
It wasn't tested. Travis to the rescue! ;)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.