### PR TITLE
Scanning of Pokestop Name, Image, Desc

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -855,7 +855,7 @@ def parse_pokestops(args, pokestop_responses):
 
     for p in pokestop_responses.values():
         p_id = p['fort_id']
-        p_img = p['image_urls'][0].replace('http://','').replace('https://', '')
+        p_img = p['image_urls'][0].replace('http://', '').replace('https://', '')
         pokestop_infos[p_id] = {
             'pokestop_id': p_id,
             'name': p['name'],
@@ -866,7 +866,7 @@ def parse_pokestops(args, pokestop_responses):
 
     if len(pokestop_infos):
         bulk_upsert(PokestopDetails, pokestop_infos)
-        
+
     log.info('Upserted %d pokestop infos',
              len(pokestop_infos))
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -855,11 +855,12 @@ def parse_pokestops(args, pokestop_responses):
 
     for p in pokestop_responses.values():
         p_id = p['fort_id']
+        p_img = p['image_urls'][0].replace('http://','').replace('https://', '')
         pokestop_infos[p_id] = {
             'pokestop_id': p_id,
             'name': p['name'],
             'description': p.get('description'),
-            'image_url': p['image_urls'][0],
+            'image_url': p_img,
             'last_scanned': datetime.utcnow()
         }
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -9,7 +9,7 @@ import time
 import geopy
 from peewee import SqliteDatabase, InsertQuery, \
     IntegerField, CharField, DoubleField, BooleanField, \
-    DateTimeField, fn, DeleteQuery, CompositeKey, FloatField, SQL, TextField
+    DateTimeField, fn, DeleteQuery, CompositeKey, FloatField, SQL, TextField, JOIN
 from playhouse.flask_utils import FlaskDB
 from playhouse.pool import PooledMySQLDatabase
 from playhouse.shortcuts import RetryOperationalError
@@ -30,7 +30,7 @@ args = get_args()
 flaskDb = FlaskDB()
 cache = TTLCache(maxsize=100, ttl=60 * 5)
 
-db_schema_version = 7
+db_schema_version = 8
 
 
 class MyRetryDB(RetryOperationalError, PooledMySQLDatabase):
@@ -346,11 +346,15 @@ class Pokestop(BaseModel):
     def get_stops(swLat, swLng, neLat, neLng):
         if swLat is None or swLng is None or neLat is None or neLng is None:
             query = (Pokestop
-                     .select()
+                     .select(Pokestop.pokestop_id, Pokestop.enabled, Pokestop.latitude, Pokestop.longitude, Pokestop.last_modified, Pokestop.lure_expiration,
+                             Pokestop.active_fort_modifier, PokestopDetails.name, PokestopDetails.description, PokestopDetails.image_url)
+                     .join(PokestopDetails, JOIN.LEFT_OUTER, on=(PokestopDetails.pokestop_id == Pokestop.pokestop_id))
                      .dicts())
         else:
             query = (Pokestop
-                     .select()
+                     .select(Pokestop.pokestop_id, Pokestop.enabled, Pokestop.latitude, Pokestop.longitude, Pokestop.last_modified, Pokestop.lure_expiration,
+                             Pokestop.active_fort_modifier, PokestopDetails.name, PokestopDetails.description, PokestopDetails.image_url)
+                     .join(PokestopDetails, JOIN.LEFT_OUTER, on=(PokestopDetails.pokestop_id == Pokestop.pokestop_id))
                      .where((Pokestop.latitude >= swLat) &
                             (Pokestop.longitude >= swLng) &
                             (Pokestop.latitude <= neLat) &
@@ -563,6 +567,14 @@ class GymDetails(BaseModel):
     last_scanned = DateTimeField(default=datetime.utcnow)
 
 
+class PokestopDetails(BaseModel):
+    pokestop_id = CharField(primary_key=True, index=True, max_length=50)
+    name = CharField()
+    description = TextField(null=True, default="")
+    image_url = TextField(null=True, default="")
+    last_scanned = DateTimeField(default=datetime.utcnow)
+
+
 def hex_bounds(center, steps):
     # Make a box that is (70m * step_limit * 2) + 70m away from the center point
     # Rationale is that you need to travel
@@ -715,6 +727,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue):
     return {
         'count': len(pokemons) + len(pokestops) + len(gyms),
         'gyms': gyms,
+        'pokestops': pokestops
     }
 
 
@@ -837,6 +850,26 @@ def parse_gyms(args, gym_responses, wh_update_queue):
              len(gym_members))
 
 
+def parse_pokestops(args, pokestop_responses):
+    pokestop_infos = {}
+
+    for p in pokestop_responses.values():
+        p_id = p['fort_id']
+        pokestop_infos[p_id] = {
+            'pokestop_id': p_id,
+            'name': p['name'],
+            'description': p.get('description'),
+            'image_url': p['image_urls'][0],
+            'last_scanned': datetime.utcnow()
+        }
+
+    if len(pokestop_infos):
+        bulk_upsert(PokestopDetails, pokestop_infos)
+        
+    log.info('Upserted %d pokestop infos',
+             len(pokestop_infos))
+
+
 def db_updater(args, q):
     # The forever loop
     while True:
@@ -925,13 +958,13 @@ def bulk_upsert(cls, data):
 def create_tables(db):
     db.connect()
     verify_database_schema(db)
-    db.create_tables([Pokemon, Pokestop, Gym, ScannedLocation, GymDetails, GymMember, GymPokemon, Trainer, MainWorker, WorkerStatus], safe=True)
+    db.create_tables([Pokemon, Pokestop, PokestopDetails, Gym, ScannedLocation, GymDetails, GymMember, GymPokemon, Trainer, MainWorker, WorkerStatus], safe=True)
     db.close()
 
 
 def drop_tables(db):
     db.connect()
-    db.drop_tables([Pokemon, Pokestop, Gym, ScannedLocation, Versions, GymDetails, GymMember, GymPokemon, Trainer, MainWorker, WorkerStatus, Versions], safe=True)
+    db.drop_tables([Pokemon, Pokestop, PokestopDetails, Gym, ScannedLocation, Versions, GymDetails, GymMember, GymPokemon, Trainer, MainWorker, WorkerStatus, Versions], safe=True)
     db.close()
 
 
@@ -1010,3 +1043,6 @@ def database_migrate(db, old_ver):
             migrator.drop_column('gymdetails', 'description'),
             migrator.add_column('gymdetails', 'description', TextField(null=True, default=""))
         )
