### PR TITLE
disable clean db option

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -156,6 +156,8 @@ def get_args():
                         nargs='*', default=False, dest='webhooks')
     parser.add_argument('-gi', '--gym-info', help='Get all details about gyms (causes an additional API hit for every gym)',
                         action='store_true', default=False)
+    parser.add_argument('--disable-clean', help='Disable clean db loop',
+                        action='store_true', default=False)
     parser.add_argument('--webhook-updates-only', help='Only send updates (pokémon & lured pokéstops)',
                         action='store_true', default=False)
     parser.add_argument('--wh-threads', help='Number of webhook threads; increase if the webhook queue falls behind',

--- a/runserver.py
+++ b/runserver.py
@@ -219,9 +219,10 @@ def main():
         t.start()
 
     # db clearner; really only need one ever
-    t = Thread(target=clean_db_loop, name='db-cleaner', args=(args,))
-    t.daemon = True
-    t.start()
+    if not args.disable_clean:
+        t = Thread(target=clean_db_loop, name='db-cleaner', args=(args,))
+        t.daemon = True
+        t.start()
 
     # WH Updates
     wh_updates_queue = Queue()


### PR DESCRIPTION
With beehive every worker run a clean db loop in a separate thread. It increase opened connections to db  twice. Also it cause a lot of deadlock issues when multiple workers run multiple db clean loops. And its not really needed. One db clean loop for one database more than enough.
So to disable it i added option --disable-clean. 

