### PR TITLE
Improving sprite image

### DIFF
--- a/docs/basic-install/index.rst
+++ b/docs/basic-install/index.rst
@@ -71,6 +71,7 @@ Windows:
 .. code-block:: bash
 
   pip install -r requirements.txt
+  pip install --upgrade git+https://github.com/maddhatter/Flask-CacheBust.git@38d940cc4f18b5fcb5687746294e0360640a107e#egg=flask_cachebust
 
 Linux/OSX:
 

--- a/static/sass/pokemon-sprite.scss
+++ b/static/sass/pokemon-sprite.scss
@@ -612,3 +612,18 @@
 .pokemon-sprite.n151 {
   background-position: -180px -360px;
 }
+.pokemon-sprite.nCommon {
+  display:none
+}
+.pokemon-sprite.nUncommon {
+  display:none
+}
+.pokemon-sprite.nRare {
+  display:none
+}
+.pokemon-sprite.nVery.Rare {
+  display:none
+}
+.pokemon-sprite.nUltra.Rare {
+  display:none
+}


### PR DESCRIPTION
## Description
A necessary command was added to the documentation (_basic-install/index.rst_) in order to get the sprint image to work on the windows.
Images was removed from "Notify of Rarity" option.

## Motivation and Context
A command to install the module "Flask CacheBust" was added to the documentation because the sprite image was missing. This affected only windows.
Sprite image was removed from suggests Common, Uncommon, Rare, Very Rare and Ultra Rare options as there have no image.

## How Has This Been Tested?
First I ran `pip install --upgrade git+https://github.com/maddhatter/Flask-CacheBust.git@38d940cc4f18b5fcb5687746294e0360640a107e#egg=flask_cachebust`.
After that I deleted the folder `dist`. and ran `npm install && npm run build` to rebuild the folder.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
