### PR TITLE
Adding 3 new map styles: Pokémon Go Day / Pokémon Go Night / Pokémon Go Dynamic

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,8 @@
     "pGoStyle": true,
     "darkStyleNoLabels": true,
     "light2StyleNoLabels": true,
-    "pGoStyleNoLabels": true
+    "pGoStyleNoLabels": true,
+    "pGoStyleDay": true,
+    "pGoStyleNight": true
   }
 }

--- a/static/data/mapstyle.json
+++ b/static/data/mapstyle.json
@@ -8,5 +8,8 @@
   "style_pgo": "Pokémon Go",
   "dark_style_nl": "Dark (No Labels)",
   "style_light2_nl": "Light2 (No Labels)",
-  "style_pgo_nl": "Pokémon Go (No Labels)"
+  "style_pgo_nl": "Pokémon Go (No Labels)",
+  "style_pgo_day": "Pokémon Go Day",
+  "style_pgo_night": "Pokémon Go Night",
+  "style_pgo_dynamic": "Pokémon Go Dynamic"
 }

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -595,6 +595,199 @@ var pGoStyleNoLabels = [{
     'visibility': 'off'
   }]
 }]
+var pGoStyleDay = [{
+  'featureType': 'landscape.man_made',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#99f291'
+  }]
+}, {
+  'featureType': 'landscape.natural.landcover',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#00af8f'
+  }]
+}, {
+  'featureType': 'landscape.natural.terrain',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#00af8f'
+  }]
+}, {
+  'featureType': 'landscape.natural',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#00af8f'
+  }]
+}, {
+  'featureType': 'poi.attraction',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'visibility': 'on'
+  }]
+}, {
+  'featureType': 'poi.business',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#e4dfd9'
+  }]
+}, {
+  'featureType': 'poi.business',
+  'elementType': 'labels.icon',
+  'stylers': [{
+    'visibility': 'off'
+  }]
+}, {
+  'featureType': 'poi.park',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#00af8f'
+  }]
+}, {
+  'featureType': 'road',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#7eb2a4'
+  }]
+}, {
+  'featureType': 'road',
+  'elementType': 'geometry.stroke',
+  'stylers': [{
+    'color': '#ffff92'
+  }, {
+    'weight': '2'
+  }]
+}, {
+  'featureType': 'road.highway',
+  'elementType': 'labels.icon',
+  'stylers': [{
+    'visibility': 'off'
+  }]
+}, {
+  'featureType': 'water',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#1688da'
+  }]
+}, {
+  'featureType': 'poi.attraction',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#e4fdee'
+  }]
+}, {
+  'featureType': 'poi.sports_complex',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#d4ffbc'
+  }]
+}]
+var pGoStyleNight = [{
+  'featureType': 'landscape.man_made',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#12a085'
+  }]
+}, {
+  'featureType': 'landscape.natural.landcover',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#02706a'
+  }]
+}, {
+  'featureType': 'landscape.natural.terrain',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#02706a'
+  }]
+}, {
+  'featureType': 'landscape.natural',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#02706a'
+  }]
+}, {
+  'featureType': 'poi',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#6da298'
+  }]
+}, {
+  'featureType': 'poi.medical',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#6da298'
+  }]
+}, {
+  'featureType': 'poi.attraction',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'visibility': 'on'
+  }]
+}, {
+  'featureType': 'poi.business',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#1fba9c'
+  }]
+}, {
+  'featureType': 'poi.business',
+  'elementType': 'labels.icon',
+  'stylers': [{
+    'visibility': 'off'
+  }]
+}, {
+  'featureType': 'poi.park',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#02706a'
+  }]
+}, {
+  'featureType': 'transit',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#428290'
+  }]
+}, {
+  'featureType': 'road',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#316589'
+  }]
+}, {
+  'featureType': 'road',
+  'elementType': 'geometry.stroke',
+  'stylers': [{
+    'color': '#7f8b60'
+  }, {
+    'weight': '2'
+  }]
+}, {
+  'featureType': 'road.highway',
+  'elementType': 'labels.icon',
+  'stylers': [{
+    'visibility': 'off'
+  }]
+}, {
+  'featureType': 'water',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#1e4fbc'
+  }]
+}, {
+  'featureType': 'poi.attraction',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#1fba9c'
+  }]
+}, {
+  'featureType': 'poi.sports_complex',
+  'elementType': 'geometry.fill',
+  'stylers': [{
+    'color': '#1fba9c'
+  }]
+}]
+
 var pokemonSprites = {
   normal: {
     columns: 12,
@@ -671,9 +864,10 @@ var StoreTypes = {
   }
 }
 
+//set the default parameters for you map here
 var StoreOptions = {
   'map_style': {
-    default: 'roadmap',
+    default: 'roadmap', //roadmap, satellite, hybrid, nolabels_style, dark_style, style_light2, style_pgo, dark_style_nl, style_pgo_day, style_pgo_night, style_pgo_dynamic
     type: StoreTypes.String
   },
   'remember_select_exclude': {
@@ -685,7 +879,7 @@ var StoreOptions = {
     type: StoreTypes.JSON
   },
   'remember_select_rarity_notify': {
-    default: [],
+    default: [], //Common, Uncommon, Rare, Very Rare, Ultra Rare
     type: StoreTypes.JSON
   },
   'remember_text_perfection_notify': {

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -864,10 +864,10 @@ var StoreTypes = {
   }
 }
 
-//set the default parameters for you map here
+// set the default parameters for you map here
 var StoreOptions = {
   'map_style': {
-    default: 'roadmap', //roadmap, satellite, hybrid, nolabels_style, dark_style, style_light2, style_pgo, dark_style_nl, style_pgo_day, style_pgo_night, style_pgo_dynamic
+    default: 'roadmap', // roadmap, satellite, hybrid, nolabels_style, dark_style, style_light2, style_pgo, dark_style_nl, style_pgo_day, style_pgo_night, style_pgo_dynamic
     type: StoreTypes.String
   },
   'remember_select_exclude': {
@@ -879,7 +879,7 @@ var StoreOptions = {
     type: StoreTypes.JSON
   },
   'remember_select_rarity_notify': {
-    default: [], //Common, Uncommon, Rare, Very Rare, Ultra Rare
+    default: [], // Common, Uncommon, Rare, Very Rare, Ultra Rare
     type: StoreTypes.JSON
   },
   'remember_text_perfection_notify': {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1,4 +1,4 @@
-﻿//
+//
 // Global map.js variables
 //
 
@@ -113,7 +113,10 @@ function initMap () { // eslint-disable-line no-unused-vars
         'style_pgo',
         'dark_style_nl',
         'style_light2_nl',
-        'style_pgo_nl'
+        'style_pgo_nl',
+		'style_pgo_day',
+		'style_pgo_night',
+		'style_pgo_dynamic'
       ]
     }
   })
@@ -153,6 +156,22 @@ function initMap () { // eslint-disable-line no-unused-vars
   })
   map.mapTypes.set('style_pgo_nl', stylePgoNl)
 
+  var stylePgoDay = new google.maps.StyledMapType(pGoStyleDay, {
+    name: 'PokemonGo Day'
+  })
+  map.mapTypes.set('style_pgo_day', stylePgoDay)
+  
+  var stylePgoNight = new google.maps.StyledMapType(pGoStyleNight, {
+    name: 'PokemonGo Night'
+  })
+  map.mapTypes.set('style_pgo_night', stylePgoNight)
+  
+  //dynamic map style chooses stylePgoDay or stylePgoNight depending on client time
+  var current_date = new Date()
+  var current_hour = current_date.getHours()
+  var stylePgoDynamic = (current_hour >= 6 && current_hour < 19) ? stylePgoDay : stylePgoNight
+  map.mapTypes.set('style_pgo_dynamic', stylePgoDynamic)
+  
   map.addListener('maptypeid_changed', function (s) {
     Store.set('map_style', this.mapTypeId)
   })

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -114,9 +114,9 @@ function initMap () { // eslint-disable-line no-unused-vars
         'dark_style_nl',
         'style_light2_nl',
         'style_pgo_nl',
-		'style_pgo_day',
-		'style_pgo_night',
-		'style_pgo_dynamic'
+        'style_pgo_day',
+        'style_pgo_night',
+        'style_pgo_dynamic'
       ]
     }
   })
