### PR TITLE
moves.json: add entry for Transform move

### DIFF
--- a/static/data/moves.json
+++ b/static/data/moves.json
@@ -1054,5 +1054,13 @@
 		"duration": 3200,
 		"energy": 20,
 		"dps": 4.68
+	},
+	"242": {
+		"name": "Transform",
+		"type": "Normal",
+		"damage": 0,
+		"duration": 1730,
+		"energy": 0,
+		"dps": 0
 	}
 }


### PR DESCRIPTION
Even though Ditto won’t show up as Ditto on the map, it makes sense to include its Transform move here for the sake of completeness. It might also help out other projects who are reusing the `moves.json` file.

## Motivation and Context

This change makes the `moves.json` file complete based on the following data found in `GAME_MASTER.protobuf`:

```protobuf
item_templates {
  template_id: "V0242_MOVE_TRANSFORM_FAST"
  move_settings {
    movement_id: TRANSFORM_FAST
    animation_id: 4
    pokemon_type: POKEMON_TYPE_NORMAL
    accuracy_chance: 1
    stamina_loss_scalar: 0.01
    trainer_level_min: 1
    trainer_level_max: 100
    vfx_name: "transform_fast"
    duration_ms: 1730
    damage_window_start_ms: 300
    damage_window_end_ms: 700
  }
}
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
