### PR TITLE
Enable automated recaptcha solving with 2captcha

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -427,7 +427,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                 log.debug("Using proxy %s", status['proxy_url'])
                 api.set_proxy({'http': status['proxy_url'], 'https': status['proxy_url']})
 
-            # api.activate_signature(encryption_lib_path)
+            api.activate_signature(encryption_lib_path)
 
             # The forever loop for the searches
             while True:

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -414,7 +414,6 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
 
             # only sleep when consecutive_fails reaches max_failures, overall fails for stat purposes
             consecutive_fails = 0
-            consecutive_empties = 0
 
             # Create the API instance this will use
             if args.mock != '':
@@ -426,7 +425,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                 log.debug("Using proxy %s", status['proxy_url'])
                 api.set_proxy({'http': status['proxy_url'], 'https': status['proxy_url']})
 
-            # api.activate_signature(encryption_lib_path)
+            api.activate_signature(encryption_lib_path)
 
             # The forever loop for the searches
             while True:
@@ -437,37 +436,6 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                     log.warning(status['message'])
                     account_failures.append({'account': account, 'last_fail_time': now(), 'reason': 'failures'})
                     break  # exit this loop to get a new account and have the API recreated
-
-                if args.captcha_solving:
-
-                    if consecutive_empties >= 2:
-                        captcha_url = captcha_request(api)
-
-                        if len(captcha_url) > 1:
-                            status['message'] = 'Account {} is encountering a captcha, starting 2captcha sequence'.format(account['username'])
-                            log.warning(status['message'])
-                            captcha_token = token_request(args, status, captcha_url)
-
-                            if 'ERROR' in captcha_token:
-                                log.warning("Unable to resolve captcha, please check your 2captcha API key and/or wallet balance")
-                                account_failures.append({'account': account, 'last_fail_time': now(), 'reason': 'catpcha failed to verify'})
-                                break
-
-                            else:
-                                status['message'] = 'Retrieved captcha token, attempting to verify challenge for {}'.format(account['username'])
-                                log.info(status['message'])
-                                response = api.verify_challenge(token = captcha_token)
-
-                                if 'success' in response['responses']['VERIFY_CHALLENGE']:
-                                    status['message'] = "Account {} successfully uncaptcha'd".format(account['username'])
-                                    log.info(status['message'])
-
-                                else:
-                                    status['message'] = "Account {} failed verifyChallenge, putting away account for now".format(account['username'])
-                                    log.info(status['message'])
-                                    account_failures.append({'account': account, 'last_fail_time': now(), 'reason': 'catpcha failed to verify'})
-                                    break
-                                time.sleep(1)
 
                 while pause_bit.is_set():
                     status['message'] = 'Scanning paused'
@@ -541,12 +509,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                 try:
                     parsed = parse_map(args, response_dict, step_location, dbq, whq, api)
                     search_items_queue.task_done()
-                    if parsed['count'] > 0:
-                        status['success'] += 1
-                        consecutive_empties = 0
-                    else:
-                        status['noitems'] += 1
-                        consecutive_empties += 1
+                    status[('success' if parsed['count'] > 0 else 'noitems')] += 1
                     consecutive_fails = 0
                     status['message'] = 'Search at {:6f},{:6f} completed with {} finds'.format(step_location[0], step_location[1], parsed['count'])
                     log.debug(status['message'])
@@ -691,34 +654,6 @@ def gym_request(api, position, gym):
     except Exception as e:
         log.warning('Exception while downloading gym details: %s', e)
         return False