@@ -160,18 +160,18 @@ function initMap () { // eslint-disable-line no-unused-vars
     name: 'PokemonGo Day'
   })
   map.mapTypes.set('style_pgo_day', stylePgoDay)
-  
+
   var stylePgoNight = new google.maps.StyledMapType(pGoStyleNight, {
     name: 'PokemonGo Night'
   })
   map.mapTypes.set('style_pgo_night', stylePgoNight)
-  
-  //dynamic map style chooses stylePgoDay or stylePgoNight depending on client time
-  var current_date = new Date()
-  var current_hour = current_date.getHours()
-  var stylePgoDynamic = (current_hour >= 6 && current_hour < 19) ? stylePgoDay : stylePgoNight
+
+  // dynamic map style chooses stylePgoDay or stylePgoNight depending on client time
+  var currentDate = new Date()
+  var currentHour = currentDate.getHours()
+  var stylePgoDynamic = (currentHour >= 6 && currentHour < 19) ? stylePgoDay : stylePgoNight
   map.mapTypes.set('style_pgo_dynamic', stylePgoDynamic)
-  
+
   map.addListener('maptypeid_changed', function (s) {
     Store.set('map_style', this.mapTypeId)
   })

--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -308,7 +308,10 @@ function initMap () {
         'style_pgo',
         'dark_style_nl',
         'style_light2_nl',
-        'style_pgo_nl'
+        'style_pgo_nl',
+        'style_pgo_day',
+        'style_pgo_night',
+        'style_pgo_dynamic'
       ]
     }
   })
