### PR TITLE
add default notify and excluded moons for web

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -66,23 +66,23 @@ var audio = new Audio('static/sounds/ding.mp3')
 // Functions
 //
 
-function set_default_value(exclude, notify) {
-  if (exclude) { 
-    Store.set('remember_select_exclude', get_localstore_value('remember_select_exclude')) 
+function setDefaultValue (exclude, notify) {
+  if (exclude) {
+    Store.set('remember_select_exclude', getLocaleStoreValue('remember_select_exclude'))
   }
-  if (notify) { 
-    Store.set('remember_select_notify', get_localstore_value('remember_select_notify')) 
+  if (notify) {
+    Store.set('remember_select_notify', getLocaleStoreValue('remember_select_notify'))
   }
 }
 
-function get_localstore_value(name) {
+function getLocaleStoreValue (name) {
   if (Store.get(name) !== null) {
     var value = Store.get(name)
     if (value.length !== 0) {
       return value
     }
 
-    return (name == 'remember_select_exclude') ? excludedPokemon : notifiedPokemon
+    return (name === 'remember_select_exclude') ? excludedPokemon : notifiedPokemon
   }
 }
 
@@ -212,7 +212,7 @@ function initMap () { // eslint-disable-line no-unused-vars
   locationMarker = createLocationMarker()
   createMyLocationButton()
   initSidebar()
-  set_default_value(1,1)
+  setDefaultValue(1, 1)
 
   $('#scan-here').on('click', function () {
     var loc = map.getCenter()

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -66,6 +66,26 @@ var audio = new Audio('static/sounds/ding.mp3')
 // Functions
 //
 
+function set_default_value(exclude, notify) {
+  if (exclude) { 
+    Store.set('remember_select_exclude', get_localstore_value('remember_select_exclude')) 
+  }
+  if (notify) { 
+    Store.set('remember_select_notify', get_localstore_value('remember_select_notify')) 
+  }
+}
+
+function get_localstore_value(name) {
+  if (Store.get(name) !== null) {
+    var value = Store.get(name)
+    if (value.length !== 0) {
+      return value
+    }
+
+    return (name == 'remember_select_exclude') ? excludedPokemon : notifiedPokemon
+  }
+}
+
 function excludePokemon (id) { // eslint-disable-line no-unused-vars
   $selectExclude.val(
     $selectExclude.val().concat(id)
@@ -192,6 +212,7 @@ function initMap () { // eslint-disable-line no-unused-vars
   locationMarker = createLocationMarker()
   createMyLocationButton()
   initSidebar()
+  set_default_value(1,1)
 
   $('#scan-here').on('click', function () {
     var loc = map.getCenter()


### PR DESCRIPTION
add support to set exclude and notify pokemons in static/js/maps.js
just add your exclude or notfy pokedex id to the variable.

as example, change:
static/js/map.js line 27: var excludedPokemon = []
to:
var excludedPokemon = [16, 19]

same with:
static/js/map.js line 28: var notifiedPokemon = []
to
var notifiedPokemon = [131, 143, 149]

![pr_map](https://cloud.githubusercontent.com/assets/7890628/21574460/5fa4fc36-cef3-11e6-8bf0-b0ae20f4ecf2.jpg)
![pr_map1](https://cloud.githubusercontent.com/assets/7890628/21574326/591729cc-cef1-11e6-90d7-726f2494cacb.jpg)
![pr_map2](https://cloud.githubusercontent.com/assets/7890628/21574325/59074c6e-cef1-11e6-87f6-81e777b0c3bc.jpg)

don't forgott after change

$ npm run buld
and restart the web process