-
-
-def captcha_request(api):
-    captcha = {}
-    response = api.check_challenge()
-    captcha_url = response['responses']['CHECK_CHALLENGE']['challenge_url']
-    return captcha_url
-
-
-def token_request(args, status, url):
-    s = requests.Session()
-    # Fetch the CAPTCHA_ID from 2captcha
-    try:
-        captcha_id = s.post("http://2captcha.com/in.php?key={}&method=userrecaptcha&googlekey={}&pageurl={}".format(args.captcha_key, args.captcha_dsk, url)).text.split('|')[1]
-        captcha_id = str(captcha_id)
-    # IndexError implies that the retuned response was a 2captcha error
-    except IndexError: 
-        return 'ERROR'
-    status['message'] = 'Retrieved captcha ID: {}; now retrieving token'.format(captcha_id)
-    log.info(status['message'])
-    # Get the response, retry every 5 seconds if its not ready
-    recaptcha_response = s.get("http://2captcha.com/res.php?key={}&action=get&id={}".format(args.captcha_key, captcha_id)).text
-    while 'CAPCHA_NOT_READY' in recaptcha_response:
-        log.info("Captcha token is not ready, retrying in 5 seconds")
-        time.sleep(5)
-        recaptcha_response = s.get("http://2captcha.com/res.php?key={}&action=get&id={}".format(args.captcha_key, captcha_id)).text
-    token = str(recaptcha_response.split('|')[1])
-    return token
 
 
 def calc_distance(pos1, pos2):

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -457,7 +457,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                             else:
                                 status['message'] = 'Retrieved captcha token, attempting to verify challenge for {}'.format(account['username'])
                                 log.info(status['message'])
-                                response = api.verify_challenge(token = captcha_token)
+                                response = api.verify_challenge(token=captcha_token)
 
                                 if 'success' in response['responses']['VERIFY_CHALLENGE']:
                                     status['message'] = "Account {} successfully uncaptcha'd".format(account['username'])
@@ -695,7 +695,6 @@ def gym_request(api, position, gym):
 
 
 def captcha_request(api):
-    captcha = {}
     response = api.check_challenge()
     captcha_url = response['responses']['CHECK_CHALLENGE']['challenge_url']
     return captcha_url
@@ -708,7 +707,7 @@ def token_request(args, status, url):
         captcha_id = s.post("http://2captcha.com/in.php?key={}&method=userrecaptcha&googlekey={}&pageurl={}".format(args.captcha_key, args.captcha_dsk, url)).text.split('|')[1]
         captcha_id = str(captcha_id)
     # IndexError implies that the retuned response was a 2captcha error
-    except IndexError: 
+    except IndexError:
         return 'ERROR'
     status['message'] = 'Retrieved captcha ID: {}; now retrieving token'.format(captcha_id)
     log.info(status['message'])

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -414,6 +414,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
 
             # only sleep when consecutive_fails reaches max_failures, overall fails for stat purposes
             consecutive_fails = 0
+            consecutive_empties = 0
 
             # Create the API instance this will use
             if args.mock != '':
@@ -425,7 +426,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                 log.debug("Using proxy %s", status['proxy_url'])
                 api.set_proxy({'http': status['proxy_url'], 'https': status['proxy_url']})
 
-            api.activate_signature(encryption_lib_path)
+            # api.activate_signature(encryption_lib_path)
 
             # The forever loop for the searches
             while True:
@@ -436,6 +437,37 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                     log.warning(status['message'])
                     account_failures.append({'account': account, 'last_fail_time': now(), 'reason': 'failures'})
                     break  # exit this loop to get a new account and have the API recreated