@@ -347,6 +350,22 @@ function initMap () {
     name: 'PokemonGo (No Labels)'
   })
   map.mapTypes.set('style_pgo_nl', stylePgoNl)
+
+  var stylePgoDay = new google.maps.StyledMapType(pGoStyleDay, {
+    name: 'PokemonGo Day'
+  })
+  map.mapTypes.set('style_pgo_day', stylePgoDay)
+
+  var stylePgoNight = new google.maps.StyledMapType(pGoStyleNight, {
+    name: 'PokemonGo Night'
+  })
+  map.mapTypes.set('style_pgo_night', stylePgoNight)
+
+  // dynamic map style chooses stylePgoDay or stylePgoNight depending on client time
+  var currentDate = new Date()
+  var currentHour = currentDate.getHours()
+  var stylePgoDynamic = (currentHour >= 6 && currentHour < 19) ? stylePgoDay : stylePgoNight
+  map.mapTypes.set('style_pgo_dynamic', stylePgoDynamic)
 
   map.addListener('maptypeid_changed', function (s) {
     Store.set('map_style', this.mapTypeId)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

This change adds 3 new map styles to the frontend:

Pokémon Go Day
Pokémon Go Night
Pokémon Go Dynamic

These map styles are designed to match the ingame appearance.
Pokémon Go Dynamic chooses Day or Night style depending on the client time.
## Motivation and Context

There are still many places, where we can improve the frontend design, starting here with more/better map styles.
## How Has This Been Tested?

Tested on my own map, works just as expected.
Live demo can be viewed here: [https://pogo.bruckbu.de/](https://pogo.bruckbu.de/)
## Screenshots (if appropriate):

![mapstyles](https://cloud.githubusercontent.com/assets/22676075/19219738/1a9f9f82-8e1c-11e6-8c4f-67f822038c18.jpg)
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->

<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->

<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
