### PR TITLE
add option to specify config file on command line or via env variable #1341 - Rebased

### DIFF
--- a/docs/extras/commandline.md
+++ b/docs/extras/commandline.md
@@ -1,41 +1,42 @@
 # Command Line
 
-    usage: runserver.py 
-                        [-h] [-a AUTH_SERVICE] [-u USERNAME] [-p PASSWORD]
-                        [-w WORKERS] [-asi ACCOUNT_SEARCH_INTERVAL]
+    usage: runserver.py
+                        [-h] [-cf CONFIG] [-a AUTH_SERVICE] [-u USERNAME]
+                        [-p PASSWORD] [-w WORKERS] [-asi ACCOUNT_SEARCH_INTERVAL]
                         [-ari ACCOUNT_REST_INTERVAL] [-ac ACCOUNTCSV]
                         [-l LOCATION] [-j] [-st STEP_LIMIT] [-sd SCAN_DELAY]
                         [-ld LOGIN_DELAY] [-lr LOGIN_RETRIES] [-mf MAX_FAILURES]
                         [-msl MIN_SECONDS_LEFT] [-dc] [-H HOST] [-P PORT]
                         [-L LOCALE] [-c] [-m MOCK] [-ns] [-os] [-nsc] [-fl] -k
-                        GMAPS_KEY [--skip-empty] [-C] [-D DB] [-cd] [-np] [-ng]
-                        [-nk] [-ss [SPAWNPOINT_SCANNING]] [--dump-spawnpoints]
-                        [-pd PURGE_DATA] [-px PROXY] [-pxsc] [-pxt PROXY_TIMEOUT]
-                        [-pxd PROXY_DISPLAY] [--db-type DB_TYPE]
-                        [--db-name DB_NAME] [--db-user DB_USER]
-                        [--db-pass DB_PASS] [--db-host DB_HOST]
-                        [--db-port DB_PORT]
+                        GMAPS_KEY [--skip-empty] [-C] [-D DB] [-cd] [-np]
+                        [-ng] [-nk] [-ss [SPAWNPOINT_SCANNING]]
+                        [--dump-spawnpoints] [-pd PURGE_DATA] [-px PROXY]
+                        [-pxt PROXY_TIMEOUT] [-pxd PROXY_DISPLAY]
+                        [--db-type DB_TYPE] [--db-name DB_NAME]
+                        [--db-user DB_USER] [--db-pass DB_PASS]
+                        [--db-host DB_HOST] [--db-port DB_PORT]
                         [--db-max_connections DB_MAX_CONNECTIONS]
                         [--db-threads DB_THREADS] [-wh [WEBHOOKS [WEBHOOKS ...]]]
-                        [-gi] [--disable-clean] [--webhook-updates-only]
-                        [--wh-threads WH_THREADS]
+                        [-gi] [--webhook-updates-only] [--wh-threads WH_THREADS]
                         [--ssl-certificate SSL_CERTIFICATE]
                         [--ssl-privatekey SSL_PRIVATEKEY] [-ps] [-sn STATUS_NAME]
                         [-spp STATUS_PAGE_PASSWORD] [-el ENCRYPT_LIB]
-                        [-odt ON_DEMAND_TIMEOUT] [-v [filename.log] | -vv
-                        [filename.log] | -d]
+                        [-v [filename.log] | -vv [filename.log] | -d]
     
     Args that start with '--' (eg. -a) can also be set in a config file
-    (/home/primaxius/PokemonGo-Map/pogom/../config/config.ini or ). The recognized
-    syntax for setting (key, value) pairs is based on the INI and YAML formats
-    (e.g. key=value or foo=TRUE). For full documentation of the differences from
-    the standards please refer to the ConfigArgParse documentation. If an arg is
-    specified in more than one place, then commandline values override environment
-    variables which override config file values which override defaults.
+    (default: <PokemonGo-Map Project Root>/config/config.ini or via -cf).
+    The recognized syntax for setting (key, value) pairs is based on the INI and
+    YAML formats (e.g. key=value or foo=TRUE). For full documentation of the
+    differences from the standards please refer to the ConfigArgParse
+    documentation. If an arg is specified in more than one place, then commandline
+    values override environment variables which override config file values which
+    override defaults.
     
     optional arguments:
       -h, --help            show this help message and exit [env var:
                             POGOMAP_HELP]