+
+                if args.captcha_solving:
+
+                    if consecutive_empties >= 2:
+                        captcha_url = captcha_request(api)
+
+                        if len(captcha_url) > 1:
+                            status['message'] = 'Account {} is encountering a captcha, starting 2captcha sequence'.format(account['username'])
+                            log.warning(status['message'])
+                            captcha_token = token_request(args, status, captcha_url)
+
+                            if 'ERROR' in captcha_token:
+                                log.warning("Unable to resolve captcha, please check your 2captcha API key and/or wallet balance")
+                                account_failures.append({'account': account, 'last_fail_time': now(), 'reason': 'catpcha failed to verify'})
+                                break
+
+                            else:
+                                status['message'] = 'Retrieved captcha token, attempting to verify challenge for {}'.format(account['username'])
+                                log.info(status['message'])
+                                response = api.verify_challenge(token = captcha_token)
+
+                                if 'success' in response['responses']['VERIFY_CHALLENGE']:
+                                    status['message'] = "Account {} successfully uncaptcha'd".format(account['username'])
+                                    log.info(status['message'])
+
+                                else:
+                                    status['message'] = "Account {} failed verifyChallenge, putting away account for now".format(account['username'])
+                                    log.info(status['message'])
+                                    account_failures.append({'account': account, 'last_fail_time': now(), 'reason': 'catpcha failed to verify'})
+                                    break
+                                time.sleep(1)
 
                 while pause_bit.is_set():
                     status['message'] = 'Scanning paused'
@@ -509,7 +541,12 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                 try:
                     parsed = parse_map(args, response_dict, step_location, dbq, whq, api)
                     search_items_queue.task_done()
-                    status[('success' if parsed['count'] > 0 else 'noitems')] += 1
+                    if parsed['count'] > 0:
+                        status['success'] += 1
+                        consecutive_empties = 0
+                    else:
+                        status['noitems'] += 1
+                        consecutive_empties += 1
                     consecutive_fails = 0
                     status['message'] = 'Search at {:6f},{:6f} completed with {} finds'.format(step_location[0], step_location[1], parsed['count'])
                     log.debug(status['message'])
@@ -654,6 +691,34 @@ def gym_request(api, position, gym):
     except Exception as e:
         log.warning('Exception while downloading gym details: %s', e)
         return False
+
+
+def captcha_request(api):
+    captcha = {}
+    response = api.check_challenge()
+    captcha_url = response['responses']['CHECK_CHALLENGE']['challenge_url']
+    return captcha_url
+
+
+def token_request(args, status, url):
+    s = requests.Session()
+    # Fetch the CAPTCHA_ID from 2captcha
+    try:
+        captcha_id = s.post("http://2captcha.com/in.php?key={}&method=userrecaptcha&googlekey={}&pageurl={}".format(args.captcha_key, args.captcha_dsk, url)).text.split('|')[1]
+        captcha_id = str(captcha_id)
+    # IndexError implies that the retuned response was a 2captcha error
+    except IndexError: 
+        return 'ERROR'
+    status['message'] = 'Retrieved captcha ID: {}; now retrieving token'.format(captcha_id)
+    log.info(status['message'])
+    # Get the response, retry every 5 seconds if its not ready
+    recaptcha_response = s.get("http://2captcha.com/res.php?key={}&action=get&id={}".format(args.captcha_key, captcha_id)).text
+    while 'CAPCHA_NOT_READY' in recaptcha_response:
+        log.info("Captcha token is not ready, retrying in 5 seconds")
+        time.sleep(5)
+        recaptcha_response = s.get("http://2captcha.com/res.php?key={}&action=get&id={}".format(args.captcha_key, captcha_id)).text
+    token = str(recaptcha_response.split('|')[1])
+    return token
 
 
 def calc_distance(pos1, pos2):

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -24,6 +24,7 @@ import random
 import time
 import geopy
 import geopy.distance
+import requests
 
 from datetime import datetime
 from threading import Thread
@@ -414,6 +415,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
 
             # only sleep when consecutive_fails reaches max_failures, overall fails for stat purposes
             consecutive_fails = 0
+            consecutive_empties = 0
 
             # Create the API instance this will use
             if args.mock != '':
@@ -425,7 +427,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                 log.debug("Using proxy %s", status['proxy_url'])
                 api.set_proxy({'http': status['proxy_url'], 'https': status['proxy_url']})
 
-            api.activate_signature(encryption_lib_path)
+            # api.activate_signature(encryption_lib_path)
 
             # The forever loop for the searches
             while True:
@@ -436,6 +438,37 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                     log.warning(status['message'])
                     account_failures.append({'account': account, 'last_fail_time': now(), 'reason': 'failures'})
                     break  # exit this loop to get a new account and have the API recreated
+
+                if args.captcha_solving:
+
+                    if consecutive_empties >= 2:
+                        captcha_url = captcha_request(api)
+
+                        if len(captcha_url) > 1:
+                            status['message'] = 'Account {} is encountering a captcha, starting 2captcha sequence'.format(account['username'])
+                            log.warning(status['message'])
+                            captcha_token = token_request(args, status, captcha_url)
+
+                            if 'ERROR' in captcha_token:
+                                log.warning("Unable to resolve captcha, please check your 2captcha API key and/or wallet balance")
+                                account_failures.append({'account': account, 'last_fail_time': now(), 'reason': 'catpcha failed to verify'})
+                                break
+
+                            else:
+                                status['message'] = 'Retrieved captcha token, attempting to verify challenge for {}'.format(account['username'])
+                                log.info(status['message'])
+                                response = api.verify_challenge(token = captcha_token)
+
+                                if 'success' in response['responses']['VERIFY_CHALLENGE']:
+                                    status['message'] = "Account {} successfully uncaptcha'd".format(account['username'])
+                                    log.info(status['message'])
+
+                                else:
+                                    status['message'] = "Account {} failed verifyChallenge, putting away account for now".format(account['username'])
+                                    log.info(status['message'])
+                                    account_failures.append({'account': account, 'last_fail_time': now(), 'reason': 'catpcha failed to verify'})
+                                    break
+                                time.sleep(1)
 
                 while pause_bit.is_set():
                     status['message'] = 'Scanning paused'
@@ -509,7 +542,12 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                 try:
                     parsed = parse_map(args, response_dict, step_location, dbq, whq, api)
                     search_items_queue.task_done()
-                    status[('success' if parsed['count'] > 0 else 'noitems')] += 1
+                    if parsed['count'] > 0:
+                        status['success'] += 1
+                        consecutive_empties = 0
+                    else:
+                        status['noitems'] += 1
+                        consecutive_empties += 1
                     consecutive_fails = 0
                     status['message'] = 'Search at {:6f},{:6f} completed with {} finds'.format(step_location[0], step_location[1], parsed['count'])
                     log.debug(status['message'])
@@ -654,6 +692,34 @@ def gym_request(api, position, gym):
     except Exception as e:
         log.warning('Exception while downloading gym details: %s', e)
         return False
+
+
+def captcha_request(api):
+    captcha = {}
+    response = api.check_challenge()
+    captcha_url = response['responses']['CHECK_CHALLENGE']['challenge_url']
+    return captcha_url
+
+
+def token_request(args, status, url):
+    s = requests.Session()
+    # Fetch the CAPTCHA_ID from 2captcha
+    try:
+        captcha_id = s.post("http://2captcha.com/in.php?key={}&method=userrecaptcha&googlekey={}&pageurl={}".format(args.captcha_key, args.captcha_dsk, url)).text.split('|')[1]
+        captcha_id = str(captcha_id)
+    # IndexError implies that the retuned response was a 2captcha error
+    except IndexError: 
+        return 'ERROR'
+    status['message'] = 'Retrieved captcha ID: {}; now retrieving token'.format(captcha_id)
+    log.info(status['message'])
+    # Get the response, retry every 5 seconds if its not ready
+    recaptcha_response = s.get("http://2captcha.com/res.php?key={}&action=get&id={}".format(args.captcha_key, captcha_id)).text
+    while 'CAPCHA_NOT_READY' in recaptcha_response:
+        log.info("Captcha token is not ready, retrying in 5 seconds")
+        time.sleep(5)
+        recaptcha_response = s.get("http://2captcha.com/res.php?key={}&action=get&id={}".format(args.captcha_key, captcha_id)).text
+    token = str(recaptcha_response.split('|')[1])
+    return token
 
 
 def calc_distance(pos1, pos2):

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -414,6 +414,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
 
             # only sleep when consecutive_fails reaches max_failures, overall fails for stat purposes
             consecutive_fails = 0
