### PR TITLE
Fixed scroll issue on stats page after select sorting #1192

### DIFF
--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -476,4 +476,4 @@ $('#nav select')
   .select2({
     minimumResultsForSearch: Infinity
   })
-  .on('change', updateStatMap)
+  .on('change', function(){setTimeout(updateStatMap,300)})

--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -476,6 +476,6 @@ $('#nav select')
   .select2({
     minimumResultsForSearch: Infinity
   })
-  .on('change', function () { 
+  .on('change',function () { 
     setTimeout(updateStatMap, 300)
   })

--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -476,4 +476,6 @@ $('#nav select')
   .select2({
     minimumResultsForSearch: Infinity
   })
-  .on('change', function(){setTimeout(updateStatMap,300)})
+  .on('change', function () { 
+    setTimeout(updateStatMap, 300)
+  })

--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -476,6 +476,6 @@ $('#nav select')
   .select2({
     minimumResultsForSearch: Infinity
   })
-  .on('change',function () { 
+  .on('change', function () {
     setTimeout(updateStatMap, 300)
   })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Issue described at #1192 

## Description
<!--- Describe your changes in detail -->

- Static\js\statistics.js: Just add a small delay by setTimeout to updateMap after select2 init which made the CSS bug with scroll. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Not able to scroll at all after select the Duration at Stats page

<!--- If it fixes an open issue, please link to the issue here. -->

#1192 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

- Replicated on my server, issue happen
- Added setTimeout: working fine

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