+      -cf CONFIG, --config CONFIG
+                            Configuration file.  See docs/extras/configuration-files.md
       -a AUTH_SERVICE, --auth-service AUTH_SERVICE
                             Auth Services, either one for all accounts or one per
                             account: ptc or google. Defaults all to ptc. [env var:

--- a/docs/extras/configuration-files.md
+++ b/docs/extras/configuration-files.md
@@ -1,0 +1,51 @@
+# Configuration files
+
+Configuration files can be used to organize server/scanner deployments.  Any long-form command-line argument can be specified in a configuration file.
+
+##  Default file
+
+The default configuration file is *config/config.ini* underneath the project home.   However, this location can be changed by setting the environment variable POGOMAP_CONFIG or using the -cf or --config flag on the command line.   In the event that both the environment variable and the command line argument exists, the command line value will take precedence.  Note that all relative pathnames are relative to the current working directory (often, but not necessarily where runserver.py is located).
+
+## Setting configuration key/value pairs
+
+  For command line values that take a single value they can be specified as:
+
+    keyname: value
+    e.g.   host: 0.0.0.0
+
+  For parameters that may be repeated:
+
+    keyname: [ value1, value2, ...]
+    e.g.   username: [ randomjoe, bonnieclyde ]
+
+  For command line arguments that take no parameters:
+
+    keyname: True
+    e.g.   fixed-location: True
+
+## Example config file
+
+  <pre>
+  -- contents of file myconfig.seattle --
+  username: [ randomjoe, bob ]
+  password: [ password1, password2 ]
+  location: seattle, wa
+  step-limit: 5
+  gmaps-key: MyGmapsKeyGoesHereSomeLongString
+  print-status: True
+  -- end of file --
+  </pre>
+
+  Running this config file as:
+
+     python runserver.py -cf myconfig.seattle
+
+  would be the same as running with the following command line:
+
+     python runserver.py -u randomjoe -p password1 -u bob -p password2 -l "seattle, wa" -st 5 -k MyGmapsKeyGoesHereSomeLongString -ps
+
+## Running multiple configs
+
+   One common way of running multiple locations is to use two configuration files each with common or default database values, but with different location specs. The first configuration running as both a scanner and a server, and in the second configuration file, use the *no-server* flag to not start the web interface for the second configuration.   In the config file, this would mean including a line like:
+
+   no-server: True

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -44,8 +44,10 @@ def memoize(function):
 @memoize
 def get_args():
     # fuck PEP8
-    configpath = os.path.join(os.path.dirname(__file__), '../config/config.ini')
-    parser = configargparse.ArgParser(default_config_files=[configpath], auto_env_var_prefix='POGOMAP_')
+    defaultconfigpath = os.getenv('POGOMAP_CONFIG', os.path.join(os.path.dirname(__file__), '../config/config.ini'))
+    parser = configargparse.ArgParser(default_config_files=[defaultconfigpath], auto_env_var_prefix='POGOMAP_')
+    parser.add_argument('-cf', '--config', is_config_file=True, default=defaultconfigpath,
+                        help='Configuration file')
     parser.add_argument('-a', '--auth-service', type=str.lower, action='append', default=[],
                         help='Auth Services, either one for all accounts or one per account: ptc or google. Defaults all to ptc.')
     parser.add_argument('-u', '--username', action='append', default=[],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Originally PR 1341 REBASED 

add -cf --config  option to allow a config file to be specified...or use the environment variable POGOMAP_CONFIG

## Motivation and Context
allow multiple server configurations to be run via config files
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with various combinations of POGOMAP_CONFIG env variable settings and -cf command line settings.   Used both absolute and relative pathnames (relative to the current working directory)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X ] My change requires a change to the documentation.
- [X ] I have updated the documentation accordingly.

