### PR TITLE
On the fly spawn clustering

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -158,6 +158,8 @@ def get_args():
                         action='store_true', default=False)
     parser.add_argument('-ss', '--spawnpoint-scanning',
                         help='Use spawnpoint scanning (instead of hex grid). Scans in a circle based on step_limit when on DB.', nargs='?', const='nofile', default=False)
+    parser.add_argument('-clss', '--sscluster',
+                        help='Cluster spawnpoints before use (with -ss and no .json)', action='store_true', default=False)
     parser.add_argument('--dump-spawnpoints', help='Dump the spawnpoints from the db to json (only for use with -ss).',
                         action='store_true', default=False)
     parser.add_argument('-pd', '--purge-data',
@@ -309,6 +311,10 @@ def get_args():
             errors.append('Missing `username` either as -u/--username, csv file using -ac, or in config.')
         else:
             num_usernames = len(args.username)
+
+        if args.sscluster:
+            if args.spawnpoint_scanning is False:
+                errors.append('You enabled spawnpoint clustering, but without using spawnpoints!')
 
         if args.location is None:
             errors.append('Missing `location` either as -l/--location or in config.')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
OTF Spawn clustering allows you to run multiple locations or beehive without the need to dump a .json file, cluster it, then use it permanently. This is far more flexible, as if it even finds new spawns within the hex bounds by chance it can expand to catch them. Simply apply -ss and -clss to cluster your spawn scanner as it goes. It's literally just the cluster tool in the map files now. Built for compatibility with 1530

## Motivation and Context
Flexibility. Didn't want to have to dump spawn points.

## How Has This Been Tested?
Personal map.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

The clustering tool we all know and love is added into the map.