### PR TITLE
Change cool-off time display to minutes and only print it once

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -215,8 +215,8 @@ def account_recycler(accounts_queue, account_failures, args):
                 account_failures.remove(a)
                 accounts_queue.put(a['account'])
             else:
-                if not 'notified' in a:
-                    log.info('Account {} needs to cool off for {} minutes due to {}'.format(a['account']['username'], round((a['last_fail_time'] - ok_time)/60,0), a['reason']))
+                if 'notified' not in a:
+                    log.info('Account {} needs to cool off for {} minutes due to {}'.format(a['account']['username'], round((a['last_fail_time'] - ok_time) / 60, 0), a['reason']))
                     a['notified'] = True
 
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -215,7 +215,9 @@ def account_recycler(accounts_queue, account_failures, args):
                 account_failures.remove(a)
                 accounts_queue.put(a['account'])
             else:
-                log.info('Account {} needs to cool off for {} seconds due to {}'.format(a['account']['username'], a['last_fail_time'] - ok_time, a['reason']))
+                if not 'notified' in a:
+                    log.info('Account {} needs to cool off for {} minutes due to {}'.format(a['account']['username'], round((a['last_fail_time'] - ok_time)/60,0), a['reason']))
+                    a['notified'] = True
 
 
 def worker_status_db_thread(threads_status, name, db_updates_queue):


### PR DESCRIPTION
## Description

Change cool-off notification in account recycler to minutes instead of seconds, and only print it once when the cool off happens and not every minute while someone is cooled off
## Motivation and Context

Less spam
## How Has This Been Tested?

Tested on local machine
## Screenshots (if appropriate):

09-25 07:20 account-recycler  pogom.search   INFO     Account xxx needs to cool off for 119.0 minutes due to exception
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
