### PR TITLE
add option to specify config file on command line or via env variable

### DIFF
--- a/docs/extras/commandline.md
+++ b/docs/extras/commandline.md
@@ -2,7 +2,7 @@
 
     usage: runserver.py
                         [-h] [-cf CONFIG] [-a AUTH_SERVICE] [-u USERNAME]
-			[-p PASSWORD] [-w WORKERS] [-asi ACCOUNT_SEARCH_INTERVAL]
+                        [-p PASSWORD] [-w WORKERS] [-asi ACCOUNT_SEARCH_INTERVAL]
                         [-ari ACCOUNT_REST_INTERVAL] [-ac ACCOUNTCSV]
                         [-l LOCATION] [-j] [-st STEP_LIMIT] [-sd SCAN_DELAY]
                         [-ld LOGIN_DELAY] [-lr LOGIN_RETRIES] [-mf MAX_FAILURES]

--- a/docs/extras/commandline.md
+++ b/docs/extras/commandline.md
@@ -1,8 +1,8 @@
 # Command Line
 
     usage: runserver.py
-                        [-h] [-a AUTH_SERVICE] [-u USERNAME] [-p PASSWORD]
-                        [-w WORKERS] [-asi ACCOUNT_SEARCH_INTERVAL]
+                        [-h] [-cf CONFIG] [-a AUTH_SERVICE] [-u USERNAME]
+			[-p PASSWORD] [-w WORKERS] [-asi ACCOUNT_SEARCH_INTERVAL]
                         [-ari ACCOUNT_REST_INTERVAL] [-ac ACCOUNTCSV]
                         [-l LOCATION] [-j] [-st STEP_LIMIT] [-sd SCAN_DELAY]
                         [-ld LOGIN_DELAY] [-lr LOGIN_RETRIES] [-mf MAX_FAILURES]
@@ -24,7 +24,7 @@
                         [-v [filename.log] | -vv [filename.log] | -d]
     
     Args that start with '--' (eg. -a) can also be set in a config file
-    (C:\Users\User\Desktop\Pogom\PokemonGo-map\pogom\../config/config.ini or ).
+    (default: <PokemonGo-Map Project Root>/config/config.ini or via -cf).
     The recognized syntax for setting (key, value) pairs is based on the INI and
     YAML formats (e.g. key=value or foo=TRUE). For full documentation of the
     differences from the standards please refer to the ConfigArgParse
@@ -34,6 +34,8 @@
     
     optional arguments:
       -h, --help            Show this help message and exit.
+      -cf CONFIG, --config CONFIG
+                            Configuration file.
       -a AUTH_SERVICE, --auth-service AUTH_SERVICE
                             Auth Services, either one for all accounts or one per
                             account: ptc or google. Defaults all to ptc. 

--- a/docs/extras/commandline.md
+++ b/docs/extras/commandline.md
@@ -35,7 +35,7 @@
     optional arguments:
       -h, --help            Show this help message and exit.
       -cf CONFIG, --config CONFIG
-                            Configuration file.
+                            Configuration file.  See docs/extras/configuration-files.md
       -a AUTH_SERVICE, --auth-service AUTH_SERVICE
                             Auth Services, either one for all accounts or one per
                             account: ptc or google. Defaults all to ptc. 

--- a/docs/extras/commandline.md
+++ b/docs/extras/commandline.md
@@ -1,5 +1,6 @@
 # Command Line
 
+
     usage: runserver.py
                         [-h] [-cf CONFIG] [-a AUTH_SERVICE] [-u USERNAME]
                         [-p PASSWORD] [-w WORKERS] [-asi ACCOUNT_SEARCH_INTERVAL]
@@ -8,7 +9,7 @@
                         [-ld LOGIN_DELAY] [-lr LOGIN_RETRIES] [-mf MAX_FAILURES]
                         [-msl MIN_SECONDS_LEFT] [-dc] [-H HOST] [-P PORT]
                         [-L LOCALE] [-c] [-m MOCK] [-ns] [-os] [-nsc] [-fl] -k
