### PR TITLE
Partially account for invalid TTH values

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -36,8 +36,10 @@ db_schema_version = 9
 unknowntime = datetime(year=1900, month=1, day=1)
 timedelt = timedelta(minutes=args.default_spawn_timespan)
 
+
 class MyRetryDB(RetryOperationalError, PooledMySQLDatabase):
     pass
+
 
 def init_database(app):
     if args.db_type == 'mysql':
@@ -114,7 +116,7 @@ class Pokemon(BaseModel):
             # If timestamp is known only load modified pokemon in the visible area
             query = (query
                      .where((Pokemon.last_modified > datetime.utcfromtimestamp(timestamp / 1000)) &
-                             # (Pokemon.disappear_time > rightnow)) &
+                            # (Pokemon.disappear_time > rightnow)) &
                             ((Pokemon.latitude >= swLat) &
                              (Pokemon.longitude >= swLng) &
                              (Pokemon.latitude <= neLat) &

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+﻿#!/usr/bin/python
 # -*- coding: utf-8 -*-
 import logging
 import itertools

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -114,7 +114,7 @@ class Pokemon(BaseModel):
             # If timestamp is known only load modified pokemon in the visible area
             query = (query
                      .where((Pokemon.last_modified > datetime.utcfromtimestamp(timestamp / 1000)) &
-                             #(Pokemon.disappear_time > rightnow)) &
+                             # (Pokemon.disappear_time > rightnow)) &
                             ((Pokemon.latitude >= swLat) &
                              (Pokemon.longitude >= swLng) &
                              (Pokemon.latitude <= neLat) &
@@ -276,7 +276,6 @@ class Pokemon(BaseModel):
             timediff = datetime.utcnow() - timediff
         query = (Pokemon
                  .select(Pokemon.latitude, Pokemon.longitude, Pokemon.pokemon_id, fn.Count(Pokemon.spawnpoint_id).alias('count'), Pokemon.disappear_time)
-                 #disappearfix
                  .where((Pokemon.pokemon_id == pokemon_id) &
                         ((Pokemon.disappear_time > timediff) | ((Pokemon.disappear_time == unknowntime) & (Pokemon.last_modified > timediff))))
                  .group_by(Pokemon.latitude, Pokemon.longitude, Pokemon.pokemon_id, Pokemon.spawnpoint_id)
@@ -350,8 +349,8 @@ class Pokemon(BaseModel):
         # This finds the point in time when the new code began so we aren't just perpetuating invalid data.
         # This needs to be moved somewhere else to run once at startup and define a global variable.  Or something like that.
         startdatequery = (Pokemon.select((fn.Min(Pokemon.last_modified)).alias('startdate'))
-                                .where(Pokemon.disappear_time == unknowntime)
-                                .dicts())
+                          .where(Pokemon.disappear_time == unknowntime)
+                          .dicts())
         if startdatequery.exists():
             for t in startdatequery:
                 startdate = t['startdate']
@@ -377,16 +376,16 @@ class Pokemon(BaseModel):
         n, e, s, w = hex_bounds(center, steps)
 
         query = (Pokemon
-                  .select(Pokemon.latitude.alias('lat'), Pokemon.longitude.alias('lng'), Pokemon.spawnpoint_id,
-                          fn.Max(Pokemon.disappear_time).alias('disappear_time'),
-                          (fn.Min(Pokemon.last_modified.minute * 60 + Pokemon.last_modified.second)).alias('minseconds'),
-                          (fn.Max(Pokemon.last_modified.minute * 60 + Pokemon.last_modified.second)).alias('maxseconds'),
-                          (fn.Min((Pokemon.last_modified.minute + case(None, ((Pokemon.last_modified.minute < args.default_spawn_timespan, 60), ), 0)) * 60 + Pokemon.last_modified.second)).alias('shiftedminseconds'))
-                  .where((Pokemon.latitude <= n) &
-                         (Pokemon.latitude >= s) &
-                         (Pokemon.longitude >= w) &
-                         (Pokemon.longitude <= e))
-                  .group_by(Pokemon.spawnpoint_id, Pokemon.latitude, Pokemon.longitude))
+                 .select(Pokemon.latitude.alias('lat'), Pokemon.longitude.alias('lng'), Pokemon.spawnpoint_id,
+                         fn.Max(Pokemon.disappear_time).alias('disappear_time'),
+                         (fn.Min(Pokemon.last_modified.minute * 60 + Pokemon.last_modified.second)).alias('minseconds'),
+                         (fn.Max(Pokemon.last_modified.minute * 60 + Pokemon.last_modified.second)).alias('maxseconds'),
+                         (fn.Min((Pokemon.last_modified.minute + case(None, ((Pokemon.last_modified.minute < args.default_spawn_timespan, 60), ), 0)) * 60 + Pokemon.last_modified.second)).alias('shiftedminseconds'))
+                 .where((Pokemon.latitude <= n) &
+                        (Pokemon.latitude >= s) &
+                        (Pokemon.longitude >= w) &
+                        (Pokemon.longitude <= e))
+                 .group_by(Pokemon.spawnpoint_id, Pokemon.latitude, Pokemon.longitude))
 
         s = list(query.dicts())
 
@@ -834,7 +833,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
         encountered_pokemon = [(p['encounter_id'], p['spawnpoint_id'], p['disappear_time']) for p in query]
 
         for p in wild_pokemon:
-            if (b64encode(str(p['encounter_id'])), p['spawn_point_id'], datetime.utcfromtimestamp((p['last_modified_timestamp_ms'] +p['time_till_hidden_ms']) / 1000.0)) in encountered_pokemon:
+            if (b64encode(str(p['encounter_id'])), p['spawn_point_id'], datetime.utcfromtimestamp((p['last_modified_timestamp_ms'] + p['time_till_hidden_ms']) / 1000.0)) in encountered_pokemon:
                 # If pokemon has been encountered before and we already have a valid TTH recorded do not process.
                 skipped += 1
                 continue
@@ -856,8 +855,8 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
                 # This finds the point in time when the new code began so we aren't just perpetuating invalid data.
                 # This needs to be moved somewhere else to run once at startup and define a global variable.  Or something like that.
                 startdatequery = (Pokemon.select((fn.Min(Pokemon.last_modified)).alias('startdate'))
-                                        .where(Pokemon.disappear_time == unknowntime)
-                                        .dicts())
+                                  .where(Pokemon.disappear_time == unknowntime)
+                                  .dicts())
                 if startdatequery.exists():
                     for t in startdatequery:
                         startdate = t['startdate']

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -12,8 +12,7 @@ from peewee import SqliteDatabase, InsertQuery, \
     DateTimeField, fn, DeleteQuery, CompositeKey, FloatField, SQL, TextField
 from playhouse.flask_utils import FlaskDB
 from playhouse.pool import PooledMySQLDatabase
-from playhouse.shortcuts import RetryOperationalError
-from playhouse.shortcuts import case
+from playhouse.shortcuts import RetryOperationalError, case
 from playhouse.migrate import migrate, MySQLMigrator, SqliteMigrator
 from datetime import datetime, timedelta
 from base64 import b64encode

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -311,7 +311,7 @@ class Pokemon(BaseModel):
 
     @classmethod
     def get_spawnpoints(cls, swLat, swLng, neLat, neLng, timestamp=0, oSwLat=None, oSwLng=None, oNeLat=None, oNeLng=None):
-        query = Pokemon.select(Pokemon.latitude, Pokemon.longitude, Pokemon.spawnpoint_id,fn.Max(Pokemon.disappear_time).alias('disappear_time'))
+        query = Pokemon.select(Pokemon.latitude, Pokemon.longitude, Pokemon.spawnpoint_id, fn.Max(Pokemon.disappear_time).alias('disappear_time'))
 
         if timestamp > 0:
             # Only want modified spawnpoints
@@ -360,7 +360,7 @@ class Pokemon(BaseModel):
 
         for sp in queryDict:
             key = sp['spawnpoint_id']
-            sp['time']=(sp['disappear_time'].minute*60 + sp['disappear_time'].second)
+            sp['time'] = (sp['disappear_time'].minute * 60 + sp['disappear_time'].second)
             if (sp['disappear_time'] > startdate):
                 sp['dtisknown'] = True
             else:
@@ -377,16 +377,16 @@ class Pokemon(BaseModel):
         n, e, s, w = hex_bounds(center, steps)
 
         query = (Pokemon
-                  .select(Pokemon.latitude.alias('lat'), Pokemon.longitude.alias('lng'), Pokemon.spawnpoint_id
-                          ,fn.Max(Pokemon.disappear_time).alias('disappear_time')
-                          ,(fn.Min(Pokemon.last_modified.minute * 60 + Pokemon.last_modified.second)).alias('minseconds')
-                          ,(fn.Max(Pokemon.last_modified.minute * 60 + Pokemon.last_modified.second)).alias('maxseconds')
-                          ,(fn.Min((Pokemon.last_modified.minute + case(None,((Pokemon.last_modified.minute < args.default_spawn_timespan,60),),0)) * 60 + Pokemon.last_modified.second)).alias('shiftedminseconds'))
+                  .select(Pokemon.latitude.alias('lat'), Pokemon.longitude.alias('lng'), Pokemon.spawnpoint_id,
+                          fn.Max(Pokemon.disappear_time).alias('disappear_time'),
+                          (fn.Min(Pokemon.last_modified.minute * 60 + Pokemon.last_modified.second)).alias('minseconds'),
+                          (fn.Max(Pokemon.last_modified.minute * 60 + Pokemon.last_modified.second)).alias('maxseconds'),
+                          (fn.Min((Pokemon.last_modified.minute + case(None, ((Pokemon.last_modified.minute < args.default_spawn_timespan, 60), ), 0)) * 60 + Pokemon.last_modified.second)).alias('shiftedminseconds'))
                   .where((Pokemon.latitude <= n) &
                          (Pokemon.latitude >= s) &
                          (Pokemon.longitude >= w) &
                          (Pokemon.longitude <= e))
-                  .group_by(Pokemon.spawnpoint_id,Pokemon.latitude,Pokemon.longitude))
+                  .group_by(Pokemon.spawnpoint_id, Pokemon.latitude, Pokemon.longitude))
 
         s = list(query.dicts())
 
@@ -825,7 +825,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
         encounter_ids = [b64encode(str(p['encounter_id'])) for p in wild_pokemon]
         # For all the wild pokemon we found check if an active pokemon is in the database
         query = (Pokemon
-                 .select(Pokemon.encounter_id, Pokemon.spawnpoint_id,fn.Max(Pokemon.disappear_time).alias('disappear_time'))
+                 .select(Pokemon.encounter_id, Pokemon.spawnpoint_id, fn.Max(Pokemon.disappear_time).alias('disappear_time'))
                  .where(Pokemon.encounter_id << encounter_ids)
                  .group_by(Pokemon.encounter_id, Pokemon.spawnpoint_id)
                  .dicts())
@@ -840,7 +840,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
                 continue
 
             # Surely there's a better way to do this but I don't know python
-            encountered_pokemon2 = [(t[0],t[1]) for t in encountered_pokemon]
+            encountered_pokemon2 = [(t[0], t[1]) for t in encountered_pokemon]
 
             if ((b64encode(str(p['encounter_id'])), p['spawn_point_id']) in encountered_pokemon2) & ((p['time_till_hidden_ms'] >= 3600000) | (p['time_till_hidden_ms'] <= 0)):
                 # If pokemon has been encountered before and we still have an invalid TTH do not process.

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -9,7 +9,7 @@ import time
 import geopy
 from peewee import SqliteDatabase, InsertQuery, \
     IntegerField, CharField, DoubleField, BooleanField, \
-    DateTimeField, fn, DeleteQuery, CompositeKey, FloatField, SQL, TextField
+    DateTimeField, fn, DeleteQuery, CompositeKey, FloatField, TextField
 from playhouse.flask_utils import FlaskDB
 from playhouse.pool import PooledMySQLDatabase
 from playhouse.shortcuts import RetryOperationalError, case

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -7,7 +7,6 @@ import os
 import json
 import logging
 import shutil
-import platform
 import pprint
 import time
 
@@ -77,6 +76,14 @@ def get_args():
     parser.add_argument('-enc', '--encounter',
                         help='Start an encounter to gather IVs and moves',
                         action='store_true', default=False)
+    parser.add_argument('-cs', '--captcha-solving',
+                        help='Enables captcha solving',
+                        action='store_true', default=False)
+    parser.add_argument('-ck', '--captcha-key',
+                        help='2Captcha API key')
+    parser.add_argument('-cds', '--captcha-dsk',
+                        help='PokemonGo captcha data-sitekey',
+                        default="6LeeTScTAAAAADqvhqVMhPpr_vB9D364Ia-1dSgK")
     parser.add_argument('-ed', '--encounter-delay',
                         help='Time delay between encounter pokemon in scan threads',
                         type=float, default=1)
@@ -189,12 +196,6 @@ def get_args():
                         help='Set the status page password')
     parser.add_argument('-el', '--encrypt-lib', help='Path to encrypt lib to be used instead of the shipped ones')
     parser.add_argument('-odt', '--on-demand_timeout', help='Pause searching while web UI is inactive for this timeout(in seconds)', type=int, default=0)
-    parser.add_argument('-sl', '--speed-limit',
-                        help='Speed limit in kilometers per hour',
-                        type=int, default=0)
-    parser.add_argument('-msld', '--max-speed-limit-delay',
-                        help='Maximum delay in seconds allowed due to speed limit',
-                        type=int, default=0)
     parser.add_argument('-dt', '--default-spawn-timespan',
                         help='Time in minutes to use as the default length of a spawn with an unknown disappear time',
                         type=int, default=30)
@@ -332,12 +333,6 @@ def get_args():
             if num_auths > 1 and num_usernames != num_auths:
                 errors.append('The number of provided auth ({}) must match the username count ({})'.format(num_auths, num_usernames))
 
-        if args.speed_limit < 0:
-            errors.append('Speed limit cannot be less than 0')
-
-        if args.max_speed_limit_delay < 0:
-            errors.append('Maximum delay due to speed limit cannot be less than 0')
-
         if len(errors) > 0:
             parser.print_usage()
             print(sys.argv[0] + ": errors: \n - " + "\n - ".join(errors))
@@ -438,61 +433,6 @@ def get_pokemon_rarity(pokemon_id):
 def get_pokemon_types(pokemon_id):
     pokemon_types = get_pokemon_data(pokemon_id)['types']
     return map(lambda x: {"type": i8ln(x['type']), "color": x['color']}, pokemon_types)
-
-
-def get_encryption_lib_path(args):
-    if args.encrypt_lib is not None:
-        lib_path = args.encrypt_lib
-
-        if not os.path.isfile(lib_path):
-            err = "Could not find manually specified encryption library {}".format(lib_path)
-            log.error(err)
-            raise Exception(err)
-    else:
-        # win32 doesn't mean necessarily 32 bits
-        if sys.platform == "win32" or sys.platform == "cygwin":
-            if platform.architecture()[0] == '64bit':
-                lib_name = "encrypt64bit.dll"
-            else:
-                lib_name = "encrypt32bit.dll"
-
-        elif sys.platform == "darwin":
-            lib_name = "libencrypt-osx-64.so"
-
-        elif os.uname()[4].startswith("arm") and platform.architecture()[0] == '32bit':
-            lib_name = "libencrypt-linux-arm-32.so"
-
-        elif os.uname()[4].startswith("aarch64") and platform.architecture()[0] == '64bit':
-            lib_name = "libencrypt-linux-arm-64.so"
-
-        elif sys.platform.startswith('linux'):
-            if "centos" in platform.platform():
-                if platform.architecture()[0] == '64bit':
-                    lib_name = "libencrypt-centos-x86-64.so"
-                else:
-                    lib_name = "libencrypt-linux-x86-32.so"
-            else:
-                if platform.architecture()[0] == '64bit':
-                    lib_name = "libencrypt-linux-x86-64.so"
-                else:
-                    lib_name = "libencrypt-linux-x86-32.so"
-
-        elif sys.platform.startswith('freebsd'):
-            lib_name = "libencrypt-freebsd-64.so"
-
-        else:
-            err = "Unexpected/unsupported platform '{}'. If you have encrypt lib compiled for your platform, specify its location with '--encrypt-lib' parameter".format(sys.platform)
-            log.error(err)
-            raise Exception(err)
-
-        lib_path = os.path.join(os.path.dirname(__file__), "libencrypt", lib_name)
-
-        if not os.path.isfile(lib_path):
-            err = "Could not find {} encryption library {}".format(sys.platform, lib_path)
-            log.error(err)
-            raise Exception(err)
-
-    return lib_path
 
 
 class Timer():

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+﻿#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 import sys
@@ -7,6 +7,7 @@ import os
 import json
 import logging
 import shutil
+import platform
 import pprint
 import time
 
@@ -76,14 +77,6 @@ def get_args():
     parser.add_argument('-enc', '--encounter',
                         help='Start an encounter to gather IVs and moves',
                         action='store_true', default=False)
-    parser.add_argument('-cs', '--captcha-solving',
-                        help='Enables captcha solving',
-                        action='store_true', default=False)
-    parser.add_argument('-ck', '--captcha-key',
-                        help='2Captcha API key')
-    parser.add_argument('-cds', '--captcha-dsk',
-                        help='PokemonGo captcha data-sitekey',
-                        default="6LeeTScTAAAAADqvhqVMhPpr_vB9D364Ia-1dSgK")
     parser.add_argument('-ed', '--encounter-delay',
                         help='Time delay between encounter pokemon in scan threads',
                         type=float, default=1)
@@ -196,6 +189,15 @@ def get_args():
                         help='Set the status page password')
     parser.add_argument('-el', '--encrypt-lib', help='Path to encrypt lib to be used instead of the shipped ones')
     parser.add_argument('-odt', '--on-demand_timeout', help='Pause searching while web UI is inactive for this timeout(in seconds)', type=int, default=0)
+    parser.add_argument('-sl', '--speed-limit',
+                        help='Speed limit in kilometers per hour',
+                        type=int, default=0)
+    parser.add_argument('-msld', '--max-speed-limit-delay',
+                        help='Maximum delay in seconds allowed due to speed limit',
+                        type=int, default=0)
+    parser.add_argument('-dt', '--default-spawn-timespan',
+                        help='Time in minutes to use as the default length of a spawn with an unknown disappear time',
+                        type=int, default=30)
     verbosity = parser.add_mutually_exclusive_group()
     verbosity.add_argument('-v', '--verbose', help='Show debug messages from PomemonGo-Map and pgoapi. Optionally specify file to log to.', nargs='?', const='nofile', default=False, metavar='filename.log')
     verbosity.add_argument('-vv', '--very-verbose', help='Like verbose, but show debug messages from all modules as well.  Optionally specify file to log to.', nargs='?', const='nofile', default=False, metavar='filename.log')
@@ -330,6 +332,12 @@ def get_args():
             if num_auths > 1 and num_usernames != num_auths:
                 errors.append('The number of provided auth ({}) must match the username count ({})'.format(num_auths, num_usernames))
 
+        if args.speed_limit < 0:
+            errors.append('Speed limit cannot be less than 0')
+
+        if args.max_speed_limit_delay < 0:
+            errors.append('Maximum delay due to speed limit cannot be less than 0')
+
         if len(errors) > 0:
             parser.print_usage()
             print(sys.argv[0] + ": errors: \n - " + "\n - ".join(errors))
@@ -430,6 +438,61 @@ def get_pokemon_rarity(pokemon_id):
 def get_pokemon_types(pokemon_id):
     pokemon_types = get_pokemon_data(pokemon_id)['types']
     return map(lambda x: {"type": i8ln(x['type']), "color": x['color']}, pokemon_types)
+
+
+def get_encryption_lib_path(args):
+    if args.encrypt_lib is not None:
+        lib_path = args.encrypt_lib
+
+        if not os.path.isfile(lib_path):
+            err = "Could not find manually specified encryption library {}".format(lib_path)
+            log.error(err)
+            raise Exception(err)
+    else:
+        # win32 doesn't mean necessarily 32 bits
+        if sys.platform == "win32" or sys.platform == "cygwin":
+            if platform.architecture()[0] == '64bit':
+                lib_name = "encrypt64bit.dll"
+            else:
+                lib_name = "encrypt32bit.dll"
+
+        elif sys.platform == "darwin":
+            lib_name = "libencrypt-osx-64.so"
+
+        elif os.uname()[4].startswith("arm") and platform.architecture()[0] == '32bit':
+            lib_name = "libencrypt-linux-arm-32.so"
+
+        elif os.uname()[4].startswith("aarch64") and platform.architecture()[0] == '64bit':
+            lib_name = "libencrypt-linux-arm-64.so"
+
+        elif sys.platform.startswith('linux'):
+            if "centos" in platform.platform():
+                if platform.architecture()[0] == '64bit':
+                    lib_name = "libencrypt-centos-x86-64.so"
+                else:
+                    lib_name = "libencrypt-linux-x86-32.so"
+            else:
+                if platform.architecture()[0] == '64bit':
+                    lib_name = "libencrypt-linux-x86-64.so"
+                else:
+                    lib_name = "libencrypt-linux-x86-32.so"
+
+        elif sys.platform.startswith('freebsd'):
+            lib_name = "libencrypt-freebsd-64.so"
+
+        else:
+            err = "Unexpected/unsupported platform '{}'. If you have encrypt lib compiled for your platform, specify its location with '--encrypt-lib' parameter".format(sys.platform)
+            log.error(err)
+            raise Exception(err)
+
+        lib_path = os.path.join(os.path.dirname(__file__), "libencrypt", lib_name)
+
+        if not os.path.isfile(lib_path):
+            err = "Could not find {} encryption library {}".format(sys.platform, lib_path)
+            log.error(err)
+            raise Exception(err)
+
+    return lib_path
 
 
 class Timer():

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -364,14 +364,15 @@ function pokemonLabel (name, rarity, types, disappearTime, id, latitude, longitu
       `
   }
 
+  var disappearstatus = ''
   if (dtisknown) {
-    var disappearstatus = `
+    disappearstatus = `
       <div>
         <b>Known</b> disappear time is ${pad(disappearDate.getHours())}:${pad(disappearDate.getMinutes())}:${pad(disappearDate.getSeconds())}
         <span class='label-countdown' disappears-at='${disappearTime}'>(00m00s)</span>
       </div>`
   } else {
-    var disappearstatus = `
+    disappearstatus = `
       <div>
         Disappear time <b>unknown</b>.  Presumed before ${pad(disappearDate.getHours())}:${pad(disappearDate.getMinutes())}:${pad(disappearDate.getSeconds())}
         <span class='label-countdown' disappears-at='${disappearTime}'>(00m00s)</span>
@@ -534,8 +535,9 @@ function formatSpawnTime (seconds) {
   return ('0' + Math.floor(seconds / 60)).substr(-2) + 'm' + ('0' + (seconds % 60)).substr(-2) + 's'
 }
 function spawnpointLabel (item) {
+  var timeinfo = ''
   if (item.dtisknown) {
-    var timeinfo = `
+    timeinfo = `
       <div>
         Disappears every hour at ${formatSpawnTime(item.time)}
       </div>
@@ -543,7 +545,7 @@ function spawnpointLabel (item) {
         Spawn time unknown.
       </div>`
   } else {
-    var timeinfo = `
+    timeinfo = `
       <div>
         Disappear and spawn times are <b>unknown</b>.
       </div>`
@@ -744,10 +746,11 @@ function getColorBySpawnTime (value) {
   var seconds = now.getMinutes() * 60 + now.getSeconds()
 
   // account for hour roll-over
+  var diff = ''
   if (seconds > value) {
-    var diff = (3600 + value - seconds)
+    diff = (3600 + value - seconds)
   } else {
-    var diff = (value - seconds)
+    diff = (value - seconds)
   }
   // Hardcoded 30 minute timespan for spawns.  Eventually the color changing should either be
   // deprecated or it should account for different spawntypes.

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -345,7 +345,6 @@ function openMapDirections (lat, lng) { // eslint-disable-line no-unused-vars
 
 function pokemonLabel (name, rarity, types, disappearTime, id, latitude, longitude, encounterId, atk, def, sta, move1, move2, dtisknown, scanTime) {
   var disappearDate = new Date(disappearTime)
-  // disappearfix
   var scanDate = new Date(scanTime)
   var rarityDisplay = rarity ? '(' + rarity + ')' : ''
   var typesDisplay = ''
@@ -364,13 +363,6 @@ function pokemonLabel (name, rarity, types, disappearTime, id, latitude, longitu
       </div>
       `
   }
-
-//  var disappearstatus = ''
-//  if (dtisknown) {
-//    var disappearstatus = 'Known disappear time is'
-//  } else {
-//    var disappearstatus = 'Disappear time unknown.  Presumed before'
-//  }
 
   if (dtisknown) {
     var disappearstatus = `
@@ -539,8 +531,6 @@ function pokestopLabel (expireTime, latitude, longitude) {
 }
 
 function formatSpawnTime (seconds) {
-  // the addition and modulo are required here because the db stores when a spawn disappears
-  // the subtraction to get the appearance time will knock seconds under 0 if the spawn happens in the previous hour
   return ('0' + Math.floor(seconds / 60)).substr(-2) + 'm' + ('0' + (seconds % 60)).substr(-2) + 's'
 }
 function spawnpointLabel (item) {
@@ -566,12 +556,6 @@ function spawnpointLabel (item) {
     </div>
     ${timeinfo}`
 
-  if (item.special) {
-    str += `
-      <div>
-        May appear as early as ${formatSpawnTime(item.time - 1800)}
-      </div>`
-  }
   return str
 }
 
@@ -766,7 +750,8 @@ function getColorBySpawnTime (value) {
   } else {
     var diff = (value - seconds)
   }
-
+  // Hardcoded 30 minute timespan for spawns.  Eventually the color changing should either be
+  // deprecated or it should account for different spawntypes.
   var hue = 275 // light purple when spawn is neither about to spawn nor active
   if (diff < 1800) { // green to red over 30 minutes of active spawn
     hue = diff / 15
@@ -1290,8 +1275,6 @@ var updateLabelDiffTime = function () {
     $(element).text(timestring)
   })
 }
-
-// disappearfix
 
 var updateLabelUpTime = function () {
   $('.label-countup').each(function (index, element) {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -534,7 +534,6 @@ function formatSpawnTime (seconds) {
   return ('0' + Math.floor(seconds / 60)).substr(-2) + 'm' + ('0' + (seconds % 60)).substr(-2) + 's'
 }
 function spawnpointLabel (item) {
-
   if (item.dtisknown) {
     var timeinfo = `
       <div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Set disappear time = 1/1/1900 when TTH is unknown and no previous valid TTH values
have been recorded for the spawnpoint.
Add argument -dt, --default-spawn-timespan to indicate what timespan should be used
for unidentified spawntypes.  Currently uses a default of 30 minutes since 30 minute spawns
seem to be prevalent now where 15 minute spawns used to be heavily most common.
Changes the front end to provide more information regarding the status of spawns
and spawnpoints.
Does not identify spawntypes.
Does not change the DB schema.
Does not include a kitchen sink.

## How Has This Been Tested?
Poorly, hah.

## Screenshots (if appropriate):
![image](https://cloud.githubusercontent.com/assets/21130007/20460655/10ac2068-aeb0-11e6-90e4-b394ec18ccf7.png)

![image](https://cloud.githubusercontent.com/assets/21130007/20460664/56980af6-aeb0-11e6-8770-3f043ff4b9b3.png)

![image](https://cloud.githubusercontent.com/assets/21130007/20460670/713a6e12-aeb0-11e6-8353-ea03e8f88095.png)

![image](https://cloud.githubusercontent.com/assets/21130007/20460681/ba2ed2e8-aeb0-11e6-916e-e555ad5f937f.png)
