### PR TITLE
Partially account for invalid TTH values

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -100,7 +100,7 @@ class Pokemon(BaseModel):
     def get_active(swLat, swLng, neLat, neLng, timestamp=0, oSwLat=None, oSwLng=None, oNeLat=None, oNeLng=None):
         rightnow = datetime.utcnow()
 
-        # recenttime is used in queries to compare with last_modified similar to how disappear_time gets compared with rightnow
+        # Using recenttime in queries to compare with last_modified similar to how disappear_time gets compared with rightnow.
         recenttime = rightnow - timedelt
 
         query = Pokemon.select()
@@ -154,10 +154,10 @@ class Pokemon(BaseModel):
         for p in query:
             # Eventually we'll have to add logic to manage the various spawntypes.
             if p['disappear_time'] == unknowntime:
-                # when disappear_time equals unknowntime then we want to use last_modified plus
-                # the default visible timespan as the calculated disappear_time
+                # When disappear_time equals unknowntime then we want to use last_modified plus
+                # the default visible timespan as the calculated disappear_time.
                 p['disappear_time'] = p['last_modified'] + timedelt
-                # dtisknown is a flag that gets passed to the web interface specifying
+                # Use dtisknown as a flag that gets passed to the web interface specifying
                 # whether the disappear time given is known or guessed.
                 p['dtisknown'] = False
             else:
@@ -403,18 +403,18 @@ class Pokemon(BaseModel):
 
         # We need to figure out the spawn time so we know when to scan.
         for location in filtered:
-            # todo: account for different spawntypes
+            # Eventually this needs to account for spawntypes.  Until then we'll use the default spawn timespan.
             if (location['disappear_time'] == unknowntime):
-                # if the disappear_time is unknown, then try to figure out the earliest <seconds after the hour> of a contiguous timespan for a spawnpoint
+                # If the disappear_time is unknown, then try to figure out the earliest <seconds after the hour> of a contiguous timespan for a spawnpoint
                 # while accounting for wrapping around an hour and directly use that as the spawntime for a spawnpoint.
                 if ((location['minseconds'] < args.default_spawn_timespan * 60) and (location['maxseconds'] > args.default_spawn_timespan * 60)):
-                    # when the earliest scan is within the first timespan of an hour and the latest scan is within the last timespan of
-                    # an hour then we need to use the earliest scan in the final timespan of an hour to wrap around the hour.
+                    # When the earliest scan is within the first timespan of an hour and the latest scan is within the last timespan of
+                    # an hour then we need to use the earliest scan from the final timespan of an hour in order to wrap around the hour.
                     location['time'] = location['shiftedminseconds']
                 else:
                     location['time'] = location['minseconds']
             else:
-                # if disappear_time is known, then calculate spawntime.
+                # If disappear_time is known, then calculate spawntime.
                 location['time'] = cls.get_spawn_time(location['disappear_time'].minute * 60 + location['disappear_time'].second)
 
         return filtered
@@ -791,7 +791,7 @@ def construct_pokemon_dict(pokemons, p, encounter_result, d_t):
         })
 
 
-# todo: this probably shouldn't _really_ be in "models" anymore, but whatever. ¯\_(ツ)_/¯
+# This probably shouldn't _really_ be in "models" anymore, but whatever. ¯\_(ツ)_/¯
 def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, api):
     pokemons = {}
     pokestops = {}
@@ -879,7 +879,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
                         if d_t < datetime.utcnow():
                             d_t = d_t + timedelta(hours=1)
                 else:
-                    # Set disappear time to be 1/1/1900 to represent an unknown disappear time
+                    # Set disappear time to be 1/1/1900 to represent an unknown disappear time.
                     d_t = unknowntime
 
             printPokemon(p['pokemon_data']['pokemon_id'], p['latitude'],

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -79,8 +79,7 @@ class BaseModel(flaskDb.Model):
 
 
 class Pokemon(BaseModel):
-    # We are base64 encoding the ids delivered by the api
-    # because they are too big for sqlite to handle
+    # We are base64 encoding the ids delivered by the api because they are too big for sqlite to handle.
     encounter_id = CharField(primary_key=True, max_length=50)
     spawnpoint_id = CharField(index=True)
     pokemon_id = IntegerField(index=True)
@@ -107,13 +106,13 @@ class Pokemon(BaseModel):
         query = Pokemon.select()
         if not (swLat and swLng and neLat and neLng):
             # Here and in many places below, instead of using only disappear_time in the future we also
-            # use last_modified within the recent default visible timespan if the disappear_time is unknown
+            # use last_modified within the recent default visible timespan if the disappear_time is unknown.
             query = (query
                      .where((Pokemon.disappear_time > rightnow) |
                             ((Pokemon.disappear_time == unknowntime) & (Pokemon.last_modified > recenttime)))
                      .dicts())
         elif timestamp > 0:
-            # If timestamp is known only load modified pokemon in the visible area
+            # If timestamp is known only load modified pokemon in the visible area.
             query = (query
                      .where((Pokemon.last_modified > datetime.utcfromtimestamp(timestamp / 1000)) &
                             # (Pokemon.disappear_time > rightnow)) &
@@ -148,7 +147,7 @@ class Pokemon(BaseModel):
                               (Pokemon.longitude <= neLng))))
                      .dicts())
 
-        # Performance: Disable the garbage collector prior to creating a (potentially) large dict with append()
+        # Performance: Disable the garbage collector prior to creating a (potentially) large dict with append().
         gc.disable()
 
         pokemons = []
@@ -200,7 +199,7 @@ class Pokemon(BaseModel):
                             (Pokemon.longitude <= neLng))
                      .dicts())
 
-        # Performance: Disable the garbage collector prior to creating a (potentially) large dict with append()
+        # Performance: Disable the garbage collector prior to creating a (potentially) large dict with append().
         gc.disable()
 
         pokemons = []
@@ -252,7 +251,7 @@ class Pokemon(BaseModel):
                  .dicts()
                  )
 
-        # Performance: Disable the garbage collector prior to creating a (potentially) large dict with append()
+        # Performance: Disable the garbage collector prior to creating a (potentially) large dict with append().
         gc.disable()
 
         pokemons = []
@@ -372,7 +371,7 @@ class Pokemon(BaseModel):
 
     @classmethod
     def get_spawnpoints_in_hex(cls, center, steps):
-        # I believe used for spawnpoint scanning
+        # I believe used for spawnpoint scanning.
         log.info('Finding spawn points {} steps away'.format(steps))
 
         n, e, s, w = hex_bounds(center, steps)
@@ -391,10 +390,10 @@ class Pokemon(BaseModel):
 
         s = list(query.dicts())
 
-        # The distance between scan circles of radius 70 in a hex is 121.2436
-        # steps - 1 to account for the center circle then add 70 for the edge
+        # The distance between scan circles of radius 70 in a hex is 121.2436.
+        # Use steps - 1 to account for the center circle then add 70 for the edge.
         step_distance = ((steps - 1) * 121.2436) + 70
-        # Compare spawnpoint list to a circle with radius steps * 120
+        # Compare spawnpoint list to a circle with radius steps * 120.
         # Uses the direct geopy distance between the center and the spawnpoint.
         filtered = []
 
@@ -493,7 +492,7 @@ class Pokestop(BaseModel):
                             (Pokestop.longitude <= neLng))
                      .dicts())
 
-        # Performance: Disable the garbage collector prior to creating a (potentially) large dict with append()
+        # Performance: Disable the garbage collector prior to creating a (potentially) large dict with append().
         gc.disable()
 
         pokestops = []
@@ -567,7 +566,7 @@ class Gym(BaseModel):
                               (Gym.longitude <= neLng))
                        .dicts())
 
-        # Performance: Disable the garbage collector prior to creating a (potentially) large dict with append()
+        # Performance: Disable the garbage collector prior to creating a (potentially) large dict with append().
         gc.disable()
 
         gyms = {}
@@ -749,8 +748,8 @@ class GymDetails(BaseModel):
 
 
 def hex_bounds(center, steps):
-    # Make a box that is (70m * step_limit * 2) + 70m away from the center point
-    # Rationale is that you need to travel
+    # Make a box that is (70m * step_limit * 2) + 70m away from the center point.
+    # Rationale is that you need to travel.
     sp_dist = 0.07 * 2 * steps
     n = get_new_coords(center, sp_dist, 0)[0]
     e = get_new_coords(center, sp_dist, 90)[1]
@@ -792,7 +791,7 @@ def construct_pokemon_dict(pokemons, p, encounter_result, d_t):
         })
 
 