-                        GMAPS_KEY [--spawnpoints-only] [-C] [-D DB] [-cd] [-np]
+                        GMAPS_KEY [--skip-empty] [-C] [-D DB] [-cd] [-np]
                         [-ng] [-nk] [-ss [SPAWNPOINT_SCANNING]]
                         [--dump-spawnpoints] [-pd PURGE_DATA] [-px PROXY]
                         [-pxt PROXY_TIMEOUT] [-pxd PROXY_DISPLAY]
@@ -33,132 +34,178 @@
     override defaults.
     
     optional arguments:
-      -h, --help            Show this help message and exit.
+      -h, --help            show this help message and exit [env var:
+                            POGOMAP_HELP]
       -cf CONFIG, --config CONFIG
                             Configuration file.  See docs/extras/configuration-files.md
       -a AUTH_SERVICE, --auth-service AUTH_SERVICE
                             Auth Services, either one for all accounts or one per
-                            account: ptc or google. Defaults all to ptc. 
+                            account: ptc or google. Defaults all to ptc. [env var:
+                            POGOMAP_AUTH_SERVICE]
       -u USERNAME, --username USERNAME
-                            Usernames, one per account. 
+                            Usernames, one per account. [env var:
+                            POGOMAP_USERNAME]
       -p PASSWORD, --password PASSWORD
                             Passwords, either single one for all accounts or one
-                            per account. 
+                            per account. [env var: POGOMAP_PASSWORD]
       -w WORKERS, --workers WORKERS
                             Number of search worker threads to start. Defaults to
-                            the number of accounts specified. 
+                            the number of accounts specified. [env var:
+                            POGOMAP_WORKERS]
       -asi ACCOUNT_SEARCH_INTERVAL, --account-search-interval ACCOUNT_SEARCH_INTERVAL
                             Seconds for accounts to search before switching to a
-                            new account. 0 to disable.
+                            new account. 0 to disable. [env var:
+                            POGOMAP_ACCOUNT_SEARCH_INTERVAL]
       -ari ACCOUNT_REST_INTERVAL, --account-rest-interval ACCOUNT_REST_INTERVAL
                             Seconds for accounts to rest when they fail or are
-                            switched out.
+                            switched out [env var: POGOMAP_ACCOUNT_REST_INTERVAL]
       -ac ACCOUNTCSV, --accountcsv ACCOUNTCSV
                             Load accounts from CSV file containing
-                            "auth_service,username,passwd" lines.
+                            "auth_service,username,passwd" lines [env var:
+                            POGOMAP_ACCOUNTCSV]
       -l LOCATION, --location LOCATION
-                            Location, can be an address or coordinates.
-      -j, --jitter          Apply random -9m to +9m jitter to location.
+                            Location, can be an address or coordinates [env var:
+                            POGOMAP_LOCATION]
+      -j, --jitter          Apply random -9m to +9m jitter to location [env var:
+                            POGOMAP_JITTER]
       -st STEP_LIMIT, --step-limit STEP_LIMIT
-                            Steps.
+                            Steps [env var: POGOMAP_STEP_LIMIT]
       -sd SCAN_DELAY, --scan-delay SCAN_DELAY
-                            Time delay between requests in scan threads.
+                            Time delay between requests in scan threads [env var:
+                            POGOMAP_SCAN_DELAY]
       -ld LOGIN_DELAY, --login-delay LOGIN_DELAY
-                            Time delay between each login attempt.
+                            Time delay between each login attempt [env var:
+                            POGOMAP_LOGIN_DELAY]
       -lr LOGIN_RETRIES, --login-retries LOGIN_RETRIES
-                            Number of logins attempts before refreshing a thread.
+                            Number of logins attempts before refreshing a thread
+                            [env var: POGOMAP_LOGIN_RETRIES]
       -mf MAX_FAILURES, --max-failures MAX_FAILURES
                             Maximum number of failures to parse locations before
-                            an account will go into a two hour sleep.
+                            an account will go into a two hour sleep [env var:
+                            POGOMAP_MAX_FAILURES]
       -msl MIN_SECONDS_LEFT, --min-seconds-left MIN_SECONDS_LEFT
                             Time that must be left on a spawn before considering
                             it too late and skipping it. eg. 600 would skip
