### PR TITLE
Handle 2captcha server timeout

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -807,6 +807,9 @@ def token_request(args, status, url):
     try:
         captcha_id = s.post("http://2captcha.com/in.php?key={}&method=userrecaptcha&googlekey={}&pageurl={}".format(args.captcha_key, args.captcha_dsk, url)).text.split('|')[1]
         captcha_id = str(captcha_id)
+    # Gracefully handle 2captcha.com timeout
+    except requests.Timeout:
+        return 'TIMEOUT'
     # IndexError implies that the retuned response was a 2captcha error.
     except IndexError:
         return 'ERROR'

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+
 '''
 Search Architecture:
  - Have a list of accounts

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -611,6 +611,10 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                                 log.warning("Unable to resolve captcha, please check your 2captcha API key and/or wallet balance")
                                 account_failures.append({'account': account, 'last_fail_time': now(), 'reason': 'catpcha failed to verify'})
                                 break
+                            if 'TIMEOUT' in captcha_token:
+                                    log.warning("2captcha server response timed out, service may be temporarily unavailable")
+                                    account_failures.append({'account': account, 'last_fail_time': now() - (args.account_rest_interval - args.captcha_rest_interval), 'reason': '2captcha server time out'})
+                                break
                             else:
                                 status['message'] = 'Retrieved captcha token, attempting to verify challenge for {}'.format(account['username'])
                                 log.info(status['message'])

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -62,6 +62,8 @@ def get_args():
                         help='Seconds for accounts to search before switching to a new account. 0 to disable.')
     parser.add_argument('-ari', '--account-rest-interval', type=int, default=7200,
                         help='Seconds for accounts to rest when they fail or are switched out.')
+    parser.add_argument('-cri', '--captcha-rest-interval', type=int, default=600,
+                        help='Seconds for accounts to rest when failing to verify captcha due to 2captcha server timeout.')
     parser.add_argument('-ac', '--accountcsv',
                         help='Load accounts from CSV file containing "auth_service,username,passwd" lines.')
     parser.add_argument('-bh', '--beehive',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added handler to catch exception due to 2captcha server being inresponsive, and retry again after 10 minutes.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If the 2captcha server (2captcha.com) is unresponsive for longer times it will result in putting a lot of accounts on hold and eventually, if you dont have a lot of spare accounts, render the map blank. Once the 2captcha server starts responding again it will take some time before the map starts getting the accounts back unless restarting the server. It should be safe to put the accounts away for just a short time?

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On my own server, blocking access to 2captcha.com (using iptables rules)
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
