### PR TITLE
Introducing single-user: search mode (aka Scheduler) and step limit via frontend + speed limit

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -22,6 +22,8 @@
 #gym-info:              # enables detailed gym info collection (default false)
 #min-seconds-left:      # time that must be left on a spawn before considering it too late and skipping it (default 0)
 #status-name:           # enables writing status updates to the database - if you use multiple processes, each needs a unique value
+#speed-limit:           # if next scan would cause the account to move above specified speed in kmph in a straight line, sleep until such time that it could reasonably move that distance
+#max-speed-limit-sleep: # maximum time in seconds to sleep when trying to stay under the speed limit
 
 # Misc
 #gmaps-key:             # your Google Maps API key

--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -24,6 +24,7 @@
 #status-name:           # enables writing status updates to the database - if you use multiple processes, each needs a unique value
 #speed-limit:           # if next scan would cause the account to move above specified speed in kmph in a straight line, sleep until such time that it could reasonably move that distance
 #max-speed-limit-sleep: # maximum time in seconds to sleep when trying to stay under the speed limit
+#single-user-control:   # enables controlling search params for individual use
 
 # Misc
 #gmaps-key:             # your Google Maps API key

--- a/pogom/__init__.py
+++ b/pogom/__init__.py
@@ -6,5 +6,6 @@ config = {
     'LOCALES_DIR': 'static/dist/locales',
     'ROOT_PATH': '',
     'DATA_DIR': 'static/dist/data',
-    'GMAPS_KEY': None
+    'GMAPS_KEY': None,
+    'SCHEDULER': ''
 }

--- a/pogom/__init__.py
+++ b/pogom/__init__.py
@@ -7,5 +7,6 @@ config = {
     'ROOT_PATH': '',
     'DATA_DIR': 'static/dist/data',
     'GMAPS_KEY': None,
+    'STEP_LIMIT': 12,
     'SCHEDULER': ''
 }

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -70,8 +70,8 @@ class Pogom(Flask):
 
     def post_search_mode(self):
         args = get_args()
-        if args.fixed_location:
-            return 'Fixed location is enabled', 403
+        if args.fixed_location or not args.search_mode_control:
+            return 'Search mode control is disabled', 403
         if request.args:
             mode = request.args.get('mode', 'none')
             if mode in ['HexSearch', 'HexSearchSpawnpoint', 'SpawnScan']:

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -54,7 +54,7 @@ class Pogom(Flask):
 
     def post_search_control(self):
         args = get_args()
-        if not args.search_control:
+        if not args.single_user_control:
             return 'Search control is disabled', 403
         action = request.args.get('action', 'none')
         if action == 'on':
@@ -107,7 +107,6 @@ class Pogom(Flask):
     def fullmap(self):
         args = get_args()
         fixed_display = "none" if args.fixed_location else "inline"
-        search_display = "inline" if args.search_control else "none"
         su_control_display = "inline" if args.single_user_control else "none"
 
         return render_template('map.html',
@@ -116,7 +115,6 @@ class Pogom(Flask):
                                gmaps_key=config['GMAPS_KEY'],
                                lang=config['LOCALE'],
                                is_fixed=fixed_display,
-                               search_control=search_display,
                                su_control=su_control_display
                                )
 

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -217,7 +217,7 @@ class HexSearch(BaseScheduler):
 class HexSearchSpawnpoint(HexSearch):
 
     def _any_spawnpoints_in_range(self, coords, spawnpoints):
-        return any(geopy.distance.distance(coords, x).meters <= 70 for x in spawnpoints)
+        return any(geopy.distance.great_circle(coords, x).meters <= 70 for x in spawnpoints)
 
     # Extend the generate_locations function to remove locations with no spawnpoints
     def _generate_locations(self):
@@ -256,7 +256,7 @@ class SpawnScan(BaseScheduler):
     # Generate locations is called when the locations list is cleared - the first time it scans or after a location change.
     def _generate_locations(self):
         # Attempt to load spawns from file
-        if self.args.spawnpoint_scanning != 'nofile':
+        if self.args.spawnpoint_scanning and self.args.spawnpoint_scanning != 'nofile':
             log.debug('Loading spawn points from json file @ %s', self.args.spawnpoint_scanning)
             try:
                 with open(self.args.spawnpoint_scanning) as file:

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -107,6 +107,9 @@ def get_args():
     parser.add_argument('-nsc', '--no-search-control',
                         help='Disables search control',
                         action='store_false', dest='search_control', default=True)