-                            anything with < 10 minutes remaining. Default 0.
+                            anything with < 10 minutes remaining. Default 0. [env
+                            var: POGOMAP_MIN_SECONDS_LEFT]
       -dc, --display-in-console
-                            Display Found Pokemon in Console.
-      -H HOST, --host HOST  Set web server listening host.
-      -P PORT, --port PORT  Set web server listening port.
+                            Display Found Pokemon in Console [env var:
+                            POGOMAP_DISPLAY_IN_CONSOLE]
+      -H HOST, --host HOST  Set web server listening host [env var: POGOMAP_HOST]
+      -P PORT, --port PORT  Set web server listening port [env var: POGOMAP_PORT]
       -L LOCALE, --locale LOCALE
                             Locale for Pokemon names (default: en, check
-                            static/dist/locales for more).
-      -c, --china           Coordinates transformer for China.
+                            static/dist/locales for more) [env var:
+                            POGOMAP_LOCALE]
+      -c, --china           Coordinates transformer for China [env var:
+                            POGOMAP_CHINA]
       -m MOCK, --mock MOCK  Mock mode - point to a fpgo endpoint instead of using
-                            the real PogoApi, ec: http://127.0.0.1:9090.
+                            the real PogoApi, ec: http://127.0.0.1:9090 [env var:
+                            POGOMAP_MOCK]
       -ns, --no-server      No-Server Mode. Starts the searcher but not the
-                            Webserver.
+                            Webserver. [env var: POGOMAP_NO_SERVER]
       -os, --only-server    Server-Only Mode. Starts only the Webserver without
-                            the searcher.
+                            the searcher. [env var: POGOMAP_ONLY_SERVER]
       -nsc, --no-search-control
-                            Disables search control.
+                            Disables search control [env var:
+                            POGOMAP_NO_SEARCH_CONTROL]
       -fl, --fixed-location
-                            Hides the search bar for use in shared maps.
+                            Hides the search bar for use in shared maps. [env var:
+                            POGOMAP_FIXED_LOCATION]
       -k GMAPS_KEY, --gmaps-key GMAPS_KEY
-                            Google Maps Javascript API Key.
-      --spawnpoints-only    Only scan locations with spawnpoints in them.
-      -C, --cors            Enable CORS on web server.
-      -D DB, --db DB        Database filename.
+                            Google Maps Javascript API Key [env var:
+                            POGOMAP_GMAPS_KEY]
+      --skip-empty          Enables skipping of empty cells in normal scans -
+                            requires previously populated database (not to be used
+                            with -ss) [env var: POGOMAP_SKIP_EMPTY]
+      -C, --cors            Enable CORS on web server [env var: POGOMAP_CORS]
+      -D DB, --db DB        Database filename [env var: POGOMAP_DB]
       -cd, --clear-db       Deletes the existing database before starting the
-                            Webserver.
+                            Webserver. [env var: POGOMAP_CLEAR_DB]
       -np, --no-pokemon     Disables Pokemon from the map (including parsing them
-                            into local db).
+                            into local db) [env var: POGOMAP_NO_POKEMON]
       -ng, --no-gyms        Disables Gyms from the map (including parsing them
-                            into local db).
+                            into local db) [env var: POGOMAP_NO_GYMS]
       -nk, --no-pokestops   Disables PokeStops from the map (including parsing
-                            them into local db).
+                            them into local db) [env var: POGOMAP_NO_POKESTOPS]
       -ss [SPAWNPOINT_SCANNING], --spawnpoint-scanning [SPAWNPOINT_SCANNING]
                             Use spawnpoint scanning (instead of hex grid). Scans
-                            in a circle based on step_limit when on DB.
+                            in a circle based on step_limit when on DB [env var:
+                            POGOMAP_SPAWNPOINT_SCANNING]
       --dump-spawnpoints    dump the spawnpoints from the db to json (only for use
-                            with -ss).
+                            with -ss) [env var: POGOMAP_DUMP_SPAWNPOINTS]
       -pd PURGE_DATA, --purge-data PURGE_DATA
                             Clear pokemon from database this many hours after they
