### PR TITLE
Support loading proxies from file

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -28,6 +28,7 @@
 #proxy:                 # Proxy URL e.g. socks5://127.0.0.1:9050 or a list of proxies e.g. [socks5://127.0.0.1:9050,socks5://127.0.0.1:9050]
 #proxy-timeout:         # Timeout before proceeding with next proxy while checking if the proxy works, (default 5)
 #proxy-display:         # Used with -ps, full = display complete proxy address. Index = displays just the index for that proxy (default index)
+#proxyfile:             # Load proxy list from text file (one proxy per line), overrides -px/--proxy
 #webhook:               # webhook URL (including http://)
 #webhook-updates-only:  # only send updates to webhooks, (excludes gyms & non-lured pokéstops)
 

--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 
 # Simple function to do a call to Niantic's system for testing proxy connectivity
-def check_proxy(proxy_queue, timeout, proxies):
+def check_proxy(proxy_queue, timeout, proxies, show_warnings):
 
     proxy_test_url = 'https://sso.pokemon.com/'
     proxy = proxy_queue.get()
@@ -45,7 +45,11 @@ def check_proxy(proxy_queue, timeout, proxies):
     else:
             proxy_error = "Empty proxy server"
 
-    log.warning('%s', proxy_error)
+    # Decrease output amount if there are lot of proxies
+    if (show_warnings == True):
+        log.warning('%s', proxy_error)
+    else:
+        log.debug('%s', proxy_error)
     proxy_queue.task_done()
 
     return False
@@ -54,10 +58,41 @@ def check_proxy(proxy_queue, timeout, proxies):
 # Check all proxies and return a working list with proxies
 def check_proxies(args):
 
+    #Load proxies from the file. Override args.proxy if specified
+    if args.proxyfile is not None:
+        log.info('Loading proxies from file.')
+
+        if args.proxy is not None:
+            del args.proxy[:]
+        else:
+            args.proxy = []
+
+        with open(args.proxyfile) as f:
+            for line in f:
+                # Ignore blank lines and comment lines
+                if len(line.strip()) == 0 or line.startswith('#'):
+                    continue
+                #print(line.strip())
+                args.proxy.append(line.strip())
+
+        log.info('Loaded %d proxies.', len(args.proxy))
+
+	if len(args.proxy)==0:
+            log.error('Proxy file was configured but no proxies were loaded! We are aborting!')
+            sys.exit(1)
+    #print(args.proxy)
+ 
+    # No proxies - no cookies
+    if (args.proxy is None) or (len(args.proxy)==0):
+        log.info('No proxies are configured.')
+        return None
+
     proxy_queue = Queue()
     total_proxies = len(args.proxy)
-
+    
     log.info('Checking %d proxies...', total_proxies)
+    if (total_proxies > 10):
+        log.info('Enable "-d/--debug" to see checking details.')
 
     proxies = []
 
@@ -66,7 +101,7 @@ def check_proxies(args):
 
         t = Thread(target=check_proxy,
                    name='check_proxy',
-                   args=(proxy_queue, args.proxy_timeout, proxies))
+                   args=(proxy_queue, args.proxy_timeout, proxies, total_proxies <= 10))
         t.daemon = True
         t.start()
 
@@ -76,7 +111,7 @@ def check_proxies(args):
     working_proxies = len(proxies)
 
     if working_proxies == 0:
-        log.error('Proxy was configured but no working proxies was found! We are aborting!')
+        log.error('Proxy was configured but no working proxies were found! We are aborting!')
         sys.exit(1)
     else:
         log.info('Proxy check completed with %d working proxies of %d configured', working_proxies, total_proxies)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -141,6 +141,7 @@ def get_args():
     parser.add_argument('-px', '--proxy', help='Proxy url (e.g. socks5://127.0.0.1:9050)', action='append')
     parser.add_argument('-pxt', '--proxy-timeout', help='Timeout settings for proxy checker in seconds ', type=int, default=5)
     parser.add_argument('-pxd', '--proxy-display', help='Display info on which proxy beeing used (index or full) To be used with -ps', type=str, default='index')
+    parser.add_argument('-pxf', '--proxyfile', help='Load proxy list from text file (one proxy per line), overrides -px/--proxy')
     parser.add_argument('--db-type', help='Type of database to be used (default: sqlite)',
                         default='sqlite')
     parser.add_argument('--db-name', help='Name of the database to be used')

--- a/runserver.py
+++ b/runserver.py
@@ -198,11 +198,8 @@ def main():
 
     if not args.only_server:
 
-        # Check all proxies before continue so we know they are good
-        if args.proxy:
-
-            # Overwrite old args.proxy with new working list
-            args.proxy = check_proxies(args)
+        # Processing proxies if set (load from file, check and overwrite old args.proxy with new working list)
+        args.proxy = check_proxies(args)
 
         # Gather the pokemons!
 


### PR DESCRIPTION
Allows defining proxyfile with the list of proxies (cli or config).
Disable proxy check result output if more the 10 proxies configured.
Move all proxy checking from 'runserver.py' to 'proxy.py'.