### PR TITLE
Fully Implement On Demand Mode(Conflicts resolved)

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -251,7 +251,7 @@ def worker_status_db_thread(threads_status, name, db_updates_queue):
 
 
 # The main search loop that keeps an eye on the over all process
-def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_path, db_updates_queue, wh_queue):
+def search_overseer_thread(args, new_location_queue, pause_bit, heartb, encryption_lib_path, db_updates_queue, wh_queue):
 
     log.info('Search overseer starting')
 
@@ -344,6 +344,10 @@ def search_overseer_thread(args, new_location_queue, pause_bit, encryption_lib_p
 
     # The real work starts here but will halt on pause_bit.set()
     while True:
+
+        if args.on_demand_timeout > 0 and (now() - args.on_demand_timeout) > heartb[0]:
+            pause_bit.set()
+            log.info("Searching paused due to inactivity...")
 
         # Wait here while scanning is paused
         while pause_bit.is_set():

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -437,6 +437,10 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                     account_failures.append({'account': account, 'last_fail_time': now(), 'reason': 'failures'})
                     break  # exit this loop to get a new account and have the API recreated
 
+                while pause_bit.is_set():
+                    status['message'] = 'Scanning paused'
+                    time.sleep(2)
+
                 # If this account has been running too long, let it rest
                 if (args.account_search_interval is not None):
                     if (status['starttime'] <= (now() - args.account_search_interval)):
@@ -444,10 +448,6 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                         log.info(status['message'])
                         account_failures.append({'account': account, 'last_fail_time': now(), 'reason': 'rest interval'})
                         break
-
-                while pause_bit.is_set():
-                    status['message'] = 'Scanning paused'
-                    time.sleep(2)
 
                 # Grab the next thing to search (when available)
                 status['message'] = 'Waiting for item from queue'

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -171,6 +171,7 @@ def get_args():
     parser.add_argument('-spp', '--status-page-password', default=None,
                         help='Set the status page password')
     parser.add_argument('-el', '--encrypt-lib', help='Path to encrypt lib to be used instead of the shipped ones')
+    parser.add_argument('-odt', '--on-demand_timeout', help='Pause searching while web UI is inactive for this timeout(in seconds)', type=int, default=0)
     verbosity = parser.add_mutually_exclusive_group()
     verbosity.add_argument('-v', '--verbose', help='Show debug messages from PomemonGo-Map and pgoapi. Optionally specify file to log to.', nargs='?', const='nofile', default=False, metavar='filename.log')
     verbosity.add_argument('-vv', '--very-verbose', help='Like verbose, but show debug messages from all modules as well.  Optionally specify file to log to.', nargs='?', const='nofile', default=False, metavar='filename.log')

--- a/runserver.py
+++ b/runserver.py
@@ -20,7 +20,7 @@ from flask_cache_bust import init_cache_busting
 
 from pogom import config
 from pogom.app import Pogom
-from pogom.utils import get_args, get_encryption_lib_path
+from pogom.utils import get_args, get_encryption_lib_path, now
 
 from pogom.search import search_overseer_thread
 from pogom.models import init_database, create_tables, drop_tables, Pokemon, db_updater, clean_db_loop
@@ -203,6 +203,10 @@ def main():
     # Control the search status (running or not) across threads
     pause_bit = Event()
     pause_bit.clear()
+    if args.on_demand_timeout > 0:
+        pause_bit.set()
+
+    heartbeat = [now()]
 
     # Setup the location tracking queue and push the first location on
     new_location_queue = Queue()
@@ -252,7 +256,7 @@ def main():
                 file.write(json.dumps(spawns))
                 log.info('Finished exporting spawn points')
 
-        argset = (args, new_location_queue, pause_bit, encryption_lib_path, db_updates_queue, wh_updates_queue)
+        argset = (args, new_location_queue, pause_bit, heartbeat, encryption_lib_path, db_updates_queue, wh_updates_queue)
 
         log.debug('Starting a %s search thread', args.scheduler)
         search_thread = Thread(target=search_overseer_thread, name='search-overseer', args=argset)
@@ -266,6 +270,7 @@ def main():
     init_cache_busting(app)
 
     app.set_search_control(pause_bit)
+    app.set_heartbeat_control(heartbeat)
     app.set_location_queue(new_location_queue)
 
     config['ROOT_PATH'] = app.root_path


### PR DESCRIPTION
## Description
I made changes to a few files, to track when the last web request was(heartbeat). This then has a timeout that will stop the bot from scanning if there is no activity in a certain period of time, configured by "-odt" or "--on-demand_timeout". Thus, "--on-demand_timeout 900" will activate this mode, and set the timeout to 15 minutes. One thing to note, is that the timeout is in seconds. Finally, the scanner will also startup in standby mode(waiting to start) until the first client connects.

## Motivation and Context
Solves https://github.com/PokemonGoMap/PokemonGo-Map/issues/1142 and https://github.com/PokemonGoMap/PokemonGo-Map/issues/1132

## How Has This Been Tested?
Tested locally and on my server, by connecting and disconnecting, turning off and on on demand

## Screenshots (if appropriate):
N/A
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.