+    parser.add_argument('-nsm','--no-search-mode',
+                        help='Disables search mode control',
+                        action='store_false', dest='search_mode_control', default=True)
     parser.add_argument('-fl', '--fixed-location',
                         help='Hides the search bar for use in shared maps.',
                         action='store_true', default=False)
@@ -169,6 +172,12 @@ def get_args():
     parser.add_argument('-spp', '--status-page-password', default=None,
                         help='Set the status page password')
     parser.add_argument('-el', '--encrypt-lib', help='Path to encrypt lib to be used instead of the shipped ones')
+    parser.add_argument('-sl', '--speed-limit',
+                        help='If next scan would cause the account to move above specified speed in kmph in a straight line, sleep until such time that it could reasonably move that distance',
+                        type=float, default=0)
+    parser.add_argument('-msls', '--max-speed-limit-sleep',
+                        help='Maximum time in seconds to sleep when trying to stay under the speed limit',
+                        type=float, default=0)
     verbosity = parser.add_mutually_exclusive_group()
     verbosity.add_argument('-v', '--verbose', help='Show debug messages from PomemonGo-Map and pgoapi. Optionally specify file to log to.', nargs='?', const='nofile', default=False, metavar='filename.log')
     verbosity.add_argument('-vv', '--very-verbose', help='Like verbose, but show debug messages from all modules as well.  Optionally specify file to log to.', nargs='?', const='nofile', default=False, metavar='filename.log')
@@ -278,11 +287,11 @@ def get_args():
 
         # Decide which scanning mode to use
         if args.spawnpoint_scanning:
-            args.scheduler = 'SpawnScan'
+            config['SCHEDULER'] = 'SpawnScan'
         elif args.spawnpoints_only:
-            args.scheduler = 'HexSearchSpawnpoint'
+            config['SCHEDULER'] = 'HexSearchSpawnpoint'
         else:
-            args.scheduler = 'HexSearch'
+            config['SCHEDULER'] = 'HexSearch'
 
     return args
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -107,7 +107,7 @@ def get_args():
     parser.add_argument('-nsc', '--no-search-control',
                         help='Disables search control',
                         action='store_false', dest='search_control', default=True)
-    parser.add_argument('-nsm','--no-search-mode',
+    parser.add_argument('-nsm', '--no-search-mode',
                         help='Disables search mode control',
                         action='store_false', dest='search_mode_control', default=True)
     parser.add_argument('-fl', '--fixed-location',

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -104,9 +104,6 @@ def get_args():
     parser.add_argument('-os', '--only-server',
                         help='Server-Only Mode. Starts only the Webserver without the searcher.',
                         action='store_true', default=False)
-    parser.add_argument('-nsc', '--no-search-control',
-                        help='Disables search control',
-                        action='store_false', dest='search_control', default=True)
     parser.add_argument('-su', '--single-user-control',
                         help='Enables controlling search params for individual use',
                         action='store_true', dest='single_user_control', default=False)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -107,9 +107,9 @@ def get_args():
     parser.add_argument('-nsc', '--no-search-control',
                         help='Disables search control',
                         action='store_false', dest='search_control', default=True)
-    parser.add_argument('-nsm', '--no-search-mode',
-                        help='Disables search mode control',
-                        action='store_false', dest='search_mode_control', default=True)
+    parser.add_argument('-su', '--single-user-control',
+                        help='Enables controlling search params for individual use',
+                        action='store_true', dest='single_user_control', default=False)
     parser.add_argument('-fl', '--fixed-location',
                         help='Hides the search bar for use in shared maps.',
                         action='store_true', default=False)

--- a/runserver.py
+++ b/runserver.py
@@ -185,6 +185,7 @@ def main():
     if args.no_gyms:
         log.info('Parsing of Gyms disabled')
 
+    config['STEP_LIMIT'] = args.step_limit
     config['LOCALE'] = args.locale
     config['CHINA'] = args.china
 

--- a/runserver.py
+++ b/runserver.py
@@ -253,7 +253,7 @@ def main():
 
         argset = (args, new_location_queue, pause_bit, encryption_lib_path, db_updates_queue, wh_updates_queue)
 
-        log.debug('Starting a %s search thread', args.scheduler)
+        log.debug('Starting a %s search thread', config['SCHEDULER'])
         search_thread = Thread(target=search_overseer_thread, name='search-overseer', args=argset)
         search_thread.daemon = True
         search_thread.start()

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -11,6 +11,7 @@ var $selectIconSize
 var $selectLuredPokestopsOnly
 var $selectSearchIconMarker
 var $selectLocationIconMarker
+var $selectSearchMode
 
 var language = document.documentElement.lang === '' ? 'en' : document.documentElement.lang
 var idToPokemon = {}
@@ -254,6 +255,16 @@ function updateSearchStatus () {
   })
 }
 