+
+    if old_ver < 8:
+        db.create_tables([PokestopDetails], safe=True)

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -574,7 +574,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                             record = PokestopDetails.get(pokestop_id=pokestop['pokestop_id'])
 
                             if args.pokestop_info_expire and args.pokestop_info_expire > 0:
-                                if (datetime.utcnow() + timedelta(minutes = args.pokestop_info_expire)) > record.last_scanned:
+                                if (datetime.utcnow() + timedelta(minutes=args.pokestop_info_expire)) > record.last_scanned:
                                     pokestops_to_update[pokestop['pokestop_id']] = pokestop
                                     continue
                         except PokestopDetails.DoesNotExist as e:

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -156,6 +156,10 @@ def get_args():
                         nargs='*', default=False, dest='webhooks')
     parser.add_argument('-gi', '--gym-info', help='Get all details about gyms (causes an additional API hit for every gym)',
                         action='store_true', default=False)
+    parser.add_argument('-pi', '--pokestop-info', help='Get all details about pokestops (name, image, description) (causes an additional API hit for every gym)',
+                        action='store_true', default=False)
+    parser.add_argument('-pie', '--pokestop-info-expire', help='Expiry time for pokestop infos. Will request new info if we see that stop after that time. (in minutes, 0=disabled))',
+                        type=int, default=0)
     parser.add_argument('--webhook-updates-only', help='Only send updates (pokémon & lured pokéstops)',
                         action='store_true', default=False)
     parser.add_argument('--wh-threads', help='Number of webhook threads; increase if the webhook queue falls behind',

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -433,8 +433,8 @@ function pokestopLabel (item) {
   if (typeof item.name !== 'undefined' && item.name !== null) {
     pkstpinfo += '<br><b>' + item.name + '</b>'
     if (typeof item.image_url !== 'undefined' && item.image_url !== null) {
-       pkstpinfo += '<br><img width=100 height=100 src="//' + item.image_url + '"/>'
-   }
+      pkstpinfo += '<br><img width=100 height=100 src="//' + item.image_url + '"/>'
+    }
   }
 
   if (item.expireTime) {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -433,7 +433,7 @@ function pokestopLabel (item) {
   if (typeof item.name !== 'undefined' && item.name !== null) {
     pkstpinfo += '<br><b>' + item.name + '</b>'
     if (typeof item.image_url !== 'undefined' && item.image_url !== null) {
-      pkstpinfo += '<br><img width=100 height=100 src="//' + item.image_url + '"/>'
+       pkstpinfo += '<br><img width=100 height=100 src="//' + item.image_url + '"/>'
    }
   }
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -433,7 +433,7 @@ function pokestopLabel (item) {
   if (typeof item.name !== 'undefined' && item.name !== null) {
     pkstpinfo += '<br><b>' + item.name + '</b>'
     if (typeof item.image_url !== 'undefined' && item.image_url !== null) {
-      pkstpinfo += '<br><img width=100 height=100 src="' + item.image_url + '"/>'
+      pkstpinfo += '<br><img width=100 height=100 src="//' + item.image_url + '"/>'
    }
   }
 
@@ -443,6 +443,7 @@ function pokestopLabel (item) {
     str = `
       <div style="text-align: center;">
         <b>Lured Pokéstop</b>
+        ${pkstpinfo}
       </div>
       <div>
         Lure expires at ${pad(expireDate.getHours())}:${pad(expireDate.getMinutes())}:${pad(expireDate.getSeconds())}
@@ -458,6 +459,7 @@ function pokestopLabel (item) {
     str = `
       <div style="text-align: center;">
         <b>Pokéstop</b>
+        ${pkstpinfo}
       </div>
       <div>
         Location: ${item.latitude.toFixed(6)}, ${item.longitude.toFixed(7)}

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -425,35 +425,45 @@ function gymLabel (teamName, teamId, gymPoints, latitude, longitude, lastScanned
   return str
 }
 
-function pokestopLabel (expireTime, latitude, longitude) {
+function pokestopLabel (item) {
   var str
-  if (expireTime) {
-    var expireDate = new Date(expireTime)
+
+  var pkstpinfo = ''
+
+  if (typeof item.name !== 'undefined' && item.name !== null) {
+    pkstpinfo += '<br><b>' + item.name + '</b>'
+    if (typeof item.image_url !== 'undefined' && item.image_url !== null) {
+      pkstpinfo += '<br><img width=100 height=100 src="' + item.image_url + '"/>'
+   }
+  }
+
+  if (item.expireTime) {
+    var expireDate = new Date(item.expireTime)
 
     str = `
-      <div>
+      <div style="text-align: center;">
         <b>Lured Pokéstop</b>
       </div>
       <div>
         Lure expires at ${pad(expireDate.getHours())}:${pad(expireDate.getMinutes())}:${pad(expireDate.getSeconds())}
-        <span class='label-countdown' disappears-at='${expireTime}'>(00m00s)</span>
+        <span class='label-countdown' disappears-at='${item.expireTime}'>(00m00s)</span>
       </div>
       <div>
-        Location: ${latitude.toFixed(6)}, ${longitude.toFixed(7)}
+        Location: ${item.latitude.toFixed(6)}, ${item.longitude.toFixed(7)}
       </div>
       <div>
-        <a href='javascript:void(0);' onclick='javascript:openMapDirections(${latitude},${longitude});' title='View in Maps'>Get directions</a>
+        <a href='javascript:void(0);' onclick='javascript:openMapDirections(${item.latitude},${item.longitude});' title='View in Maps'>Get directions</a>
       </div>`
   } else {
     str = `
-      <div>
+      <div style="text-align: center;">
         <b>Pokéstop</b>
       </div>
       <div>
-        Location: ${latitude.toFixed(6)}, ${longitude.toFixed(7)}
+        Location: ${item.latitude.toFixed(6)}, ${item.longitude.toFixed(7)}
       </div>
       <div>
-        <a href='javascript:void(0);' onclick='javascript:openMapDirections(${latitude},${longitude});' title='View in Maps'>Get directions</a>
+        <a href='javascript:void(0);' onclick='javascript:openMapDirections(${item.latitude},${item.longitude});' title='View in Maps'>Get directions</a>
       </div>`
   }
 
@@ -606,7 +616,7 @@ function setupPokestopMarker (item) {
   }
 
   marker.infoWindow = new google.maps.InfoWindow({
-    content: pokestopLabel(item['lure_expiration'], item['latitude'], item['longitude']),
+    content: pokestopLabel(item),
     disableAutoPan: true
   })
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Implemented scanning of pokestop details just like -gi does, every time a scanner parses a pokestop, it looks in the db of information is missing and gets them.
With the -pi switch you can enable Pokestop details scanning, with the -pie you can set the expire time (the time it gets rescanned) in minutes. (Does a pokestop even change?)


## Motivation and Context
I have a really bad orientation, so I wanted to see the Images of Pokestops.
Also people tend to say "hey, Pokestop is lured!" not "Hey Pokestop at [lat, lng] is Lured!"

## How Has This Been Tested?
tested all features on my ded. server

## Screenshots (if appropriate):
![pokestop](https://cloud.githubusercontent.com/assets/703451/18403154/7f3ac408-76e3-11e6-8e3b-fa6d1622f581.PNG)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

