### PR TITLE
Modify the way trainer names are shown

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -348,7 +348,10 @@ function gymLabel (teamName, teamId, gymPoints, latitude, longitude, lastScanned
     memberStr += `
       <span class="gym-member" title="${members[i].pokemon_name} | ${members[i].trainer_name} (Lvl ${members[i].trainer_level})">
         <i class="pokemon-sprite n${members[i].pokemon_id}"></i>
-        <span class="cp team-${teamId}">${members[i].pokemon_cp}</span>
+        <span class="cp team-${teamId}"> ${members[i].pokemon_cp} </span>
+	 <span class="cp team-${teamId}"> ${members[i].pokemon_name} </span>
+        <span class="cp team-${teamId}"> ${members[i].trainer_name} </span>
+	 <span class="cp team-${teamId}"> Lvl ${members[i].trainer_level} </span>
       </span>`
   }
 


### PR DESCRIPTION
## Description
Changed the way trainer names/information is shown in gym details. 

## Motivation and Context
Current solution doesnt work on mobile devices

## How Has This Been Tested?
Tested personally on my server.

## Screenshots (if appropriate):
![31d6eeba-7a05-11e6-943e-74c135ffb5d1](https://cloud.githubusercontent.com/assets/9411415/18499378/617cdf7e-7a0c-11e6-8a70-a73b211d64fb.png)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
