### PR TITLE
Simple Location Links

### DIFF
--- a/pogom/app.py
+++ b/pogom/app.py
@@ -75,9 +75,17 @@ class Pogom(Flask):
         search_display = "inline" if args.search_control and args.on_demand_timeout <= 0 else "none"
         scan_display = "none" if (args.only_server or args.fixed_location or args.spawnpoint_scanning) else "inline"
 
+        map_lat = self.current_location[0]
+        map_lng = self.current_location[1]
+        if request.args:
+            if request.args.get('lat') is not None:
+                map_lat = request.args.get('lat')
+            if request.args.get('lon') is not None:
+                map_lng = request.args.get('lon')
+
         return render_template('map.html',
-                               lat=self.current_location[0],
-                               lng=self.current_location[1],
+                               lat=map_lat,
+                               lng=map_lng,
                                gmaps_key=config['GMAPS_KEY'],
                                lang=config['LOCALE'],
                                is_fixed=fixed_display,

--- a/pogom/app.py
+++ b/pogom/app.py
@@ -75,13 +75,9 @@ class Pogom(Flask):
         search_display = "inline" if args.search_control and args.on_demand_timeout <= 0 else "none"
         scan_display = "none" if (args.only_server or args.fixed_location or args.spawnpoint_scanning) else "inline"
 
-        map_lat = self.current_location[0]
-        map_lng = self.current_location[1]
-        if request.args:
-            if request.args.get('lat') is not None:
-                map_lat = request.args.get('lat')
-            if request.args.get('lon') is not None:
-                map_lng = request.args.get('lon')
+        if request.args and not args.fixed_location:
+            map_lat = request.args.get('lat') or self.current_location[0]
+            map_lng = request.args.get('lon') or self.current_location[1]
 
         return render_template('map.html',
                                lat=map_lat,


### PR DESCRIPTION
- added the option to move to a location with URL arguments

## Description
Automatically moves the map to the coordinations specified in the URL.

## Motivation and Context
Makes it possible to send links with location information for use with PokeAlarm for example.

## How Has This Been Tested?
On a running map with PokeAlarm and many users.

## Types of changes
- add URL arguments
- make map jump to the coords specified

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project. (pretty sure, just a little change)
- [ ] My change requires a change to the documentation. (not really, might be nice though)
- [ ] I have updated the documentation accordingly.

Automatically moves the map to the location specified in a link like this: 
http://yourdomain.com/?lat=49.903014&lon=8.5882217