+            consecutive_empties = 0
 
             # Create the API instance this will use
             if args.mock != '':
@@ -425,7 +426,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                 log.debug("Using proxy %s", status['proxy_url'])
                 api.set_proxy({'http': status['proxy_url'], 'https': status['proxy_url']})
 
-            api.activate_signature(encryption_lib_path)
+            # api.activate_signature(encryption_lib_path)
 
             # The forever loop for the searches
             while True:
@@ -436,6 +437,37 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                     log.warning(status['message'])
                     account_failures.append({'account': account, 'last_fail_time': now(), 'reason': 'failures'})
                     break  # exit this loop to get a new account and have the API recreated
+
+                if args.captcha_solving:
+
+                    if consecutive_empties >= 2:
+                        captcha_url = captcha_request(api)
+
+                        if len(captcha_url) > 1:
+                            status['message'] = 'Account {} is encountering a captcha, starting 2captcha sequence'.format(account['username'])
+                            log.warning(status['message'])
+                            captcha_token = token_request(args, status, captcha_url)
+
+                            if 'ERROR' in captcha_token:
+                                log.info("Unable to resolve captcha, please check your 2captcha API key and/or wallet balance")
+                                account_failures.append({'account': account, 'last_fail_time': now(), 'reason': 'catpcha failed to verify'})
+                                break
+
+                            else:
+                                status['message'] = 'Retrieved captcha token, attempting to verify challenge for {}'.format(account['username'])
+                                log.info(status['message'])
+                                response = api.verify_challenge(token = captcha_token)
+
+                                if 'success' in response['responses']['VERIFY_CHALLENGE']:
+                                    status['message'] = "Account {} successfully uncaptcha'd".format(account['username'])
+                                    log.info(status['message'])
+
+                                else:
+                                    status['message'] = "Account {} failed verifyChallenge, putting away account for now".format(account['username'])
+                                    log.info(status['message'])
+                                    account_failures.append({'account': account, 'last_fail_time': now(), 'reason': 'catpcha failed to verify'})
+                                    break
+                                time.sleep(1)
 
                 while pause_bit.is_set():
                     status['message'] = 'Scanning paused'
@@ -509,7 +541,12 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                 try:
                     parsed = parse_map(args, response_dict, step_location, dbq, whq, api)
                     search_items_queue.task_done()
-                    status[('success' if parsed['count'] > 0 else 'noitems')] += 1
+                    if parsed['count'] > 0:
+                        status['success'] += 1
+                        consecutive_empties = 0
+                    else:
+                        status['noitems'] += 1
+                        consecutive_empties += 1
                     consecutive_fails = 0
                     status['message'] = 'Search at {:6f},{:6f} completed with {} finds'.format(step_location[0], step_location[1], parsed['count'])
                     log.debug(status['message'])
@@ -655,6 +692,31 @@ def gym_request(api, position, gym):
         log.warning('Exception while downloading gym details: %s', e)
         return False
 