-                            disappear (0 to disable).
+                            disappear (0 to disable) [env var: POGOMAP_PURGE_DATA]
       -px PROXY, --proxy PROXY
-                            Proxy url (e.g. socks5://127.0.0.1:9050).
+                            Proxy url (e.g. socks5://127.0.0.1:9050) [env var:
+                            POGOMAP_PROXY]
+      -pxsc, --proxy-skip-check
+                            Disable checking of proxies before start [env var:
+                            POGOMAP_PROXY_SKIP_CHECK]
       -pxt PROXY_TIMEOUT, --proxy-timeout PROXY_TIMEOUT
-                            Timeout settings for proxy checker in seconds.
+                            Timeout settings for proxy checker in seconds [env
+                            var: POGOMAP_PROXY_TIMEOUT]
       -pxd PROXY_DISPLAY, --proxy-display PROXY_DISPLAY
                             Display info on which proxy beeing used (index or
-                            full) To be used with -ps.
-      --db-type DB_TYPE     Type of database to be used (default: sqlite).
-      --db-name DB_NAME     Name of the database to be used.
-      --db-user DB_USER     Username for the database.
-      --db-pass DB_PASS     Password for the database.
-      --db-host DB_HOST     IP or hostname for the database.
-      --db-port DB_PORT     Port for the database.
+                            full) To be used with -ps [env var:
+                            POGOMAP_PROXY_DISPLAY]
+      --db-type DB_TYPE     Type of database to be used (default: sqlite) [env
+                            var: POGOMAP_DB_TYPE]
+      --db-name DB_NAME     Name of the database to be used [env var:
+                            POGOMAP_DB_NAME]
+      --db-user DB_USER     Username for the database [env var: POGOMAP_DB_USER]
+      --db-pass DB_PASS     Password for the database [env var: POGOMAP_DB_PASS]
+      --db-host DB_HOST     IP or hostname for the database [env var:
+                            POGOMAP_DB_HOST]
+      --db-port DB_PORT     Port for the database [env var: POGOMAP_DB_PORT]
       --db-max_connections DB_MAX_CONNECTIONS
-                            Max connections (per thread) for the database.
+                            Max connections (per thread) for the database [env
+                            var: POGOMAP_DB_MAX_CONNECTIONS]
       --db-threads DB_THREADS
                             Number of db threads; increase if the db queue falls
-                            behind.
+                            behind [env var: POGOMAP_DB_THREADS]
       -wh [WEBHOOKS [WEBHOOKS ...]], --webhook [WEBHOOKS [WEBHOOKS ...]]
-                            Define URL(s) to POST webhook information to.
+                            Define URL(s) to POST webhook information to [env var:
+                            POGOMAP_WEBHOOK]
       -gi, --gym-info       Get all details about gyms (causes an additional API
-                            hit for every gym).
+                            hit for every gym) [env var: POGOMAP_GYM_INFO]
+      --disable-clean       Disable clean db loop [env var: POGOMAP_DISABLE_CLEAN]
       --webhook-updates-only
-                            Only send updates (pokemon & lured pokestops).
+                            Only send updates (pokÃ©mon & lured pokÃ©stops) [env
+                            var: POGOMAP_WEBHOOK_UPDATES_ONLY]
       --wh-threads WH_THREADS
                             Number of webhook threads; increase if the webhook
-                            queue falls behind.
+                            queue falls behind [env var: POGOMAP_WH_THREADS]
       --ssl-certificate SSL_CERTIFICATE
-                            Path to SSL certificate file.
+                            Path to SSL certificate file [env var:
+                            POGOMAP_SSL_CERTIFICATE]
       --ssl-privatekey SSL_PRIVATEKEY
-                            Path to SSL private key file.
+                            Path to SSL private key file [env var:
+                            POGOMAP_SSL_PRIVATEKEY]
       -ps, --print-status   Show a status screen instead of log messages. Can