+var searchModeURI = 'search_mode'
+function searchModeSet (mode) {
+  $.post(searchModeURI + '?mode=' + encodeURIComponent(mode))
+}
+function updateSearchMode () {
+  $.getJSON(searchModeURI).then(function (data) {
+    $('#search-mode').val(data.mode).change()
+  })
+}
+
 function initSidebar () {
   $('#gyms-switch').prop('checked', Store.get('showGyms'))
   $('#pokemon-switch').prop('checked', Store.get('showPokemon'))
@@ -273,6 +284,9 @@ function initSidebar () {
 
   updateSearchStatus()
   setInterval(updateSearchStatus, 5000)
+
+  updateSearchMode()
+  setInterval(updateSearchMode, 5000)
 
   searchBox.addListener('places_changed', function () {
     var places = searchBox.getPlaces()
@@ -1306,6 +1320,13 @@ $(function () {
     updateMap()
   })
 
+  $selectSearchMode = $('#search-mode')
+
+  $selectSearchMode.select2({
+    placeholder: 'Select Search Mode',
+    minimumResultsForSearch: Infinity
+  })
+
   $selectSearchIconMarker = $('#iconmarker-style')
   $selectLocationIconMarker = $('#locationmarker-style')
 
@@ -1534,6 +1555,10 @@ $(function () {
 
   $('#search-switch').change(function () {
     searchControl(this.checked ? 'on' : 'off')
+  })
+
+  $('#search-mode').change(function () {
+    searchModeSet(this.value)
   })
 
   $('#start-at-user-location-switch').change(function () {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -255,6 +255,16 @@ function updateSearchStatus () {
   })
 }
 
+var stepLimitURI = 'step_limit'
+function changeStepLimit (value) {
+  $.post(stepLimitURI + '?limit=' + encodeURIComponent(value))
+}
+function updateStepLimit () {
+  $.getJSON(stepLimitURI).then(function (data) {
+    $('#step-limit').prop('value', data.limit)
+  })
+}
+
 var searchModeURI = 'search_mode'
 function searchModeSet (mode) {
   $.post(searchModeURI + '?mode=' + encodeURIComponent(mode))
@@ -284,6 +294,9 @@ function initSidebar () {
 
   updateSearchStatus()
   setInterval(updateSearchStatus, 5000)
+
+  updateStepLimit()
+  setInterval(updateStepLimit, 5000)
 
   updateSearchMode()
   setInterval(updateSearchMode, 5000)
@@ -1555,6 +1568,10 @@ $(function () {
 
   $('#search-switch').change(function () {
     searchControl(this.checked ? 'on' : 'off')
+  })
+
+  $('#step-limit').change(function () {
+    changeStepLimit(this.value)
   })
 
   $('#search-mode').change(function () {

--- a/templates/map.html
+++ b/templates/map.html
@@ -123,6 +123,16 @@
 
           <h3>Location & Search Settings</h3>
           <div>
+            <div class="form-control switch-container" style="display:{{search_control}}">
+              <h3>Search</h3>
+              <div class="onoffswitch">
+                <input id="search-switch" type="checkbox" name="search-switch" class="onoffswitch-checkbox" checked/>
+                <label class="onoffswitch-label" for="search-switch">
+                <span class="switch-label" data-on="On" data-off="Off"></span>
+                <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
             <div class="form-control switch-container" style="display:{{is_fixed}}" >
               <label for="next-location">
               <h3>Change search location</h3>
@@ -149,21 +159,19 @@
                 </label>
               </div>
             </div>
+            <div class="form-control switch-container" style="display:{{search_mode}}">
+              <h3>Search mode</h3>
+              <select name="search-mode" id="search-mode">
+                <option value="HexSearch">Standard search</option>
+                <option value="HexSearchSpawnpoint">Cells with spawnpoints</option>
+                <option value="SpawnScan">Spawnpoint scanning</option>
+              </select>
+            </div>
             <div class="form-control switch-container" >
               <h3>Start map at me</h3>
               <div class="onoffswitch">
                 <input id="start-at-user-location-switch" type="checkbox" name="start-at-user-location-switch" class="onoffswitch-checkbox" checked/>
                 <label class="onoffswitch-label" for="start-at-user-location-switch">
-                <span class="switch-label" data-on="On" data-off="Off"></span>
-                <span class="switch-handle"></span>
-                </label>
-              </div>
-            </div>
-            <div class="form-control switch-container" style="display:{{search_control}}">
-              <h3>Search</h3>
-              <div class="onoffswitch">
-                <input id="search-switch" type="checkbox" name="search-switch" class="onoffswitch-checkbox" checked/>
-                <label class="onoffswitch-label" for="search-switch">
                 <span class="switch-label" data-on="On" data-off="Off"></span>
                 <span class="switch-handle"></span>
                 </label>

--- a/templates/map.html
+++ b/templates/map.html
@@ -162,9 +162,9 @@
             <div class="form-control switch-container" style="display:{{su_control}}">
               <h3>Search mode</h3>
               <select name="search-mode" id="search-mode">
-                <option value="HexSearch">Standard search</option>
-                <option value="HexSearchSpawnpoint">Cells with spawnpoints</option>
-                <option value="SpawnScan">Spawnpoint scanning</option>
+                <option value="HexSearch">Standard hexagonal search</option>
+                <option value="HexSearchSpawnpoint">Standard with spawnpoints only</option>
+                <option value="SpawnScan">Spawnpoints at spawn time search</option>
               </select>
             </div>
             <div class="form-control switch-container" style="display:{{su_control}}" >

--- a/templates/map.html
+++ b/templates/map.html
@@ -123,7 +123,7 @@
 
           <h3>Location & Search Settings</h3>
           <div>
-            <div class="form-control switch-container" style="display:{{search_control}}">
+            <div class="form-control switch-container" style="display:{{su_control}}">
               <h3>Search</h3>
               <div class="onoffswitch">
                 <input id="search-switch" type="checkbox" name="search-switch" class="onoffswitch-checkbox" checked/>

--- a/templates/map.html
+++ b/templates/map.html
@@ -159,13 +159,19 @@
                 </label>
               </div>
             </div>
-            <div class="form-control switch-container" style="display:{{search_mode}}">
+            <div class="form-control switch-container" style="display:{{su_control}}">
               <h3>Search mode</h3>
               <select name="search-mode" id="search-mode">
                 <option value="HexSearch">Standard search</option>
                 <option value="HexSearchSpawnpoint">Cells with spawnpoints</option>
                 <option value="SpawnScan">Spawnpoint scanning</option>
               </select>
+            </div>
+            <div class="form-control switch-container" style="display:{{su_control}}" >
+              <label for="step-limit">
+              <h3>Search step limit</h3>
+              <input id="step-limit" type="number" min="1" name="step-limit">
+              </label>
             </div>
             <div class="form-control switch-container" >
               <h3>Start map at me</h3>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ability to change search mode (scheduler) and step limit in runtime via web page. This is mainly inherited from PR #737 and #37 - I have not closed that PR's, because mybe contributors decide to use those independent. Difference is that visibility of search mode select box and step limit input field depends here on -su param.

Also added speed limit to avoid teleports on spawnpoint only search and location change

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The same as PR #737 and #37

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The same as PR #737 and #37 

## Screenshots (if appropriate):
![search_mode](https://cloud.githubusercontent.com/assets/20594810/18411104/235221e8-7771-11e6-87ec-034df78df65a.png)

![img_20160910_213354](https://cloud.githubusercontent.com/assets/20594810/18413411/c64ebf38-77a7-11e6-92d4-bfedad013f50.jpg)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