+def captcha_request(api):
+    captcha = {}
+    response = api.check_challenge()
+    captcha_url = response['responses']['CHECK_CHALLENGE']['challenge_url']
+    return captcha_url
+
+def token_request(args, status, url):
+    s = requests.Session()
+    # Fetch the CAPTCHA_ID from 2captcha
+    try:
+        captcha_id = s.post("http://2captcha.com/in.php?key={}&method=userrecaptcha&googlekey={}&pageurl={}".format(args.captcha_key, args.captcha_dsk, url)).text.split('|')[1]
+        captcha_id = str(captcha_id)
+        break
+    except IndexError: # This implies that the retuned response was an error
+        return 'ERROR'
+    status['message'] = 'Retrieved captcha ID: {}; now retrieving token'.format(captcha_id)
+    log.info(status['message'])
+    # Get the response, retry every 5 seconds if its not ready
+    recaptcha_response = s.get("http://2captcha.com/res.php?key={}&action=get&id={}".format(args.captcha_key, captcha_id)).text
+    while 'CAPCHA_NOT_READY' in recaptcha_response:
+        log.info("Captcha token is not ready, retrying in 5 seconds")
+        time.sleep(5)
+        recaptcha_response = s.get("http://2captcha.com/res.php?key={}&action=get&id={}".format(args.captcha_key, captcha_id)).text
+    token = str(recaptcha_response.split('|')[1])
+    return token
 
 def calc_distance(pos1, pos2):
     R = 6378.1  # km radius of the earth

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -414,7 +414,6 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
 
             # only sleep when consecutive_fails reaches max_failures, overall fails for stat purposes
             consecutive_fails = 0
-            consecutive_empties = 0
 
             # Create the API instance this will use
             if args.mock != '':
@@ -426,7 +425,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                 log.debug("Using proxy %s", status['proxy_url'])
                 api.set_proxy({'http': status['proxy_url'], 'https': status['proxy_url']})
 
-            # api.activate_signature(encryption_lib_path)
+            api.activate_signature(encryption_lib_path)
 
             # The forever loop for the searches
             while True:
@@ -437,37 +436,6 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                     log.warning(status['message'])
                     account_failures.append({'account': account, 'last_fail_time': now(), 'reason': 'failures'})
                     break  # exit this loop to get a new account and have the API recreated
-
-                if args.captcha_solving:
-
-                    if consecutive_empties >= 2:
-                        captcha_url = captcha_request(api)
-
-                        if len(captcha_url) > 1:
-                            status['message'] = 'Account {} is encountering a captcha, starting 2captcha sequence'.format(account['username'])
-                            log.warning(status['message'])
-                            captcha_token = token_request(args, status, captcha_url)
-
-                            if 'ERROR' in captcha_token:
-                                log.info("Unable to resolve captcha, please check your 2captcha API key and/or wallet balance")
-                                account_failures.append({'account': account, 'last_fail_time': now(), 'reason': 'catpcha failed to verify'})
-                                break
-
-                            else:
-                                status['message'] = 'Retrieved captcha token, attempting to verify challenge for {}'.format(account['username'])
-                                log.info(status['message'])
-                                response = api.verify_challenge(token = captcha_token)
-
-                                if 'success' in response['responses']['VERIFY_CHALLENGE']:
-                                    status['message'] = "Account {} successfully uncaptcha'd".format(account['username'])
-                                    log.info(status['message'])
-
-                                else:
-                                    status['message'] = "Account {} failed verifyChallenge, putting away account for now".format(account['username'])
-                                    log.info(status['message'])
-                                    account_failures.append({'account': account, 'last_fail_time': now(), 'reason': 'catpcha failed to verify'})
-                                    break
-                                time.sleep(1)
 
                 while pause_bit.is_set():
                     status['message'] = 'Scanning paused'
@@ -541,12 +509,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                 try:
                     parsed = parse_map(args, response_dict, step_location, dbq, whq, api)
                     search_items_queue.task_done()
-                    if parsed['count'] > 0:
-                        status['success'] += 1
-                        consecutive_empties = 0
-                    else:
-                        status['noitems'] += 1
-                        consecutive_empties += 1
+                    status[('success' if parsed['count'] > 0 else 'noitems')] += 1
                     consecutive_fails = 0
                     status['message'] = 'Search at {:6f},{:6f} completed with {} finds'.format(step_location[0], step_location[1], parsed['count'])
                     log.debug(status['message'])
@@ -692,31 +655,6 @@ def gym_request(api, position, gym):
         log.warning('Exception while downloading gym details: %s', e)
         return False
 
