### PR TITLE
fix default config usage

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -45,8 +45,10 @@ def memoize(function):
 def get_args():
     # fuck PEP8
     defaultconfigpath = os.getenv('POGOMAP_CONFIG', os.path.join(os.path.dirname(__file__), '../config/config.ini'))
-    parser = configargparse.ArgParser(default_config_files=[defaultconfigpath], auto_env_var_prefix='POGOMAP_')
-    parser.add_argument('-cf', '--config', is_config_file=True, help='Configuration file')
+    if not os.path.isfile(os.path.realpath(defaultconfigpath)):
+        defaultconfigpath = None
+    parser = configargparse.ArgParser(auto_env_var_prefix='POGOMAP_')
+    parser.add_argument('-cf', '--config', is_config_file=True, default=defaultconfigpath, help='Configuration file')
     parser.add_argument('-a', '--auth-service', type=str.lower, action='append', default=[],
                         help='Auth Services, either one for all accounts or one per account: ptc or google. Defaults all to ptc.')
     parser.add_argument('-u', '--username', action='append', default=[],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This addresses the issues that configargparse layers config files if both the default config file and a command line config file exist.   

## Description
<!--- Describe your changes in detail -->
1) check for the existance of the default config file or the ENV variable setting... if they do not point to a real file (after resolving links)...set the default to None.   Setting this to None prevents a file not found error if no config file is specified.
2) set the defalt config file (as determined above) only in the add_argument() call -- this prevents layering of config files in cases where the default config.ini exists as well as a command line option is specified

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes layering of config files by configargparse
<!--- If it fixes an open issue, please link to the issue here. -->
#1413 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
tested combinations of:
no config files
just the default
config file specified on command line and a default exists (only uses the one on command line
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

