### PR TITLE
Output better error when csv file has > 3 fields

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -262,6 +262,10 @@ def get_args():
                         else:
                             field_error = 'password'
 
+                    if num_fields > 3:
+                        print 'Too many fields in accounts file: max supported are 3 fields. Found {} fields'.format(num_fields)
+                        sys.exit(1)
+
                     # If something is wrong display error.
                     if field_error != '':
                         type_error = 'empty!'


### PR DESCRIPTION
## Description
print "Too many fields in accounts file: max supported are 3 fields. Found 8 fields" when ptc-file has > 3 fields

## Motivation and Context
Enhance output to user when incorrect input format encountered

## How Has This Been Tested?
Tested on local PC

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