-def captcha_request(api):
-    captcha = {}
-    response = api.check_challenge()
-    captcha_url = response['responses']['CHECK_CHALLENGE']['challenge_url']
-    return captcha_url
-
-def token_request(args, status, url):
-    s = requests.Session()
-    # Fetch the CAPTCHA_ID from 2captcha
-    try:
-        captcha_id = s.post("http://2captcha.com/in.php?key={}&method=userrecaptcha&googlekey={}&pageurl={}".format(args.captcha_key, args.captcha_dsk, url)).text.split('|')[1]
-        captcha_id = str(captcha_id)
-        break
-    except IndexError: # This implies that the retuned response was an error
-        return 'ERROR'
-    status['message'] = 'Retrieved captcha ID: {}; now retrieving token'.format(captcha_id)
-    log.info(status['message'])
-    # Get the response, retry every 5 seconds if its not ready
-    recaptcha_response = s.get("http://2captcha.com/res.php?key={}&action=get&id={}".format(args.captcha_key, captcha_id)).text
-    while 'CAPCHA_NOT_READY' in recaptcha_response:
-        log.info("Captcha token is not ready, retrying in 5 seconds")
-        time.sleep(5)
-        recaptcha_response = s.get("http://2captcha.com/res.php?key={}&action=get&id={}".format(args.captcha_key, captcha_id)).text
-    token = str(recaptcha_response.split('|')[1])
-    return token
 
 def calc_distance(pos1, pos2):
     R = 6378.1  # km radius of the earth

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -77,6 +77,14 @@ def get_args():
     parser.add_argument('-enc', '--encounter',
                         help='Start an encounter to gather IVs and moves',
                         action='store_true', default=False)
+    parser.add_argument('-cs', '--captcha-solving',
+                        help='Enables captcha solving',
+                        action='store_true', default=False)
+    parser.add_argument('-ck', '--captcha-key',
+                        help='2Captcha API key')
+    parser.add_argument('-cds', '--captcha-dsk',
+                        help='PokemonGo captcha data-sitekey',
+                        default="6LeeTScTAAAAADqvhqVMhPpr_vB9D364Ia-1dSgK")
     parser.add_argument('-ed', '--encounter-delay',
                         help='Time delay between encounter pokemon in scan threads',
                         type=float, default=1)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -77,14 +77,6 @@ def get_args():
     parser.add_argument('-enc', '--encounter',
                         help='Start an encounter to gather IVs and moves',
                         action='store_true', default=False)
-    parser.add_argument('-cs', '--captcha-solving',
-                        help='Enables captcha solving',
-                        action='store_true', default=False)
-    parser.add_argument('-ck', '--captcha-key',
-                        help='2Captcha API key')
-    parser.add_argument('-cds', '--captcha-dsk',
-                        help='PokemonGo captcha data-sitekey',
-                        default="6LeeTScTAAAAADqvhqVMhPpr_vB9D364Ia-1dSgK")
     parser.add_argument('-ed', '--encounter-delay',
                         help='Time delay between encounter pokemon in scan threads',
                         type=float, default=1)


### PR DESCRIPTION
## Description

CODE FLOW:
1. If account has 2 consecutive empty scans, a check is performed to see if the account is encountering a captcha
2. If yes, it attempts to solve the captcha. If not, operation resumes. 

USAGE:

Below are the flags added:
[-cs --CAPTCHA-SOLVING]: Enables captcha solving.
[-ck --CAPTCHA-KEY]: 2captcha API key.
[-cds --CAPTCHA-DATASITEKEY]: `data-sitekey` for the captchas

## Motivation and Context

Solves captcha'd accounts.

## How Has This Been Tested?

Ran for 48 hours with 400 workers. 12 captcha'd accounts solved without any errors.

## Screenshots (if appropriate):

![image](https://cloud.githubusercontent.com/assets/16789070/20202932/3eaf4310-a7bb-11e6-8afa-df647315aa83.png)


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
