### PR TITLE
Removed references to third party docker container

### DIFF
--- a/docs/advanced-install/amazon-ecs.md
+++ b/docs/advanced-install/amazon-ecs.md
@@ -2,7 +2,7 @@
 
 > **Warning** -- Most cloud providers have been IP blocked from accessing the API
 
-Amazon ECS is essentially managed docker allowed you to run multi-container environments easily with minimal configuration. In this guide we'll create an ECS Task that will run a single pokemongo-map container with a MariaDB container
+Amazon ECS is essentially managed docker allowed you to run multi-container environments easily with minimal configuration. In this guide we'll create an ECS Task that will run a single pokemongo-map container with a MariaDB container for persisting the data
 
 ## Requirements
 
@@ -14,12 +14,12 @@ Amazon ECS is essentially managed docker allowed you to run multi-container envi
 
 In the AWS ECS console create a Task Definition with the JSON below. You will need to set the following values:
 
-* `POKEMON_USERNAME` - username for pokemongo
-* `POKEMON_PASSWORD` - password for pokemongo
-* `POKEMON_AUTH_SERVICE` - Define if you are using google or ptc auth
-* `POKEMON_LOCATION` - Location to search
-* `POKEMON_DB_USER` - Database user for MariaDB
-* `POKEMON_DB_PASS` - Database password for MariaDB
+* `POGOM_USERNAME` - username for pokemongo
+* `POGOM_PASSWORD` - password for pokemongo
+* `POGOM_AUTH_SERVICE` - Define if you are using google or ptc auth
+* `POGOM_LOCATION` - Location to search
+* `POGOM_DB_USER` - Database user for MariaDB
+* `POGOM_DB_PASS` - Database password for MariaDB
 
 ```json
 {
@@ -48,51 +48,47 @@ In the AWS ECS console create a Task Definition with the JSON below. You will ne
             "dockerSecurityOptions": null,
             "environment": [
                 {
-                    "name": "POKEMON_DB_TYPE",
+                    "name": "POGOM_DB_TYPE",
                     "value": "mysql"
                 },
                 {
-                    "name": "POKEMON_LOCATION",
+                    "name": "POGOM_LOCATION",
                     "value": "Seattle, WA"
                 },
                 {
-                    "name": "POKEMON_DB_HOST",
+                    "name": "POGOM_DB_HOST",
                     "value": "database"
                 },
                 {
-                    "name": "POKEMON_NUM_THREADS",
+                    "name": "POGOM_NUM_THREADS",
                     "value": "1"
                 },
                 {
-                    "name": "POKEMON_DB_NAME",
+                    "name": "POGOM_DB_NAME",
                     "value": "pogom"
                 },
                 {
-                    "name": "POKEMON_PASSWORD",
+                    "name": "POGOM_PASSWORD",
                     "value": "MyPassword"
                 },
                 {
-                    "name": "POKEMON_GMAPS_KEY",
+                    "name": "POGOM_GMAPS_KEY",
                     "value": "SUPERSECRET"
                 },
                 {
-                    "name": "POKEMON_AUTH_SERVICE",
+                    "name": "POGOM_AUTH_SERVICE",
                     "value": "ptc"
                 },
                 {
-                    "name": "POKEMON_DB_PASS",
+                    "name": "POGOM_DB_PASS",
                     "value": "somedbpassword"
                 },
                 {
-                    "name": "POKEMON_DB_USER",
+                    "name": "POGOM_DB_USER",
                     "value": "pogom"
                 },
                 {
-                    "name": "POKEMON_STEP_LIMIT",
-                    "value": "10"
-                },
-                {
-                    "name": "POKEMON_USERNAME",
+                    "name": "POGOM_USERNAME",
                     "value": "MyUser"
                 }
             ],
@@ -101,7 +97,7 @@ In the AWS ECS console create a Task Definition with the JSON below. You will ne
             ],
             "workingDirectory": null,
             "readonlyRootFilesystem": null,
-            "image": "ashex/pokemongo-map",
+            "image": "pokemap/pokemongo-map",
             "command": null,
             "user": null,
             "dockerLabels": null,
@@ -160,6 +156,6 @@ In the AWS ECS console create a Task Definition with the JSON below. You will ne
 ```
 
 
-If you would like to add workers you can easily do so by adding another container with the additional variable `POKEMON_NO_SERVER` set to `true`. You have to let one of the pokemongo-map containers start first to create the database, an easy way to control this is to create a link from the worker to the primary one as it will delay the start.
+If you would like to add workers you can easily do so by adding another container with the additional variable `POGOM_NO_SERVER` set to `true`. You have to let one of the pokemongo-map containers start first to create the database, an easy way to control this is to create a link from the worker to the primary one as it will delay the start.
 
 Once the Task is running you'll be able to access the app via the Instances IP on port 80.

--- a/docs/advanced-install/amazon-ecs.md
+++ b/docs/advanced-install/amazon-ecs.md
@@ -97,7 +97,7 @@ In the AWS ECS console create a Task Definition with the JSON below. You will ne
             ],
             "workingDirectory": null,
             "readonlyRootFilesystem": null,