-                            switch between status and logs by pressing enter.
+                            switch between status and logs by pressing enter. [env
+                            var: POGOMAP_PRINT_STATUS]
       -sn STATUS_NAME, --status-name STATUS_NAME
                             Enable status page database update using STATUS_NAME
-                            as main worker name.
+                            as main worker name [env var: POGOMAP_STATUS_NAME]
       -spp STATUS_PAGE_PASSWORD, --status-page-password STATUS_PAGE_PASSWORD
-                            Set the status page password.
+                            Set the status page password [env var:
+                            POGOMAP_STATUS_PAGE_PASSWORD]
       -el ENCRYPT_LIB, --encrypt-lib ENCRYPT_LIB
                             Path to encrypt lib to be used instead of the shipped
-                            ones.
+                            ones [env var: POGOMAP_ENCRYPT_LIB]
+      -odt ON_DEMAND_TIMEOUT, --on-demand_timeout ON_DEMAND_TIMEOUT
+                            Pause searching while web UI is inactive for this
+                            timeout(in seconds) [env var:
+                            POGOMAP_ON_DEMAND_TIMEOUT]
       -v [filename.log], --verbose [filename.log]
                             Show debug messages from PomemonGo-Map and pgoapi.
-                            Optionally specify file to log to.
+                            Optionally specify file to log to. [env var:
+                            POGOMAP_VERBOSE]
       -vv [filename.log], --very-verbose [filename.log]
                             Like verbose, but show debug messages from all modules
-                            as well. Optionally specify file to log to.
-      -d, --debug           Depreciated, use -v or -vv instead.
-    
+                            as well. Optionally specify file to log to. [env var:
+                            POGOMAP_VERY_VERBOSE]
+      -d, --debug           Deprecated, use -v or -vv instead. [env var:
+                            POGOMAP_DEBUG]

--- a/docs/extras/configuration-files.md
+++ b/docs/extras/configuration-files.md
@@ -4,7 +4,7 @@ Configuration files can be used to organize server/scanner deployments.  Any lon
 
 ##  Default file
 
-The default configuration file is *config/config.ini* underneath the project home.   However, this location can be changed by setting the environment variable POGOMAP_CONFIG or using the -cf or --config flag on the command line.   In the event that both the environment variable and the command line argument exists, the command line value will take precedence.
+The default configuration file is *config/config.ini* underneath the project home.   However, this location can be changed by setting the environment variable POGOMAP_CONFIG or using the -cf or --config flag on the command line.   In the event that both the environment variable and the command line argument exists, the command line value will take precedence.  Note that all relative pathnames are relative to the current working directory (often, but not necessarily where runserver.py is located).
 
 ## Setting configuration key/value pairs
 
@@ -25,6 +25,7 @@ The default configuration file is *config/config.ini* underneath the project hom
 
 ## Example config file
 
+  <pre>
   -- contents of file myconfig.seattle --
   username: [ randomjoe, bob ]
   password: [ password1, password2 ]
@@ -33,6 +34,7 @@ The default configuration file is *config/config.ini* underneath the project hom
   gmaps-key: MyGmapsKeyGoesHereSomeLongString
   print-status: True
   -- end of file --
+  </pre>
 
   Running this config file as:
 
@@ -44,6 +46,6 @@ The default configuration file is *config/config.ini* underneath the project hom
 
 ## running multiple configs
 
-   One common way of running multiple locations is to use two configuration files, with the first running as both a scanner and a server, and in the second configuration file, use the *no-server* flag to not start the web interface for the second configuration.   In the config file, this would mean including a line like:
+   One common way of running multiple locations is to use two configuration files each with common or default database values, but with different location specs. The first configuration running as both a scanner and a server, and in the second configuration file, use the *no-server* flag to not start the web interface for the second configuration.   In the config file, this would mean including a line like:
 
    no-server: True

