### PR TITLE
Add scan here function

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -73,7 +73,7 @@ class Pogom(Flask):
             self.search_control.clear()
         fixed_display = "none" if args.fixed_location else "inline"
         search_display = "inline" if args.search_control and args.on_demand_timeout <= 0 else "none"
-		scan_display = "none" if (args.only_server or args.fixed_location or args.spawnpoint_scanning) else "inline"
+        scan_display = "none" if (args.only_server or args.fixed_location or args.spawnpoint_scanning) else "inline"
 
         return render_template('map.html',
                                lat=self.current_location[0],
@@ -82,7 +82,7 @@ class Pogom(Flask):
                                lang=config['LOCALE'],
                                is_fixed=fixed_display,
                                search_control=search_display,
-							   show_scan=scan_display
+                               show_scan=scan_display
                                )
 
     def raw_data(self):

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -73,6 +73,7 @@ class Pogom(Flask):
             self.search_control.clear()
         fixed_display = "none" if args.fixed_location else "inline"
         search_display = "inline" if args.search_control and args.on_demand_timeout <= 0 else "none"
+		scan_display = "none" if (args.only_server or args.fixed_location or args.spawnpoint_scanning) else "inline"
 
         return render_template('map.html',
                                lat=self.current_location[0],
@@ -80,7 +81,8 @@ class Pogom(Flask):
                                gmaps_key=config['GMAPS_KEY'],
                                lang=config['LOCALE'],
                                is_fixed=fixed_display,
-                               search_control=search_display
+                               search_control=search_display,
+							   show_scan=scan_display
                                )
 
     def raw_data(self):

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -154,6 +154,16 @@ function initMap () { // eslint-disable-line no-unused-vars
   locationMarker = createLocationMarker()
   createMyLocationButton()
   initSidebar()
+  
+  $('#scan-here').on('click', function () {
+    var loc = map.getCenter()
+    changeLocation(loc.lat(), loc.lng())
+
+    if (!$('#search-switch').checked) {
+      $('#search-switch').prop('checked', true)
+      searchControl('on')
+    }
+  })
 }
 
 function updateLocationMarker (style) {
@@ -251,10 +261,12 @@ function createSearchMarker () {
 var searchControlURI = 'search_control'
 function searchControl (action) {
   $.post(searchControlURI + '?action=' + encodeURIComponent(action))
+  $('#scan-here').toggleClass('disabled', action === 'off')
 }
 function updateSearchStatus () {
   $.getJSON(searchControlURI).then(function (data) {
     $('#search-switch').prop('checked', data.status)
+	$('#scan-here').toggleClass('disabled', !data.status)
   })
 }
 

--- a/static/sass/layout/_main.scss
+++ b/static/sass/layout/_main.scss
@@ -31,3 +31,29 @@ html, body {
   bottom: 0px;
   width: 100%;
 }
+
+.fab {
+  background: darken(_palette(accent2, bg), 12);
+  color: _palette(accent2, fg);
+  width:30px;
+  height:30px;
+  border-radius:100%;
+  border:none;
+  outline:none;
+  font-size:18px;
+  box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);
+  transition:.3s;
+  -webkit-tap-highlight-color: rgba(0,0,0,0);
+  text-align: center;
+}
+ 
+#scan-here {
+  @include icon('\f002');
+  position: fixed;
+  left: 50%;
+  margin-left: -15px;
+  bottom: 1.5em;
+  &.disabled {
+    opacity: 0.5;
+  }
+}

--- a/templates/map.html
+++ b/templates/map.html
@@ -280,6 +280,7 @@
         </div>
       </nav>
       <div id="map"></div>
+	  <div class="fab" id="scan-here" style="display:{{show_scan}}"></div>
     </div>
     <!-- Scripts -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.9.1/polyfill.min.js"></script>

--- a/templates/map.html
+++ b/templates/map.html
@@ -280,7 +280,7 @@
         </div>
       </nav>
       <div id="map"></div>
-	  <div class="fab" id="scan-here" style="display:{{show_scan}}"></div>
+      <div class="fab" id="scan-here" style="display:{{show_scan}}"></div>
     </div>
     <!-- Scripts -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/6.9.1/polyfill.min.js"></script>


### PR DESCRIPTION
## Description
Adds a "scan here" Floating Action Button at bottom center of the map. When clicked/touched, will set the current map center as new search location.

## Motivation and Context
When outside hunting Pokemon you often want to check a few nearby places before deciding which way to go. This is way more convenient when you can just move the map one or two kilometers/miles and tap "scan here" instead of having to type in the name of some location.

## How Has This Been Tested?
Tested using docker.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

This is the updated #16 PR, #1231 PR and #1307 including the last changes.