-            "image": "pokemap/pokemongo-map",
+            "image": "frostthefox/pokemongo-map",
             "command": null,
             "user": null,
             "dockerLabels": null,

--- a/docs/advanced-install/docker.md
+++ b/docs/advanced-install/docker.md
@@ -101,17 +101,16 @@ If you are running a ngrok container, you've got to stop it as well. To start th
 
 ## Running on docker cloud 
 
-If you want to run pokemongo-map on a service that doesn't support arguments like docker cloud or ECS, you'll need to use one of the more specialised images out there that supports variables. The image `ashex/pokemongo-map` handles variables, below is an example:
+If you want to run pokemongo-map on a service that doesn't support arguments like docker cloud or ECS, you'll need to pass settings via variables below is an example:
 
 ```bash
   docker run -d -P \
-    -e "AUTH_SERVICE=ptc" \
-    -e "USERNAME=UserName" \
-    -e "PASSWORD=Password" \
-    -e "LOCATION=Seattle, WA" \
-    -e "STEP_LIMIT=5" \
-    -e "GMAPS_KEY=SUPERSECRET" \
-    ashex/pokemongo-map
+    -e "POGOM_AUTH_SERVICE=ptc" \
+    -e "POGOM_USERNAME=UserName" \
+    -e "POGOM_PASSWORD=Password" \
+    -e "POGOM_LOCATION=Seattle, WA" \
+    -e "POGOM_GMAPS_KEY=SUPERSECRET" \
+    pokemap/pokemongo-map
 ```
 
 ## Advanced Docker Setup

--- a/docs/advanced-install/docker.md
+++ b/docs/advanced-install/docker.md
@@ -22,14 +22,14 @@ If that doesn't bother you, and you just want to give PokemonGo-Map a go, keep o
 In order to start the map, you've got to run your docker container with a few arguments, such as authentication type, account, password, desired location and steps. If you don't know which arguments are necessary, you can use the following command to get help:
 
 ```
-docker run --rm pokemap/pokemongo-map -h
+docker run --rm frostthefox/pokemongo-map -h
 ```
 
 To be able to access the map in your machine via browser, you've got to bind a port on your host machine to the one wich will be exposed by the container (default is 5000). The following docker run command is an example of to launch a container with a very basic setup of the map, following the instructions above:
 
 ```
 docker run -d --name pogomap -p 5000:5000 \
-  pokemap/pokemongo-map \
+  frostthefox/pokemongo-map \
     -a ptc -u username -p password \
     -k 'your-google-maps-key' \
     -l 'lat, lon' \
@@ -94,7 +94,7 @@ Open that URL in your browser and you're ready to rock!
 In order to update your PokemonGo-Map docker image, you should stop/remove all the containers running with the current (outdated) version (refer to "Stopping the server"), pull the latest docker image version, and restart everything. To pull the latest image, use the following command:
 
 ```
-docker pull pokemap/pokemongo-map
+docker pull frostthefox/pokemongo-map
 ```
 
 If you are running a ngrok container, you've got to stop it as well. To start the server after updating your image, simply use the same commands that were used before, and the containers will be launched with the latest version.
@@ -110,7 +110,7 @@ If you want to run pokemongo-map on a service that doesn't support arguments lik
     -e "POGOM_PASSWORD=Password" \
     -e "POGOM_LOCATION=Seattle, WA" \
     -e "POGOM_GMAPS_KEY=SUPERSECRET" \
-    pokemap/pokemongo-map
+    frostthefox/pokemongo-map
 ```
 
 ## Advanced Docker Setup
@@ -161,7 +161,7 @@ Now that we have a persistent database up and running, we need to launch our Pok
 
 ```
 docker run -d --name pogomap --net=pogonw -p 5000:5000 \
-  pokemap/pokemongo-map \
+  frostthefox/pokemongo-map \
     -a ptc -u username -p password \
     -k 'your-google-maps-key' \
     -l 'lat, lon' \
@@ -190,7 +190,7 @@ If you would like to launch a different worker sharing the same db, to scan a di
 
 ```
 docker run -d --name pogomap2 --net=pogonw \
-  pokemap/pokemongo-map \
+  frostthefox/pokemongo-map \
     -a ptc -u username2 -p password2 \
     -k 'your-google-maps-key' \
     -l 'newlat, newlon' \
@@ -246,7 +246,7 @@ If you have a docker image for a notification webhook that you want to be called
 
 ```
 docker run -d --name pogomap --net=pogonw -p 5000:5000 \
-  pokemap/pokemongo-map \
+  frostthefox/pokemongo-map \
     -a ptc -u username -p password \
     -k 'your-google-maps-key' \
     -l 'lat, lon' \


### PR DESCRIPTION
Documentation cleanup. develop is the new master and releases aren't happening so my container is out of date therefore we should point users to the official docker container. I mostly did a quick search/replace to fix the variables and change the container name.


## Description
Removed references to the container `ashex/pokemongo-map`

## Motivation and Context
Glorious container has evolved and no longer deems the documentation worthy of mentioning it.

## How Has This Been Tested?
It's readable

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

