### PR TITLE
Handle default config file in configargparse correctly

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -43,12 +43,14 @@ def memoize(function):
 
 @memoize
 def get_args():
-    # fuck PEP8
-    defaultconfigpath = os.getenv('POGOMAP_CONFIG', os.path.join(os.path.dirname(__file__), '../config/config.ini'))
-    if not os.path.isfile(os.path.realpath(defaultconfigpath)):
-        defaultconfigpath = None
-    parser = configargparse.ArgParser(auto_env_var_prefix='POGOMAP_')
-    parser.add_argument('-cf', '--config', is_config_file=True, default=defaultconfigpath, help='Configuration file')
+    # pre-check to see if the -cf or --config flag is used on the command line
+    # if not, we'll use the env var or default value.  this prevents layering of
+    # config files, and handles missing config.ini as well
+    defaultconfigfiles = []
+    if '-cf' not in sys.argv and '--config' not in sys.argv:
+        defaultconfigfiles = [os.getenv('POGOMAP_CONFIG', os.path.join(os.path.dirname(__file__), '../config/config.ini'))]
+    parser = configargparse.ArgParser(default_config_files=defaultconfigfiles, auto_env_var_prefix='POGOMAP_')
+    parser.add_argument('-cf', '--config', is_config_file=True, help='Configuration file')
     parser.add_argument('-a', '--auth-service', type=str.lower, action='append', default=[],
                         help='Auth Services, either one for all accounts or one per account: ptc or google. Defaults all to ptc.')
     parser.add_argument('-u', '--username', action='append', default=[],

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -45,8 +45,10 @@ def memoize(function):
 def get_args():
     # fuck PEP8
     defaultconfigpath = os.getenv('POGOMAP_CONFIG', os.path.join(os.path.dirname(__file__), '../config/config.ini'))
-    parser = configargparse.ArgParser(default_config_files=[defaultconfigpath], auto_env_var_prefix='POGOMAP_')
-    parser.add_argument('-cf', '--config', is_config_file=True, help='Configuration file')
+    if not os.path.isfile(os.path.realpath(defaultconfigpath)):
+        defaultconfigpath = None
+    parser = configargparse.ArgParser(auto_env_var_prefix='POGOMAP_')
+    parser.add_argument('-cf', '--config', is_config_file=True, default=defaultconfigpath, help='Configuration file')
     parser.add_argument('-a', '--auth-service', type=str.lower, action='append', default=[],
                         help='Auth Services, either one for all accounts or one per account: ptc or google. Defaults all to ptc.')
     parser.add_argument('-u', '--username', action='append', default=[],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
because of how configargparse doesn't use the default value of the add_argument() call for config files, we need to check to see if the flag is going to be used before we set the default_config_files value in the parser create call

Solution is to prescan for the flags (-cf --config) in the sys.argv list... or to use another parser w/ just the -cf option and use parse_known_arguments(), but the former is the simpler solution.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
 #1447 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
removed config.ini and tested w/ and w/o -cf flag
had both config.ini and -cf options....  only -cf was used (no layering)
tested w/ env variable to override config.ini  as well

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
