### PR TITLE
auth_service for google acct should be 'google' not 'gmail'

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -203,7 +203,7 @@ def get_args():
                     csv_input.append('')
                     csv_input.append('<username>')
                     csv_input.append('<username>,<password>')
-                    csv_input.append('<ptc/gmail>,<username>,<password>')
+                    csv_input.append('<ptc/google>,<username>,<password>')
 
                     # If the number of fields is differend this is not a CSV
                     if num_fields != line.count(',') + 1:
@@ -243,8 +243,8 @@ def get_args():
 
                     # If the number of fields is three then assume this is "ptc,username,password". As requested..
                     if num_fields == 3:
-                        # If field 0 is not ptc or gmail something is wrong!
-                        if fields[0].lower() == 'ptc' or fields[0].lower() == 'gmail':
+                        # If field 0 is not ptc or google something is wrong!
+                        if fields[0].lower() == 'ptc' or fields[0].lower() == 'google':
                             args.auth_service.append(fields[0])
                         else:
                             field_error = 'method'
@@ -265,7 +265,7 @@ def get_args():
                     if field_error != '':
                         type_error = 'empty!'
                         if field_error == 'method':
-                            type_error = 'not ptc or gmail instead we got \'' + fields[0] + '\'!'
+                            type_error = 'not ptc or google instead we got \'' + fields[0] + '\'!'
                         print(sys.argv[0] + ": Error parsing CSV file on line " + str(num) + ". We found " + str(num_fields) + " fields, so your input should have looked like '" + csv_input[num_fields] + "'\nBut you gave us '" + line + "', your " + field_error + " was " + type_error)
                         sys.exit(1)
 


### PR DESCRIPTION
Recent commit have made choose between 'ptc' and 'gmail' for account csv, but the auth service really should be 'google' according to the way pgoapi is handled.