### PR TITLE
Non-skipping speed limiter

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -75,6 +75,9 @@ def get_args():
     parser.add_argument('-sd', '--scan-delay',
                         help='Time delay between requests in scan threads.',
                         type=float, default=10)
+    parser.add_argument('-sl', '--speed_limit',
+                        help='Maximum speed between jumps in KM/hr, default 32 kph',
+                        type=float, default=32)
     parser.add_argument('-enc', '--encounter',
                         help='Start an encounter to gather IVs and moves.',
                         action='store_true', default=False)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Useful for multi-account hex scans and --skip-empty. Calculates and adjusts scan delay to stay under a certain speed limit.  Limiter's scan delay takes precedence over -sd (but you'll still be using -sd for re-scanning if you merge that PR). Use -sl flag to use, speed in kilometers per hour (speed limit is 35-36kph, this PR default is 32)

## Motivation and Context
Reducing empty scans

## How Has This Been Tested?
Personal map

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