-# todo: this probably shouldn't _really_ be in "models" anymore, but w/e
+# todo: this probably shouldn't _really_ be in "models" anymore, but whatever. ¯\_(ツ)_/¯
 def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, api):
     pokemons = {}
     pokestops = {}
@@ -824,31 +823,32 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
 
     if pokesfound:
         encounter_ids = [b64encode(str(p['encounter_id'])) for p in wild_pokemon]
-        # For all the wild pokemon we found check if an active pokemon is in the database
+        # For all the wild Pokemon we found check if an active Pokemon is in the database.
         query = (Pokemon
                  .select(Pokemon.encounter_id, Pokemon.spawnpoint_id, fn.Max(Pokemon.disappear_time).alias('disappear_time'))
                  .where(Pokemon.encounter_id << encounter_ids)
                  .group_by(Pokemon.encounter_id, Pokemon.spawnpoint_id)
                  .dicts())
 
-        # Store all encounter_ids, spawnpoint_ids, and disappear times for the pokemon in query (all that is needed to make sure its unique)
+        # Store known Pokemon information for various comparisons below.
         encountered_pokemon = [(p['encounter_id'], p['spawnpoint_id'], p['disappear_time']) for p in query]
 
         for p in wild_pokemon:
             if (b64encode(str(p['encounter_id'])), p['spawn_point_id'], datetime.utcfromtimestamp((p['last_modified_timestamp_ms'] + p['time_till_hidden_ms']) / 1000.0)) in encountered_pokemon:
-                # If pokemon has been encountered before and we already have a valid TTH recorded do not process.
+                # If Pokemon has been encountered before and we already have a valid TTH recorded then do not process.
                 skipped += 1
                 continue
 
-            # Surely there's a better way to do this but I don't know python
+            # Surely there's a better way to do this (using encountered_pokemon directly) but I don't know python.
+            # Create a list from encountered_pokemon that doesn't include disappear_time.
             encountered_pokemon2 = [(t[0], t[1]) for t in encountered_pokemon]
 
             if ((b64encode(str(p['encounter_id'])), p['spawn_point_id']) in encountered_pokemon2) & ((p['time_till_hidden_ms'] >= 3600000) | (p['time_till_hidden_ms'] <= 0)):
-                # If pokemon has been encountered before and we still have an invalid TTH do not process.
+                # If pokemon has been encountered before but we still have an invalid TTH then do not process.
                 skipped += 1
                 continue
 
