### PR TITLE
Fix scrolling issue on small screens/mobile

### DIFF
--- a/templates/map.html
+++ b/templates/map.html
@@ -241,7 +241,7 @@
           </div>
         </div>
       </nav>
-      <nav id="stats">
+      <nav id="stats" style="position:fixed;">
         <div class="switch-container">
           <div class="switch-container">
             <div><center><a href="stats">Full Stats</a></center></div>


### PR DESCRIPTION
I noticed that on mobile, the stats tab(on the far right), wouldn't let me scroll down it. 

## Description
I investigated the CSS on the stats div, and discovered that the position needs to be "fixed" in order to allow for scrolling.

## Motivation and Context
Fixed stats usage on small screens

## How Has This Been Tested?
Tested on my mobile device, and on my desktop

## Screenshots (if appropriate):
N/A
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
