### PR TITLE
Show empty slots on the Gym Details popup

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -344,7 +344,20 @@ function pokemonLabel (name, rarity, types, disappearTime, id, latitude, longitu
 }
 
 function gymLabel (teamName, teamId, gymPoints, latitude, longitude, lastScanned = null, name = null, members = []) {
+  var gymPrestige = [2000, 4000, 8000, 12000, 16000, 20000, 30000, 40000, 50000]
+  var gymLevel = 1
+  while (gymPoints >= gymPrestige[gymLevel - 1]) {
+    gymLevel++
+  }
+
   var memberStr = ''
+  if (teamId && members.length > 0 && gymLevel > members.length) {
+    for (var j = 0; j < gymLevel - members.length; j++) {
+      memberStr +=
+        `<span class="gym-member free" title="Free slot">
+        </span>`
+    }
+  }
   for (var i = 0; i < members.length; i++) {
     memberStr += `
       <span class="gym-member" title="${members[i].pokemon_name} | ${members[i].trainer_name} (Lvl ${members[i].trainer_level})">
@@ -386,11 +399,6 @@ function gymLabel (teamName, teamId, gymPoints, latitude, longitude, lastScanned
         </center>
       </div>`
   } else {
-    var gymPrestige = [2000, 4000, 8000, 12000, 16000, 20000, 30000, 40000, 50000]
-    var gymLevel = 1
-    while (gymPoints >= gymPrestige[gymLevel - 1]) {
-      gymLevel++
-    }
     str = `
       <div>
         <center>

--- a/static/sass/components/_gym-member.scss
+++ b/static/sass/components/_gym-member.scss
@@ -1,7 +1,15 @@
 .gym-member {
-  
+
   display: inline-block;
   margin-left: 1px;
+  vertical-align: bottom;
+
+  &.free {
+    width: 30px;
+    height: 48px;
+    background-color: lightgray;
+    border-radius: 5px;
+  }
 
   .cp {
     display: block;


### PR DESCRIPTION
Currently you can calculate the available empty slots from dividing the member count from the gym level. Although this is easy, it would be even easier to see the empty slots, just like ingame.
## Description

I have created grey rectangles for the empty slots.
## Motivation and Context

Improves readability.
## How Has This Been Tested?

By npm run build and ctrl+f5 in the browser. Incredible testing environment.
## Screenshots (if appropriate):

![gym-empty-slots](https://cloud.githubusercontent.com/assets/988167/18847052/e5309cf4-8428-11e6-9de3-79f333d7fbf0.png)
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
