### PR TITLE
use only resent SpawnPoints

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -346,13 +346,15 @@ class Pokemon(BaseModel):
         query = (query.where((Pokemon.latitude <= n) &
                              (Pokemon.latitude >= s) &
                              (Pokemon.longitude >= w) &
-                             (Pokemon.longitude <= e)
+                             (Pokemon.longitude <= e) &
+                             (Pokemon.disappear_time > (datetime.now() - timedelta(days=1)))
                              ))
         # Sqlite doesn't support distinct on columns
-        if args.db_type == 'mysql':
-            query = query.distinct(Pokemon.spawnpoint_id)
-        else:
-            query = query.group_by(Pokemon.spawnpoint_id)
+        #if args.db_type == 'mysql':
+        #    query = query.distinct(Pokemon.spawnpoint_id)
+        #else:
+        # mysql is f**king this up for some reason (2.6k => 400 spawnpoints found)
+        query = query.group_by(Pokemon.spawnpoint_id)
 
         s = list(query.dicts())
 

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -350,9 +350,9 @@ class Pokemon(BaseModel):
                              (Pokemon.disappear_time > (datetime.now() - timedelta(days=1)))
                              ))
         # Sqlite doesn't support distinct on columns
-        #if args.db_type == 'mysql':
+        # if args.db_type == 'mysql':
         #    query = query.distinct(Pokemon.spawnpoint_id)
-        #else:
+        # else:
         # mysql is f**king this up for some reason (2.6k => 400 spawnpoints found)
         query = query.group_by(Pokemon.spawnpoint_id)
 


### PR DESCRIPTION
instead of using all ever gained SpawnPoints only use the resent ones

## Description
I'm currently getting tonnes of SpawnPoints from the last 4 (or more) changes
which finally makes SpawnPoints Scanning inefficient even compared to HexScanning 

## Motivation and Context
filter get_spawnpoints_in_hex by disappear_time

## How Has This Been Tested?
yes, I had 2.6k spawnpoint, after the update 400
compared with a newly setup database this gives about the same value

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

