### PR TITLE
Alternate proxy checking fix

### DIFF
--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 # Simple function to do a call to Niantic's system for testing proxy connectivity
 def check_proxy(proxy_queue, timeout, proxies):
 
-    proxy_test_url = 'https://sso.pokemon.com/'
+    proxy_test_url = 'https://sso.pokemon.com/sso/login'
     proxy = proxy_queue.get()
 
     if proxy and proxy[1]:


### PR DESCRIPTION
Secondary to my previous pull; https://github.com/PokemonGoMap/PokemonGo-Map/pull/1281

This is an alternate fix which returns 200s on success.

**However**, this doesn't verify IP bans, whereas the RPC link will.