### PR TITLE
Add feature #1257: Ignore to parse the Pokemon by IDs

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -17,6 +17,7 @@
 #no-gyms:               # disables gym scanning (default false)
 #no-pokemon:            # disables pokemon scanning (default false)
 #no-pokestops:          # disables pokestop scanning (default false)
+#ignore-list:           # list of Pokemon IDs to ignore scanning (default [])
 #scan-delay:            # default 10
 #step-limit:            # default 12
 #gym-info:              # enables detailed gym info collection (default false)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -595,26 +595,29 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue):
 
                 printPokemon(p['pokemon_data']['pokemon_id'], p['latitude'],
                              p['longitude'], d_t)
-                pokemons[p['encounter_id']] = {
-                    'encounter_id': b64encode(str(p['encounter_id'])),
-                    'spawnpoint_id': p['spawn_point_id'],
-                    'pokemon_id': p['pokemon_data']['pokemon_id'],
-                    'latitude': p['latitude'],
-                    'longitude': p['longitude'],
-                    'disappear_time': d_t
-                }
 
-                if args.webhooks:
-                    wh_update_queue.put(('pokemon', {
+                # Not in Ignore list
+                if str(p['pokemon_data']['pokemon_id']) not in args.ignore_list:
+                    pokemons[p['encounter_id']] = {
                         'encounter_id': b64encode(str(p['encounter_id'])),
                         'spawnpoint_id': p['spawn_point_id'],
                         'pokemon_id': p['pokemon_data']['pokemon_id'],
                         'latitude': p['latitude'],
                         'longitude': p['longitude'],
-                        'disappear_time': calendar.timegm(d_t.timetuple()),
-                        'last_modified_time': p['last_modified_timestamp_ms'],
-                        'time_until_hidden_ms': p['time_till_hidden_ms']
-                    }))
+                        'disappear_time': d_t
+                    }
+
+                    if args.webhooks:
+                        wh_update_queue.put(('pokemon', {
+                            'encounter_id': b64encode(str(p['encounter_id'])),
+                            'spawnpoint_id': p['spawn_point_id'],
+                            'pokemon_id': p['pokemon_data']['pokemon_id'],
+                            'latitude': p['latitude'],
+                            'longitude': p['longitude'],
+                            'disappear_time': calendar.timegm(d_t.timetuple()),
+                            'last_modified_time': p['last_modified_timestamp_ms'],
+                            'time_until_hidden_ms': p['time_till_hidden_ms']
+                        }))
 
         for f in cell.get('forts', []):
             if config['parse_pokestops'] and f.get('type') == 1:  # Pokestops

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -596,8 +596,8 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue):
                 printPokemon(p['pokemon_data']['pokemon_id'], p['latitude'],
                              p['longitude'], d_t)
 
-                # Not in Ignore list
-                if str(p['pokemon_data']['pokemon_id']) not in args.ignore_list:
+                # Parse only if Pokemon not in Ignore list
+                if p['pokemon_data']['pokemon_id'] not in args.ignore_list:
                     pokemons[p['encounter_id']] = {
                         'encounter_id': b64encode(str(p['encounter_id'])),
                         'spawnpoint_id': p['spawn_point_id'],

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -288,13 +288,13 @@ def get_args():
             args.scheduler = 'HexSearchSpawnpoint'
         else:
             args.scheduler = 'HexSearch'
-            
+
         # Return int for Pokemon Ignore list if it's exist
         if len(args.ignore_list):
             try:
                 args.ignore_list = set([int(i) for i in args.ignore_list])
             except Exception as e:
-                print("Error: Pokemon IDs need to be Interger",e)
+                print("Error: Pokemon IDs need to be Interger", e)
                 sys.exit(1)
                 
     return args

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -131,6 +131,9 @@ def get_args():
     parser.add_argument('-nk', '--no-pokestops',
                         help='Disables PokeStops from the map (including parsing them into local db)',
                         action='store_true', default=False)
+    parser.add_argument('-igl', '--ignore-list',
+                        help='Ignores Pokemon from the map (including parsing them into local db)',
+                        action='append', default=[])
     parser.add_argument('-ss', '--spawnpoint-scanning',
                         help='Use spawnpoint scanning (instead of hex grid). Scans in a circle based on step_limit when on DB', nargs='?', const='nofile', default=False)
     parser.add_argument('--dump-spawnpoints', help='dump the spawnpoints from the db to json (only for use with -ss)',

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -288,7 +288,7 @@ def get_args():
             args.scheduler = 'HexSearchSpawnpoint'
         else:
             args.scheduler = 'HexSearch'
-
+            
         # Return int for Pokemon Ignore list if it's exist
         if len(args.ignore_list):
             try:

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -289,6 +289,14 @@ def get_args():
         else:
             args.scheduler = 'HexSearch'
 
+        # Return int for Pokemon Ignore list if it's exist
+        if len(args.ignore_list):
+            try:
+                args.ignore_list = set([int(i) for i in args.ignore_list])
+            except ValueError:
+                print(sys.argv[0] + ": Error: Pokemon IDs ned to be Interger")
+                sys.exit(1)
+                
     return args
 
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -293,8 +293,8 @@ def get_args():
         if len(args.ignore_list):
             try:
                 args.ignore_list = set([int(i) for i in args.ignore_list])
-            except ValueError:
-                print(sys.argv[0] + ": Error: Pokemon IDs ned to be Interger")
+            except Exception as e:
+                print("Error: Pokemon IDs need to be Interger",e)
                 sys.exit(1)
                 
     return args

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -296,7 +296,7 @@ def get_args():
             except Exception as e:
                 print("Error: Pokemon IDs need to be Interger", e)
                 sys.exit(1)
-                
+
     return args
 
 

--- a/runserver.py
+++ b/runserver.py
@@ -184,6 +184,8 @@ def main():
         log.info('Parsing of Pokestops disabled')
     if args.no_gyms:
         log.info('Parsing of Gyms disabled')
+    if len(args.ignore_list):
+        log.info('Ignore Pokemon IDs: {}'.format(args.ignore_list))
 
     config['LOCALE'] = args.locale
     config['CHINA'] = args.china


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

It's good idea for people who's scanning large area and want to avoid large database input. We can ignore almost common Pokemons.
- Feature request: https://github.com/PokemonGoMap/PokemonGo-Map/issues/1257
## Description

<!--- Describe your changes in detail -->
- runserver.py: add info on ignore list running
- utils.py: Add -igl / --ignore-list config, validate values and store the ignore list by Set
- models.py: Check if Pokemon ID not in the ignore list, because the ignore list default empty so we dont need option to enable/disable. Who want to enable just need to input in the list.
- config.ini.example: Add sample line
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
- Add pigey, rattata ID to the list, no hide pokemon and see the screenshot

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->
## Screenshots (if appropriate):

![ignore-list](https://cloud.githubusercontent.com/assets/5210757/18416415/65ddb6a8-783e-11e6-8595-902df07fa956.png)
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
