### PR TITLE
Make -ac csvinput ptc-acc-gen compatible again

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -198,6 +198,12 @@ def get_args():
                     # First time around populate num_fields with current field count.
                     if num_fields < 0:
                         num_fields = line.count(',') + 1
+                        if num_fields > 3:
+                           num_fields = 3
+
+                    next_num_fields = line.count(',') + 1
+                    if next_num_fields > 3:
+                       next_num_fields = 3
 
                     csv_input = []
                     csv_input.append('')
@@ -206,8 +212,8 @@ def get_args():
                     csv_input.append('<ptc/gmail>,<username>,<password>')
 
                     # If the number of fields is differend this is not a CSV
-                    if num_fields != line.count(',') + 1:
-                        print(sys.argv[0] + ": Error parsing CSV file on line " + str(num) + ". Your file started with the following input, '" + csv_input[num_fields] + "' but now you gave us '" + csv_input[line.count(',') + 1] + "'.")
+                    if num_fields != next_num_fields:
+                        print(sys.argv[0] + ": Error parsing CSV file on line " + str(num) + ". Your file started with the following input, '" + csv_input[num_fields] + "' but now you gave us '" + csv_input[next_num_fields] + "'.")
                         sys.exit(1)
 
                     field_error = ''
@@ -266,7 +272,11 @@ def get_args():
                         type_error = 'empty!'
                         if field_error == 'method':
                             type_error = 'not ptc or gmail instead we got \'' + fields[0] + '\'!'
-                        print(sys.argv[0] + ": Error parsing CSV file on line " + str(num) + ". We found " + str(num_fields) + " fields, so your input should have looked like '" + csv_input[num_fields] + "'\nBut you gave us '" + line + "', your " + field_error + " was " + type_error)
+
+                        if line.count(',') > 3:
+                            line = fields[0] + ',' + fields[1] + ',' + fields[2]
+
+                        print(sys.argv[0] + ": Error parsing CSV file on line " + str(num) + ". We found " + str(line.count(',') + 1) + " fields, so your input should have looked like '" + csv_input[num_fields] + "'\nBut you gave us '" + line + "', your " + field_error + " was " + type_error)
                         sys.exit(1)
 
         errors = []

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -198,10 +198,12 @@ def get_args():
                     # First time around populate num_fields with current field count.
                     if num_fields < 0:
                         num_fields = line.count(',') + 1
+                        # Make sure we ignore anything after the 3rd field
                         if num_fields > 3:
                             num_fields = 3
 
                     next_num_fields = line.count(',') + 1
+                    # Make sure we ignore anything after the 3rd field
                     if next_num_fields > 3:
                         next_num_fields = 3
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -199,11 +199,11 @@ def get_args():
                     if num_fields < 0:
                         num_fields = line.count(',') + 1
                         if num_fields > 3:
-                           num_fields = 3
+                            num_fields = 3
 
                     next_num_fields = line.count(',') + 1
                     if next_num_fields > 3:
-                       next_num_fields = 3
+                        next_num_fields = 3
 
                     csv_input = []
                     csv_input.append('')

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -211,7 +211,7 @@ def get_args():
                     csv_input.append('')
                     csv_input.append('<username>')
                     csv_input.append('<username>,<password>')
-                    csv_input.append('<ptc/gmail>,<username>,<password>')
+                    csv_input.append('<ptc/google>,<username>,<password>')
 
                     # If the number of fields is differend this is not a CSV
                     if num_fields != next_num_fields:
@@ -251,8 +251,8 @@ def get_args():
 
                     # If the number of fields is three then assume this is "ptc,username,password". As requested..
                     if num_fields == 3:
-                        # If field 0 is not ptc or gmail something is wrong!
-                        if fields[0].lower() == 'ptc' or fields[0].lower() == 'gmail':
+                        # If field 0 is not ptc or google something is wrong!
+                        if fields[0].lower() == 'ptc' or fields[0].lower() == 'google':
                             args.auth_service.append(fields[0])
                         else:
                             field_error = 'method'
@@ -273,7 +273,7 @@ def get_args():
                     if field_error != '':
                         type_error = 'empty!'
                         if field_error == 'method':
-                            type_error = 'not ptc or gmail instead we got \'' + fields[0] + '\'!'
+                            type_error = 'not ptc or google instead we got \'' + fields[0] + '\'!'
 
                         if line.count(',') > 3:
                             line = fields[0] + ',' + fields[1] + ',' + fields[2]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
ptc-acc-gen adds location and nickname to CSV.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

most folks would use ptc-acc-gen which inputs 5-6 fields in CSV, previous code only worked with 3 or less fields.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally with multiple CSV layouts

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