--- a/docs/extras/configuration-files.md
+++ b/docs/extras/configuration-files.md
@@ -1,0 +1,49 @@
+# Configuration files
+
+Configuration files can be used to organize server/scanner deployments.  Any long-form command-line argument can be specified in a configuration file.
+
+##  Default file
+
+The default configuration file is *config/config.ini* underneath the project home.   However, this location can be changed by setting the environment variable POGOMAP_CONFIG or using the -cf or --config flag on the command line.   In the event that both the environment variable and the command line argument exists, the command line value will take precedence.
+
+## Setting configuration key/value pairs
+
+  For command line values that take a single value they can be specified as:
+
+    keyname: value
+    e.g.   host: 0.0.0.0
+
+  For parameters that may be repeated:
+
+    keyname: [ value1, value2, ...]
+    e.g.   username: [ randomjoe, bonnieclyde ]
+
+  For command line arguments that take no parameters:
+
+    keyname: True
+    e.g.   fixed-location: True
+
+## Example config file
+
+  -- contents of file myconfig.seattle --
+  username: [ randomjoe, bob ]
+  password: [ password1, password2 ]
+  location: seattle, wa
+  step-limit: 5
+  gmaps-key: MyGmapsKeyGoesHereSomeLongString
+  print-status: True
+  -- end of file --
+
+  Running this config file as:
+
+     python runserver.py -c myconfig.seattle
+
+  would be the same as running with the following command line:
+
+     python runserver.py -u randomjoe -p password1 -u bob -p password2 -l "seattle, wa" -st 5 -k MyGmapsKeyGoesHereSomeLongString -ps
+
+## running multiple configs
+
+   One common way of running multiple locations is to use two configuration files, with the first running as both a scanner and a server, and in the second configuration file, use the *no-server* flag to not start the web interface for the second configuration.   In the config file, this would mean including a line like:
+
+   no-server: True

--- a/docs/extras/configuration-files.md
+++ b/docs/extras/configuration-files.md
@@ -44,7 +44,7 @@ The default configuration file is *config/config.ini* underneath the project hom
 
      python runserver.py -u randomjoe -p password1 -u bob -p password2 -l "seattle, wa" -st 5 -k MyGmapsKeyGoesHereSomeLongString -ps
 
-## running multiple configs
+## Running multiple configs
 
    One common way of running multiple locations is to use two configuration files each with common or default database values, but with different location specs. The first configuration running as both a scanner and a server, and in the second configuration file, use the *no-server* flag to not start the web interface for the second configuration.   In the config file, this would mean including a line like:
 

--- a/docs/extras/configuration-files.md
+++ b/docs/extras/configuration-files.md
@@ -38,7 +38,7 @@ The default configuration file is *config/config.ini* underneath the project hom
 
   Running this config file as:
 
-     python runserver.py -c myconfig.seattle
+     python runserver.py -cf myconfig.seattle
 
   would be the same as running with the following command line:
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -44,8 +44,10 @@ def memoize(function):
 @memoize
 def get_args():
     # fuck PEP8
-    configpath = os.path.join(os.path.dirname(__file__), '../config/config.ini')
-    parser = configargparse.ArgParser(default_config_files=[configpath], auto_env_var_prefix='POGOMAP_')
+    defaultconfigpath = os.getenv('POGOMAP_CONFIG', os.path.join(os.path.dirname(__file__), '../config/config.ini'))
+    parser = configargparse.ArgParser(default_config_files=[defaultconfigpath], auto_env_var_prefix='POGOMAP_')
+    parser.add_argument('-cf', '--config', is_config_file=True, default=defaultconfigpath,
+                        help='Configuration file')
     parser.add_argument('-a', '--auth-service', type=str.lower, action='append', default=[],
                         help='Auth Services, either one for all accounts or one per account: ptc or google. Defaults all to ptc.')
     parser.add_argument('-u', '--username', action='append', default=[],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
add -cf --config  option to allow a config file to be specified...or use the environment variable POGOMAP_CONFIG

## Motivation and Context
allow multiple server configurations to be run via config files
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with various combinations of POGOMAP_CONFIG env variable settings and -cf command line settings.   Used both absolute and relative pathnames (relative to the current working directory)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X ] My change requires a change to the documentation.
- [X ] I have updated the documentation accordingly.

