### PR TITLE
Keep map updating while background on mobile

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
     "setupPokemonMarker": true,
 
     "isTouchDevice": true,
+    "isMobileDevice": true,
     "pokemonSprites": true,
     "noLabelsStyle": true,
     "darkStyle": true,

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -850,3 +850,8 @@ function isTouchDevice () {
   // Should cover most browsers
   return 'ontouchstart' in window || navigator.maxTouchPoints
 }
+
+function isMobileDevice () {
+  //  Basic mobile OS (not browser) detection
+  return (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent))
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR ensures map updates will still occur when a browser is minimized/background on mobile, by implementing a webworker which calls some of the updating functions.

Generally interval timers are suspended/slowed when a browser is background on mobile, which prevents the map from updating and also prevents notifications from occurring.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->



<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested on Win ff/chrome/edge. Android Chrome/FF. Should work on IOS Safari, as it supports the necessary functions, but needs testing.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