-            # Check for a valid TTH
+            # Check for a valid TTH.
             if 0 < p['time_till_hidden_ms'] < 3600000:
                 d_t = datetime.utcfromtimestamp(
                     (p['last_modified_timestamp_ms'] +
@@ -865,7 +865,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
                 else:
                     startdate = datetime.utcnow()
 
-                # See if we can find a known disappear time for the spawnpoint
+                # See if we can find a known disappear time for the spawnpoint.
                 query = (Pokemon
                          .select((fn.Max(Pokemon.disappear_time)).alias('disappear_time'))
                          .where((Pokemon.spawnpoint_id == p['spawn_point_id']) & (Pokemon.disappear_time >= startdate))
@@ -885,7 +885,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
             printPokemon(p['pokemon_data']['pokemon_id'], p['latitude'],
                          p['longitude'], d_t)
 
-            # Scan for IVs and moves
+            # Scan for IVs and moves.
             encounter_result = None
             if (args.encounter and (p['pokemon_data']['pokemon_id'] in args.encounter_whitelist or
                                     p['pokemon_data']['pokemon_id'] not in args.encounter_blacklist and not args.encounter_whitelist)):
@@ -923,7 +923,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
                 encountered_pokestops = [(f['pokestop_id'], int((f['last_modified'] - datetime(1970, 1, 1)).total_seconds())) for f in query]
 
         for f in forts:
-            if config['parse_pokestops'] and f.get('type') == 1:  # Pokestops
+            if config['parse_pokestops'] and f.get('type') == 1:  # Pokestops.
                 if 'active_fort_modifier' in f:
                     lure_expiration = datetime.utcfromtimestamp(
                         f['last_modified_timestamp_ms'] / 1000.0) + timedelta(minutes=30)
@@ -941,7 +941,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
                 else:
                     lure_expiration, active_fort_modifier = None, None
 
-                # Send all pokéstops to webhooks
+                # Send all pokéstops to webhooks.
                 if args.webhooks and not args.webhook_updates_only:
                     # Explicitly set 'webhook_data', in case we want to change the information pushed to webhooks,
                     # similar to above and previous commits.
@@ -977,7 +977,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
                 }
 
             elif config['parse_gyms'] and f.get('type') is None:  # Currently, there are only stops and gyms
-                # Send gyms to webhooks
+                # Send gyms to webhooks.
                 if args.webhooks and not args.webhook_updates_only:
                     # Explicitly set 'webhook_data', in case we want to change the information pushed to webhooks,
                     # similar to above and previous commits.
@@ -1126,7 +1126,7 @@ def parse_gyms(args, gym_responses, wh_update_queue):
     # We _could_ synchronously upsert GymDetails, then queue the other tables for
     # upsert, but that would put that Gym's overall information in a weird non-atomic state.
 
-    # upsert all the models
+    # Upsert all the models.
     if len(gym_details):
         bulk_upsert(GymDetails, gym_details)
     if len(gym_pokemon):
@@ -1137,11 +1137,11 @@ def parse_gyms(args, gym_responses, wh_update_queue):
     # This needs to be completed in a transaction, because we don't wany any other thread or process
     # to mess with the GymMembers for the gyms we're updating while we're updating the bridge table.
     with flaskDb.database.transaction():
-        # get rid of all the gym members, we're going to insert new records
+        # Get rid of all the gym members, we're going to insert new records.
         if len(gym_details):
             DeleteQuery(GymMember).where(GymMember.gym_id << gym_details.keys()).execute()
 
-        # insert new gym members
+        # Insert new gym members.
         if len(gym_members):
             bulk_upsert(GymMember, gym_members)
 
@@ -1151,7 +1151,7 @@ def parse_gyms(args, gym_responses, wh_update_queue):
 
 
 def db_updater(args, q):
-    # The forever loop
+    # The forever loop.
     while True:
         try:
 
@@ -1162,7 +1162,7 @@ def db_updater(args, q):
                 except Exception as e:
                     log.warning('%s... Retrying', e)
 
-            # Loop the queue
+            # Loop the queue.
             while True:
                 model, data = q.get()
                 bulk_upsert(model, data)
@@ -1181,7 +1181,7 @@ def db_updater(args, q):
 def clean_db_loop(args):
     while True:
         try:
-            # Clean out old scanned locations
+            # Clean out old scanned locations.
             query = (ScannedLocation
                      .delete()
                      .where((ScannedLocation.last_modified <
@@ -1200,13 +1200,13 @@ def clean_db_loop(args):
                              (datetime.utcnow() - timedelta(minutes=30)))))
             query.execute()
 
-            # Remove active modifier from expired lured pokestops
+            # Remove active modifier from expired lured pokestops.
             query = (Pokestop
                      .update(lure_expiration=None, active_fort_modifier=None)
                      .where(Pokestop.lure_expiration < datetime.utcnow()))
             query.execute()
 
-            # If desired, clear old pokemon spawns
+            # If desired, clear old pokemon spawns.
             if args.purge_data > 0:
                 query = (Pokemon
                          .delete()
@@ -1282,19 +1282,19 @@ def verify_database_schema(db):
 
 
 def database_migrate(db, old_ver):
-    # Update database schema version
+    # Update database schema version.
     Versions.update(val=db_schema_version).where(Versions.key == 'schema_version').execute()
 
     log.info("Detected database version %i, updating to %i", old_ver, db_schema_version)
 
-    # Perform migrations here
+    # Perform migrations here.
     migrator = None
     if args.db_type == 'mysql':
         migrator = MySQLMigrator(db)
     else:
         migrator = SqliteMigrator(db)
 
-#   No longer necessary, we're doing this at schema 4 as well
+#   No longer necessary, we're doing this at schema 4 as well.
 #    if old_ver < 1:
 #        db.drop_tables([ScannedLocation])
 
@@ -1312,8 +1312,8 @@ def database_migrate(db, old_ver):
         db.drop_tables([ScannedLocation])
 
     if old_ver < 5:
-        # Some pokemon were added before the 595 bug was "fixed"
-        # Clean those up for a better UX
+        # Some pokemon were added before the 595 bug was "fixed".
+        # Clean those up for a better UX.
         query = (Pokemon
                  .delete()
                  .where(Pokemon.disappear_time >

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -197,7 +197,7 @@ def get_args():
     parser.add_argument('-el', '--encrypt-lib', help='Path to encrypt lib to be used instead of the shipped ones.')
     parser.add_argument('-odt', '--on-demand_timeout', help='Pause searching while web UI is inactive for this timeout(in seconds).', type=int, default=0)
     parser.add_argument('-dt', '--default-spawn-timespan',
-                        help='Time in minutes to use as the default length of a spawn with an unknown disappear time',
+                        help='Time in minutes to use as the default timespan of a spawn with an unknown disappear time.',
                         type=int, default=30)
     verbosity = parser.add_mutually_exclusive_group()
     verbosity.add_argument('-v', '--verbose', help='Show debug messages from PomemonGo-Map and pgoapi. Optionally specify file to log to.', nargs='?', const='nofile', default=False, metavar='filename.log')

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+﻿#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 import sys
@@ -196,6 +196,9 @@ def get_args():
                         help='Set the status page password.')
     parser.add_argument('-el', '--encrypt-lib', help='Path to encrypt lib to be used instead of the shipped ones.')
     parser.add_argument('-odt', '--on-demand_timeout', help='Pause searching while web UI is inactive for this timeout(in seconds).', type=int, default=0)
+    parser.add_argument('-dt', '--default-spawn-timespan',
+                        help='Time in minutes to use as the default length of a spawn with an unknown disappear time',
+                        type=int, default=30)
     verbosity = parser.add_mutually_exclusive_group()
     verbosity.add_argument('-v', '--verbose', help='Show debug messages from PomemonGo-Map and pgoapi. Optionally specify file to log to.', nargs='?', const='nofile', default=False, metavar='filename.log')
     verbosity.add_argument('-vv', '--very-verbose', help='Like verbose, but show debug messages from all modules as well.  Optionally specify file to log to.', nargs='?', const='nofile', default=False, metavar='filename.log')

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -323,18 +323,20 @@ function initSidebar () {
   $('#spawnpoints-switch').prop('checked', Store.get('showSpawnpoints'))
   $('#ranges-switch').prop('checked', Store.get('showRanges'))
   $('#sound-switch').prop('checked', Store.get('playSound'))
-  var searchBox = new google.maps.places.Autocomplete(document.getElementById('next-location'))
+  var searchBox = new google.maps.places.SearchBox(document.getElementById('next-location'))
   $('#next-location').css('background-color', $('#geoloc-switch').prop('checked') ? '#e0e0e0' : '#ffffff')
 
   updateSearchStatus()
   setInterval(updateSearchStatus, 5000)
 
-  searchBox.addListener('place_changed', function () {
-    var place = searchBox.getPlace()
+  searchBox.addListener('places_changed', function () {
+    var places = searchBox.getPlaces()
 
-    if (!place.geometry) return
+    if (places.length === 0) {
+      return
+    }
 
-    var loc = place.geometry.location
+    var loc = places[0].geometry.location
     changeLocation(loc.lat(), loc.lng())
   })
 
@@ -360,8 +362,9 @@ function openMapDirections (lat, lng) { // eslint-disable-line no-unused-vars
   window.open(url, '_blank')
 }
 
-function pokemonLabel (name, rarity, types, disappearTime, id, latitude, longitude, encounterId, atk, def, sta, move1, move2) {
+function pokemonLabel (name, rarity, types, disappearTime, id, latitude, longitude, encounterId, atk, def, sta, move1, move2, dtisknown, scanTime) {
   var disappearDate = new Date(disappearTime)
+  var scanDate = new Date(scanTime)
   var rarityDisplay = rarity ? '(' + rarity + ')' : ''
   var typesDisplay = ''
   $.each(types, function (index, type) {
@@ -379,6 +382,22 @@ function pokemonLabel (name, rarity, types, disappearTime, id, latitude, longitu
       </div>
       `
   }
+
+  var disappearstatus = ''
+  if (dtisknown) {
+    disappearstatus = `
+      <div>
+        <b>Known</b> disappear time is ${pad(disappearDate.getHours())}:${pad(disappearDate.getMinutes())}:${pad(disappearDate.getSeconds())}
+        <span class='label-countdown' disappears-at='${disappearTime}'>(00m00s)</span>
+      </div>`
+  } else {
+    disappearstatus = `
+      <div>
+        Disappear time <b>unknown</b>.  Presumed before ${pad(disappearDate.getHours())}:${pad(disappearDate.getMinutes())}:${pad(disappearDate.getSeconds())}
+        <span class='label-countdown' disappears-at='${disappearTime}'>(00m00s)</span>
+      </div>`
+  }
+
   var contentstring = `
     <div>
       <b>${name}</b>
@@ -391,9 +410,10 @@ function pokemonLabel (name, rarity, types, disappearTime, id, latitude, longitu
       <small>${typesDisplay}</small>
     </div>
     <div>
-      Disappears at ${pad(disappearDate.getHours())}:${pad(disappearDate.getMinutes())}:${pad(disappearDate.getSeconds())}
-      <span class='label-countdown' disappears-at='${disappearTime}'>(00m00s)</span>
+      Scanned/updated at ${pad(scanDate.getHours())}:${pad(scanDate.getMinutes())}:${pad(scanDate.getSeconds())}
+      <span class='label-countup' scanned-at='${scanTime}'>(00m00s)</span>
     </div>
+    ${disappearstatus}
     <div>
       Location: ${latitude.toFixed(6)}, ${longitude.toFixed(7)}
     </div>
@@ -502,7 +522,7 @@ function pokestopLabel (expireTime, latitude, longitude) {
 
     str = `
       <div>
-        <b>Lured PokÃ©stop</b>
+        <b>Lured Pokéstop</b>
       </div>
       <div>
         Lure expires at ${pad(expireDate.getHours())}:${pad(expireDate.getMinutes())}:${pad(expireDate.getSeconds())}
@@ -517,7 +537,7 @@ function pokestopLabel (expireTime, latitude, longitude) {
   } else {
     str = `
       <div>
-        <b>PokÃ©stop</b>
+        <b>Pokéstop</b>
       </div>
       <div>
         Location: ${latitude.toFixed(6)}, ${longitude.toFixed(7)}
@@ -531,25 +551,31 @@ function pokestopLabel (expireTime, latitude, longitude) {
 }
 
 function formatSpawnTime (seconds) {
-  // the addition and modulo are required here because the db stores when a spawn disappears
-  // the subtraction to get the appearance time will knock seconds under 0 if the spawn happens in the previous hour
-  return ('0' + Math.floor(((seconds + 3600) % 3600) / 60)).substr(-2) + ':' + ('0' + seconds % 60).substr(-2)
+  return ('0' + Math.floor(seconds / 60)).substr(-2) + 'm' + ('0' + (seconds % 60)).substr(-2) + 's'
 }
 function spawnpointLabel (item) {
+  var timeinfo = ''
+  if (item.dtisknown) {
+    timeinfo = `
+      <div>
+        Disappears every hour at ${formatSpawnTime(item.time)}
+      </div>
+      <div>
+        Spawn time unknown.
+      </div>`
+  } else {
+    timeinfo = `
+      <div>
+        Disappear and spawn times are <b>unknown</b>.
+      </div>`
+  }
+
   var str = `
     <div>
       <b>Spawn Point</b>
     </div>
-    <div>
-      Every hour from ${formatSpawnTime(item.time)} to ${formatSpawnTime(item.time + 900)}
-    </div>`
+    ${timeinfo}`
 
-  if (item.special) {
-    str += `
-      <div>
-        May appear as early as ${formatSpawnTime(item.time - 1800)}
-      </div>`
-  }
   return str
 }
 
@@ -611,7 +637,7 @@ function customizePokemonMarker (marker, item, skipNotification) {
   }
 
   marker.infoWindow = new google.maps.InfoWindow({
-    content: pokemonLabel(item['pokemon_name'], item['pokemon_rarity'], item['pokemon_types'], item['disappear_time'], item['pokemon_id'], item['latitude'], item['longitude'], item['encounter_id'], item['individual_attack'], item['individual_defense'], item['individual_stamina'], item['move_1'], item['move_2']),
+    content: pokemonLabel(item['pokemon_name'], item['pokemon_rarity'], item['pokemon_types'], item['disappear_time'], item['pokemon_id'], item['latitude'], item['longitude'], item['encounter_id'], item['individual_attack'], item['individual_defense'], item['individual_stamina'], item['move_1'], item['move_2'], item['dtisknown'], item['last_modified']),
     disableAutoPan: true
   })
 
@@ -739,18 +765,19 @@ function getColorBySpawnTime (value) {
   var seconds = now.getMinutes() * 60 + now.getSeconds()
 
   // account for hour roll-over
-  if (seconds < 900 && value > 2700) {
-    seconds += 3600
-  } else if (seconds > 2700 && value < 900) {
-    value += 3600
+  var diff = ''
+  if (seconds > value) {
+    diff = (3600 + value - seconds)
+  } else {
+    diff = (value - seconds)
   }
-
-  var diff = (seconds - value)
+  // Hardcoded 30 minute timespan for spawns.  Eventually the color changing should either be
+  // deprecated or it should account for different spawntypes.
   var hue = 275 // light purple when spawn is neither about to spawn nor active
-  if (diff >= 0 && diff <= 900) { // green to red over 15 minutes of active spawn
-    hue = (1 - (diff / 60 / 15)) * 120
-  } else if (diff < 0 && diff > -300) { // light blue to dark blue over 5 minutes til spawn
-    hue = ((1 - (-diff / 60 / 5)) * 50) + 200
+  if (diff < 1800) { // green to red over 30 minutes of active spawn
+    hue = diff / 15
+  } else if (diff < 2100) { // light blue to dark blue over 5 minutes til spawn
+    hue = (11 - diff / 60 / 5) * 50
   }
 
   hue = Math.round(hue / 5) * 5
@@ -832,6 +859,7 @@ function addListeners (marker) {
       marker.infoWindow.open(map, marker)
       clearSelection()
       updateLabelDiffTime()
+      updateLabelUpTime()
       marker.persist = true
       marker.infoWindowIsOpen = true
     } else {
@@ -849,6 +877,7 @@ function addListeners (marker) {
     marker.infoWindow.open(map, marker)
     clearSelection()
     updateLabelDiffTime()
+    updateLabelUpTime()
   })
 
   marker.addListener('mouseout', function () {
@@ -1256,12 +1285,39 @@ var updateLabelDiffTime = function () {
     } else {
       timestring = '('
       if (hours > 0) {
-        timestring = hours + 'h'
+        timestring += hours + 'h'
       }
 
       timestring += ('0' + minutes).slice(-2) + 'm'
       timestring += ('0' + seconds).slice(-2) + 's'
       timestring += ')'
+    }
+
+    $(element).text(timestring)
+  })
+}
+
+var updateLabelUpTime = function () {
+  $('.label-countup').each(function (index, element) {
+    var scannedAt = new Date(parseInt(element.getAttribute('scanned-at')))
+    var now = new Date()
+
+    var difference = Math.abs(now - scannedAt)
+    var hours = Math.floor(difference / 36e5)
+    var minutes = Math.floor((difference - (hours * 36e5)) / 6e4)
+    var seconds = Math.floor((difference - (hours * 36e5) - (minutes * 6e4)) / 1e3)
+    var timestring = ''
+
+    if (scannedAt > now) {
+      timestring = '(invalid)'
+    } else {
+      timestring = '('
+      if (hours > 0) {
+        timestring += hours + 'h'
+      }
+
+      timestring += ('0' + minutes).slice(-2) + 'm'
+      timestring += ('0' + seconds).slice(-2) + 's ago)'
     }
 
     $(element).text(timestring)
@@ -1662,12 +1718,12 @@ $(function () {
 
     // setup the filter lists
     $selectExclude.select2({
-      placeholder: i8ln('Select PokÃ©mon'),
+      placeholder: i8ln('Select Pokémon'),
       data: pokeList,
       templateResult: formatState
     })
     $selectPokemonNotify.select2({
-      placeholder: i8ln('Select PokÃ©mon'),
+      placeholder: i8ln('Select Pokémon'),
       data: pokeList,
       templateResult: formatState
     })
@@ -1719,6 +1775,7 @@ $(function () {
 
   // run interval timers to regularly update map and timediffs
   window.setInterval(updateLabelDiffTime, 1000)
+  window.setInterval(updateLabelUpTime, 1000)
   window.setInterval(updateMap, 5000)
   window.setInterval(updateGeoLocation, 1000)
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -323,20 +323,18 @@ function initSidebar () {
   $('#spawnpoints-switch').prop('checked', Store.get('showSpawnpoints'))
   $('#ranges-switch').prop('checked', Store.get('showRanges'))
   $('#sound-switch').prop('checked', Store.get('playSound'))
-  var searchBox = new google.maps.places.SearchBox(document.getElementById('next-location'))
+  var searchBox = new google.maps.places.Autocomplete(document.getElementById('next-location'))
   $('#next-location').css('background-color', $('#geoloc-switch').prop('checked') ? '#e0e0e0' : '#ffffff')
 
   updateSearchStatus()
   setInterval(updateSearchStatus, 5000)
 
-  searchBox.addListener('places_changed', function () {
-    var places = searchBox.getPlaces()
+  searchBox.addListener('place_changed', function () {
+    var place = searchBox.getPlace()
 
-    if (places.length === 0) {
-      return
-    }
+    if (!place.geometry) return
 
-    var loc = places[0].geometry.location
+    var loc = place.geometry.location
     changeLocation(loc.lat(), loc.lng())
   })
 
@@ -522,7 +520,7 @@ function pokestopLabel (expireTime, latitude, longitude) {
 
     str = `
       <div>
-        <b>Lured Pokéstop</b>
+        <b>Lured PokÃ©stop</b>
       </div>
       <div>
         Lure expires at ${pad(expireDate.getHours())}:${pad(expireDate.getMinutes())}:${pad(expireDate.getSeconds())}
@@ -537,7 +535,7 @@ function pokestopLabel (expireTime, latitude, longitude) {
   } else {
     str = `
       <div>
-        <b>Pokéstop</b>
+        <b>PokÃ©stop</b>
       </div>
       <div>
         Location: ${latitude.toFixed(6)}, ${longitude.toFixed(7)}
@@ -773,10 +771,10 @@ function getColorBySpawnTime (value) {
   }
   // Hardcoded 30 minute timespan for spawns.  Eventually the color changing should either be
   // deprecated or it should account for different spawntypes.
-  var hue = 275 // light purple when spawn is neither about to spawn nor active
-  if (diff < 1800) { // green to red over 30 minutes of active spawn
+  var hue = 275 // Light purple when spawn is neither about to spawn nor active.
+  if (diff < 1800) { // Green to red over 30 minutes of active spawn.
     hue = diff / 15
-  } else if (diff < 2100) { // light blue to dark blue over 5 minutes til spawn
+  } else if (diff < 2100) { // Light blue to dark blue over the 5 minutes before a spawn.
     hue = (11 - diff / 60 / 5) * 50
   }
 
@@ -1718,12 +1716,12 @@ $(function () {
 
     // setup the filter lists
     $selectExclude.select2({
-      placeholder: i8ln('Select Pokémon'),
+      placeholder: i8ln('Select PokÃ©mon'),
       data: pokeList,
       templateResult: formatState
     })
     $selectPokemonNotify.select2({
-      placeholder: i8ln('Select Pokémon'),
+      placeholder: i8ln('Select PokÃ©mon'),
       data: pokeList,
       templateResult: formatState
     })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Set disappear time = 1/1/1900 when TTH is unknown and no previous valid TTH values
have been recorded for the spawnpoint.
Add argument -dt, --default-spawn-timespan to indicate what timespan should be used
for unidentified spawntypes. Currently uses a default of 30 minutes since 30 minute spawns
seem to be prevalent now where 15 minute spawns used to be heavily most common.
Changes the front end to provide more information regarding the status of spawns
and spawnpoints.
Spawnpoint color changing hardcoded to 30 minute spawns.
Does not identify spawntypes.
Does not change the DB schema.

## Screenshots (if appropriate):
![image](https://cloud.githubusercontent.com/assets/21130007/20465517/51e4c58e-af24-11e6-8480-e40d41bd28ab.png)

![image](https://cloud.githubusercontent.com/assets/21130007/20465519/5b7b4190-af24-11e6-94f7-6c3de9c9a520.png)

![image](https://cloud.githubusercontent.com/assets/21130007/20465520/61cae0c8-af24-11e6-8369-bb529ab1d96b.png)

![image](https://cloud.githubusercontent.com/assets/21130007/20465522/66054dc2-af24-11e6-89aa-8cb71833bc6d.png)
