### PR TITLE
Modify bad scan and logging to include nearby_pokemon

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -24,9 +24,9 @@ from cachetools import TTLCache
 from cachetools import cached
 
 from . import config
-from .utils import get_pokemon_name, get_pokemon_rarity, get_pokemon_types, get_args, \
-    cellid, in_radius, date_secs, clock_between, secs_between, get_move_name, get_move_damage, \
-    get_move_energy, get_move_type
+from .utils import get_pokemon_name, get_pokemon_rarity, get_pokemon_types, \
+    get_args, cellid, in_radius, date_secs, clock_between, secs_between, \
+    get_move_name, get_move_damage, get_move_energy, get_move_type
 from .transform import transform_from_wgs_to_gcj, get_new_coords
 from .customLog import printPokemon
 log = logging.getLogger(__name__)
@@ -44,7 +44,7 @@ class MyRetryDB(RetryOperationalError, PooledMySQLDatabase):
 
 def init_database(app):
     if args.db_type == 'mysql':
-        log.info('Connecting to MySQL database on %s:%i',
+        log.info('Connecting to MySQL database on %s:%i...',
                  args.db_host, args.db_port)
         connections = args.db_max_connections
         if hasattr(args, 'accounts'):
@@ -58,7 +58,7 @@ def init_database(app):
             max_connections=connections,
             stale_timeout=300)
     else:
-        log.info('Connecting to local SQLite database')
+        log.info('Connecting to local SQLite database...')
         db = SqliteDatabase(args.db)
 
     app.config['DATABASE'] = db
@@ -81,7 +81,7 @@ class BaseModel(flaskDb.Model):
 
 
 class Pokemon(BaseModel):
-    # We are base64 encoding the ids delivered by the api,
+    # We are base64 encoding the ids delivered by the api
     # because they are too big for sqlite to handle.
     encounter_id = CharField(primary_key=True, max_length=50)
     spawnpoint_id = CharField(index=True)
@@ -101,18 +101,19 @@ class Pokemon(BaseModel):
         indexes = ((('latitude', 'longitude'), False),)
 
     @staticmethod
-    def get_active(swLat, swLng, neLat, neLng, timestamp=0, oSwLat=None, oSwLng=None, oNeLat=None, oNeLng=None):
+    def get_active(swLat, swLng, neLat, neLng, timestamp=0, oSwLat=None,
+                   oSwLng=None, oNeLat=None, oNeLng=None):
         now_date = datetime.utcnow()
-        # now_secs = date_secs(now_date)
         query = Pokemon.select()
         if not (swLat and swLng and neLat and neLng):
             query = (query
                      .where(Pokemon.disappear_time > now_date)
                      .dicts())
         elif timestamp > 0:
-            # If timestamp is known only load modified pokemon.
+            # If timestamp is known only load modified Pokemon.
             query = (query
-                     .where(((Pokemon.last_modified > datetime.utcfromtimestamp(timestamp / 1000)) &
+                     .where(((Pokemon.last_modified >
+                              datetime.utcfromtimestamp(timestamp / 1000)) &
                              (Pokemon.disappear_time > now_date)) &
                             ((Pokemon.latitude >= swLat) &
                              (Pokemon.longitude >= swLng) &
@@ -137,8 +138,8 @@ class Pokemon(BaseModel):
         else:
             query = (Pokemon
                      .select()
-                     # add 1 hour buffer to include spawnpoints that persist
-                     # after tth, like shsh
+                     # Add 1 hour buffer to include spawnpoints that persist
+                     # after tth, like shsh.
                      .where((Pokemon.disappear_time > now_date) &
                             (((Pokemon.latitude >= swLat) &
                               (Pokemon.longitude >= swLng) &
@@ -146,11 +147,11 @@ class Pokemon(BaseModel):
                               (Pokemon.longitude <= neLng))))
                      .dicts())
 
-        # Performance: Disable the garbage collector prior to creating a
+        # Performance:  disable the garbage collector prior to creating a
         # (potentially) large dict with append().
         gc.disable()
 
-        pokemons = []
+        pokemon = []
         for p in list(query):
 
             p['pokemon_name'] = get_pokemon_name(p['pokemon_id'])
@@ -159,12 +160,12 @@ class Pokemon(BaseModel):
             if args.china:
                 p['latitude'], p['longitude'] = \
                     transform_from_wgs_to_gcj(p['latitude'], p['longitude'])
-            pokemons.append(p)
+            pokemon.append(p)
 
         # Re-enable the GC.
         gc.enable()
 
-        return pokemons
+        return pokemon
 
     @staticmethod
     def get_active_by_id(ids, swLat, swLng, neLat, neLng):
@@ -185,11 +186,11 @@ class Pokemon(BaseModel):
                             (Pokemon.longitude <= neLng))
                      .dicts())
 
-        # Performance: Disable the garbage collector prior to creating a
+        # Performance:  disable the garbage collector prior to creating a
         # (potentially) large dict with append().
         gc.disable()
 
-        pokemons = []
+        pokemon = []
         for p in query:
             p['pokemon_name'] = get_pokemon_name(p['pokemon_id'])
             p['pokemon_rarity'] = get_pokemon_rarity(p['pokemon_id'])
@@ -197,12 +198,12 @@ class Pokemon(BaseModel):
             if args.china:
                 p['latitude'], p['longitude'] = \
                     transform_from_wgs_to_gcj(p['latitude'], p['longitude'])
-            pokemons.append(p)
+            pokemon.append(p)
 
         # Re-enable the GC.
         gc.enable()
 
-        return pokemons
+        return pokemon
 
     @classmethod
     @cached(cache)
@@ -226,27 +227,29 @@ class Pokemon(BaseModel):
                          Pokemon.latitude,
                          Pokemon.longitude,
                          pokemon_count_query.c.count)
-                 .join(pokemon_count_query, on=(Pokemon.pokemon_id == pokemon_count_query.c.pokemon_id))
+                 .join(pokemon_count_query, on=(
+                    Pokemon.pokemon_id == pokemon_count_query.c.pokemon_id))
                  .distinct()
-                 .where(Pokemon.disappear_time == pokemon_count_query.c.lastappeared)
+                 .where(Pokemon.disappear_time ==
+                        pokemon_count_query.c.lastappeared)
                  .dicts()
                  )
 
-        # Performance: Disable the garbage collector prior to creating a
+        # Performance:  disable the garbage collector prior to creating a
         # (potentially) large dict with append().
         gc.disable()
 
-        pokemons = []
+        pokemon = []
         total = 0
         for p in query:
             p['pokemon_name'] = get_pokemon_name(p['pokemon_id'])
-            pokemons.append(p)
+            pokemon.append(p)
             total += p['count']
 
         # Re-enable the GC.
         gc.enable()
 
-        return {'pokemon': pokemons, 'total': total}
+        return {'pokemon': pokemon, 'total': total}
 
     @classmethod
     def get_appearances(cls, pokemon_id, timediff):
@@ -258,23 +261,28 @@ class Pokemon(BaseModel):
         if timediff:
             timediff = datetime.utcnow() - timediff
         query = (Pokemon
-                 .select(Pokemon.latitude, Pokemon.longitude, Pokemon.pokemon_id, fn.Count(Pokemon.spawnpoint_id).alias('count'), Pokemon.spawnpoint_id)
+                 .select(Pokemon.latitude, Pokemon.longitude,
+                         Pokemon.pokemon_id,
+                         fn.Count(Pokemon.spawnpoint_id).alias('count'),
+                         Pokemon.spawnpoint_id)
                  .where((Pokemon.pokemon_id == pokemon_id) &
                         (Pokemon.disappear_time > timediff)
                         )
-                 .group_by(Pokemon.latitude, Pokemon.longitude, Pokemon.pokemon_id, Pokemon.spawnpoint_id)
+                 .group_by(Pokemon.latitude, Pokemon.longitude,
+                           Pokemon.pokemon_id, Pokemon.spawnpoint_id)
                  .dicts()
                  )
 
         return list(query)
 
     @classmethod
-    def get_appearances_times_by_spawnpoint(cls, pokemon_id, spawnpoint_id, timediff):
+    def get_appearances_times_by_spawnpoint(cls, pokemon_id,
+                                            spawnpoint_id, timediff):
         '''
-        :param pokemon_id: id of Pokemon that we need appearances times for
-        :param spawnpoint_id: spawnpoing id we need appearances times for
-        :param timediff: limiting period of the selection
-        :return: list of time appearances over a selected period
+        :param pokemon_id: id of Pokemon that we need appearances times for.
+        :param spawnpoint_id: spawnpoint id we need appearances times for.
+        :param timediff: limiting period of the selection.
+        :return: list of time appearances over a selected period.
         '''
         if timediff:
             timediff = datetime.utcnow() - timediff
@@ -295,13 +303,18 @@ class Pokemon(BaseModel):
         return (disappear_time + 2700) % 3600
 
     @classmethod
-    def get_spawnpoints(cls, swLat, swLng, neLat, neLng, timestamp=0, oSwLat=None, oSwLng=None, oNeLat=None, oNeLng=None):
-        query = Pokemon.select(Pokemon.latitude, Pokemon.longitude, Pokemon.spawnpoint_id, (date_secs(
-            Pokemon.disappear_time)).alias('time'), fn.Count(Pokemon.spawnpoint_id).alias('count'))
+    def get_spawnpoints(cls, swLat, swLng, neLat, neLng, timestamp=0,
+                        oSwLat=None, oSwLng=None, oNeLat=None, oNeLng=None):
+        query = (Pokemon
+                 .select(Pokemon.latitude, Pokemon.longitude,
+                         Pokemon.spawnpoint_id,
+                         (date_secs(Pokemon.disappear_time)).alias('time'),
+                         fn.Count(Pokemon.spawnpoint_id).alias('count')))
 
         if timestamp > 0:
             query = (query
-                     .where(((Pokemon.last_modified > datetime.utcfromtimestamp(timestamp / 1000))) &
+                     .where(((Pokemon.last_modified >
+                              datetime.utcfromtimestamp(timestamp / 1000))) &
                             ((Pokemon.latitude >= swLat) &
                              (Pokemon.longitude >= swLng) &
                              (Pokemon.latitude <= neLat) &
@@ -328,8 +341,8 @@ class Pokemon(BaseModel):
                             (Pokemon.longitude <= neLng)
                             ))
 
-        query = query.group_by(
-            Pokemon.latitude, Pokemon.longitude, Pokemon.spawnpoint_id, SQL('time'))
+        query = query.group_by(Pokemon.latitude, Pokemon.longitude,
+                               Pokemon.spawnpoint_id, SQL('time'))
 
         queryDict = query.dicts()
         spawnpoints = {}
@@ -344,7 +357,8 @@ class Pokemon(BaseModel):
             else:
                 spawnpoints[key]['special'] = True
 
-            if 'time' not in spawnpoints[key] or count >= spawnpoints[key]['count']:
+            if ('time' not in spawnpoints[key] or
+                    count >= spawnpoints[key]['count']):
                 spawnpoints[key]['time'] = disappear_time
                 spawnpoints[key]['count'] = count
 
@@ -355,7 +369,7 @@ class Pokemon(BaseModel):
 
     @classmethod
     def get_spawnpoints_in_hex(cls, center, steps):
-        log.info('Finding spawn points {} steps away'.format(steps))
+        log.info('Finding spawnpoints {} steps away.'.format(steps))
 
         n, e, s, w = hex_bounds(center, steps)
 
@@ -386,15 +400,13 @@ class Pokemon(BaseModel):
         filtered = []
 
         for idx, sp in enumerate(s):
-            if geopy.distance.distance(center, (sp['lat'], sp['lng'])).meters <= step_distance:
+            if geopy.distance.distance(center, (sp['lat'],
+                                       sp['lng'])).meters <= step_distance:
                 filtered.append(s[idx])
 
         # At this point, 'time' is DISAPPEARANCE time, we're going to morph it
-        # to APPEARANCE time.
+        # to APPEARANCE time accounting for hour wraparound.
         for location in filtered:
-            # examples: time    shifted
-            #           0       (   0 + 2700) = 2700 % 3600 = 2700 (0th minute to 45th minute, 15 minutes prior to appearance as time wraps around the hour.)
-            #           1800    (1800 + 2700) = 4500 % 3600 =  900 (30th minute, moved to arrive at 15th minute.)
             # todo: this DOES NOT ACCOUNT for Pokemon that appear sooner and
             # live longer, but you'll _always_ have at least 15 minutes, so it
             # works well enough.
@@ -418,17 +430,21 @@ class Pokestop(BaseModel):
         indexes = ((('latitude', 'longitude'), False),)
 
     @staticmethod
-    def get_stops(swLat, swLng, neLat, neLng, timestamp=0, oSwLat=None, oSwLng=None, oNeLat=None, oNeLng=None, lured=False):
+    def get_stops(swLat, swLng, neLat, neLng, timestamp=0, oSwLat=None,
+                  oSwLng=None, oNeLat=None, oNeLng=None, lured=False):
 
-        query = Pokestop.select(Pokestop.active_fort_modifier, Pokestop.enabled, Pokestop.latitude,
-                                Pokestop.longitude, Pokestop.last_modified, Pokestop.lure_expiration, Pokestop.pokestop_id)
+        query = Pokestop.select(Pokestop.active_fort_modifier,
+                                Pokestop.enabled, Pokestop.latitude,
+                                Pokestop.longitude, Pokestop.last_modified,
+                                Pokestop.lure_expiration, Pokestop.pokestop_id)
 
         if not (swLat and swLng and neLat and neLng):
             query = (query
                      .dicts())
         elif timestamp > 0:
             query = (query
-                     .where(((Pokestop.last_updated > datetime.utcfromtimestamp(timestamp / 1000))) &
+                     .where(((Pokestop.last_updated >
+                              datetime.utcfromtimestamp(timestamp / 1000))) &
                             (Pokestop.latitude >= swLat) &
                             (Pokestop.longitude >= swLng) &
                             (Pokestop.latitude <= neLat) &
@@ -462,7 +478,8 @@ class Pokestop(BaseModel):
                      .dicts())
         elif lured:
             query = (query
-                     .where(((Pokestop.last_updated > datetime.utcfromtimestamp(timestamp / 1000))) &
+                     .where(((Pokestop.last_updated >
+                              datetime.utcfromtimestamp(timestamp / 1000))) &
                             ((Pokestop.latitude >= swLat) &
                              (Pokestop.longitude >= swLng) &
                              (Pokestop.latitude <= neLat) &
@@ -478,7 +495,7 @@ class Pokestop(BaseModel):
                             (Pokestop.longitude <= neLng))
                      .dicts())
 
-        # Performance: Disable the garbage collector prior to creating a
+        # Performance:  disable the garbage collector prior to creating a
         # (potentially) large dict with append().
         gc.disable()
 
@@ -515,7 +532,8 @@ class Gym(BaseModel):
         indexes = ((('latitude', 'longitude'), False),)
 
     @staticmethod
-    def get_gyms(swLat, swLng, neLat, neLng, timestamp=0, oSwLat=None, oSwLng=None, oNeLat=None, oNeLng=None):
+    def get_gyms(swLat, swLng, neLat, neLng, timestamp=0, oSwLat=None,
+                 oSwLng=None, oNeLat=None, oNeLng=None):
         if not (swLat and swLng and neLat and neLng):
             results = (Gym
                        .select()
@@ -524,7 +542,8 @@ class Gym(BaseModel):
             # If timestamp is known only send last scanned Gyms.
             results = (Gym
                        .select()
-                       .where(((Gym.last_scanned > datetime.utcfromtimestamp(timestamp / 1000)) &
+                       .where(((Gym.last_scanned >
+                                datetime.utcfromtimestamp(timestamp / 1000)) &
                                (Gym.latitude >= swLat) &
                                (Gym.longitude >= swLng) &
                                (Gym.latitude <= neLat) &
@@ -554,7 +573,7 @@ class Gym(BaseModel):
                               (Gym.longitude <= neLng))
                        .dicts())
 
-        # Performance: Disable the garbage collector prior to creating a
+        # Performance:  disable the garbage collector prior to creating a
         # (potentially) large dict with append().
         gc.disable()
 
@@ -575,8 +594,10 @@ class Gym(BaseModel):
                            Trainer.name.alias('trainer_name'),
                            Trainer.level.alias('trainer_level'))
                        .join(Gym, on=(GymMember.gym_id == Gym.gym_id))
-                       .join(GymPokemon, on=(GymMember.pokemon_uid == GymPokemon.pokemon_uid))
-                       .join(Trainer, on=(GymPokemon.trainer_name == Trainer.name))
+                       .join(GymPokemon, on=(GymMember.pokemon_uid ==
+                                             GymPokemon.pokemon_uid))
+                       .join(Trainer, on=(GymPokemon.trainer_name ==
+                                          Trainer.name))
                        .where(GymMember.gym_id << gym_ids)
                        .where(GymMember.last_scanned > Gym.last_modified)
                        .order_by(GymMember.gym_id, GymPokemon.cp)
@@ -614,7 +635,8 @@ class Gym(BaseModel):
                           Gym.longitude,
                           Gym.last_modified,
                           Gym.last_scanned)
-                  .join(GymDetails, JOIN.LEFT_OUTER, on=(Gym.gym_id == GymDetails.gym_id))
+                  .join(GymDetails, JOIN.LEFT_OUTER,
+                        on=(Gym.gym_id == GymDetails.gym_id))
                   .where(Gym.gym_id == id)
                   .dicts()
                   .get())
@@ -635,7 +657,8 @@ class Gym(BaseModel):
                            Trainer.name.alias('trainer_name'),
                            Trainer.level.alias('trainer_level'))
                    .join(Gym, on=(GymMember.gym_id == Gym.gym_id))
-                   .join(GymPokemon, on=(GymMember.pokemon_uid == GymPokemon.pokemon_uid))
+                   .join(GymPokemon,
+                         on=(GymMember.pokemon_uid == GymPokemon.pokemon_uid))
                    .join(Trainer, on=(GymPokemon.trainer_name == Trainer.name))
                    .where(GymMember.gym_id == id)
                    .where(GymMember.last_scanned > Gym.last_modified)
@@ -666,28 +689,29 @@ class ScannedLocation(BaseModel):
     longitude = DoubleField()
     last_modified = DateTimeField(
         index=True, default=datetime.utcnow, null=True)
-    # marked true when all five bands have been completed
+    # Marked true when all five bands have been completed.
     done = BooleanField(default=False)
 
-    # Five scans/hour is required to catch all spawns
+    # Five scans/hour is required to catch all spawns.
     # Each scan must be at least 12 minutes from the previous check,
-    # with a 2 minute window during which the scan can be done
+    # with a 2 minute window during which the scan can be done.
 
-    # default of -1 is for bands not yet scanned
+    # Default of -1 is for bands not yet scanned.
     band1 = IntegerField(default=-1)
     band2 = IntegerField(default=-1)
     band3 = IntegerField(default=-1)
     band4 = IntegerField(default=-1)
     band5 = IntegerField(default=-1)
 
-    # midpoint is the center of the bands relative to band 1
-    # e.g., if band 1 is 10.4 min, and band 4 is 34.0 min, midpoint is -0.2 min in minsec
-    # extra 10 seconds in case of delay in recording now time
+    # midpoint is the center of the bands relative to band 1.
+    # If band 1 is 10.4 minutes, and band 4 is 34.0 minutes, midpoint
+    # is -0.2 minutes in minsec.  Extra 10 seconds in case of delay in
+    # recording now time.
     midpoint = IntegerField(default=0)
 
-    # width is how wide the valid window is. Default is 0, max is 2 min
-    # e.g., if band 1 is 10.4 min, and band 4 is 34.0 min, midpoint is 0.4 min
-    # in minsec
+    # width is how wide the valid window is. Default is 0, max is 2 minutes.
+    # If band 1 is 10.4 minutes, and band 4 is 34.0 minutes, midpoint
+    # is 0.4 minutes in minsec.
     width = IntegerField(default=0)
 
     class Meta:
@@ -701,12 +725,14 @@ class ScannedLocation(BaseModel):
                        Check('width >= 0'), Check('width <= 130')]
 
     @staticmethod
-    def get_recent(swLat, swLng, neLat, neLng, timestamp=0, oSwLat=None, oSwLng=None, oNeLat=None, oNeLng=None):
+    def get_recent(swLat, swLng, neLat, neLng, timestamp=0, oSwLat=None,
+                   oSwLng=None, oNeLat=None, oNeLng=None):
         activeTime = (datetime.utcnow() - timedelta(minutes=15))
         if timestamp > 0:
             query = (ScannedLocation
                      .select()
-                     .where(((ScannedLocation.last_modified >= datetime.utcfromtimestamp(timestamp / 1000))) &
+                     .where(((ScannedLocation.last_modified >=
+                              datetime.utcfromtimestamp(timestamp / 1000))) &
                             (ScannedLocation.latitude >= swLat) &
                             (ScannedLocation.longitude >= swLng) &
                             (ScannedLocation.latitude <= neLat) &
@@ -741,7 +767,7 @@ class ScannedLocation(BaseModel):
 
         return list(query)
 
-    # DB format of a new location
+    # DB format of a new location.
     @staticmethod
     def new_loc(loc):
         return {'cellid': cellid(loc),
@@ -757,7 +783,7 @@ class ScannedLocation(BaseModel):
                 'midpoint': 0,
                 'last_modified': None}
 
-    # Used to update bands
+    # Used to update bands.
     @staticmethod
     def db_format(scan, band, nowms):
         scan.update({'band' + str(band): nowms})
@@ -765,12 +791,13 @@ class ScannedLocation(BaseModel):
             scan['band' + str(y)] > -1), range(1, 6), True)
         return scan
 
-    # Shorthand helper for DB dict
+    # Shorthand helper for DB dict.
     @staticmethod
     def _q_init(scan, start, end, kind, sp_id=None):
-        return {'loc': scan['loc'], 'kind': kind, 'start': start, 'end': end, 'step': scan['step'], 'sp': sp_id}
+        return {'loc': scan['loc'], 'kind': kind, 'start': start, 'end': end,
+                'step': scan['step'], 'sp': sp_id}
 
-    # return value of a particular scan from loc, or default dict if not found
+    # Return value of a particular scan from loc, or default dict if not found.
     @classmethod
     def get_by_loc(cls, loc):
         query = (cls
@@ -781,26 +808,30 @@ class ScannedLocation(BaseModel):
 
         return query[0] if len(list(query)) else cls.new_loc(loc)
 
-    # Check if spawn points in a list are in any of the existing spannedlocation records
-    # Otherwise, search through the spawn point list, and update
-    # scan_spawn_point dict for DB bulk upserting
+    # Check if spawnpoints in a list are in any of the existing
+    # spannedlocation records.  Otherwise, search through the spawnpoint list
+    # and update scan_spawn_point dict for DB bulk upserting.
     @classmethod
-    def link_spawn_points(cls, scans, initial, spawn_points, distance, scan_spawn_point, force=False):
+    def link_spawn_points(cls, scans, initial, spawn_points, distance,
+                          scan_spawn_point, force=False):
         for cell, scan in scans.iteritems():
             if initial[cell]['done'] and not force:
                 continue
 
             for sp in spawn_points:
-                if in_radius((sp['latitude'], sp['longitude']), scan['loc'], distance):
-                    scan_spawn_point[cell + sp['id']] = {'spawnpoint': sp['id'],
-                                                         'scannedlocation': cell}
+                if in_radius((sp['latitude'], sp['longitude']),
+                             scan['loc'], distance):
+                    scan_spawn_point[cell + sp[
+                        'id']] = {'spawnpoint': sp['id'],
+                                  'scannedlocation': cell}
 
-    # return list of dicts for upcoming valid band times
+    # Return list of dicts for upcoming valid band times.
     @classmethod
     def linked_spawn_points(cls, cell):
 
-        # unable to use a normal join, since MySQL produces foreignkey constraint errors when
-        # trying to upsert fields that are foreignkeys on another table
+        # Unable to use a normal join, since MySQL produces foreignkey
+        # constraint errors when trying to upsert fields that are foreignkeys
+        # on another table
 
         query = (SpawnPoint
                  .select()
@@ -810,41 +841,43 @@ class ScannedLocation(BaseModel):
 
         return list(query)
 
-    # return list of dicts for upcoming valid band times
+    # Return list of dicts for upcoming valid band times.
     @staticmethod
     def visible_forts(step_location):
         distance = 0.45
         n, e, s, w = hex_bounds(step_location, radius=distance * 1000)
         for g in Gym.get_gyms(s, w, n, e).values():
-            if in_radius((g['latitude'], g['longitude']), step_location, distance):
+            if in_radius((g['latitude'], g['longitude']), step_location,
+                         distance):
                 return True
 
         for g in Pokestop.get_stops(s, w, n, e):
-            if in_radius((g['latitude'], g['longitude']), step_location, distance):
+            if in_radius((g['latitude'], g['longitude']), step_location,
+                         distance):
                 return True
 
         return False
 
-    # return list of dicts for upcoming valid band times
+    # Return list of dicts for upcoming valid band times.
     @classmethod
     def get_times(cls, scan, now_date):
         s = cls.get_by_loc(scan['loc'])
         if s['done']:
             return []
 
-        max = 3600 * 2 + 250  # greater than maximum possible value
+        max = 3600 * 2 + 250  # Greater than maximum possible value.
         min = {'end': max}
 
         nowms = date_secs(now_date)
         if s['band1'] == -1:
             return [cls._q_init(scan, nowms, nowms + 3599, 'band')]
 
-        # Find next window
+        # Find next window.
         basems = s['band1']
         for i in range(2, 6):
             ms = s['band' + str(i)]
 
-            # skip bands already done
+            # Skip bands already done.
             if ms > -1:
                 continue
 
@@ -857,8 +890,8 @@ class ScannedLocation(BaseModel):
 
         return [min] if min['end'] < max else []
 
-    # Checks if now falls within an unfilled band for a scanned location
-    # Returns the updated scan location dict
+    # Checks if now falls within an unfilled band for a scanned location.
+    # Returns the updated scan location dict.
     @classmethod
     def update_band(cls, scan):
         now_date = datetime.utcnow()
@@ -871,21 +904,21 @@ class ScannedLocation(BaseModel):
         if scan['band1'] == -1:
             return cls.db_format(scan, 1, now_secs)
 
-        # calc if number falls in band with remaining points
+        # Calculate if number falls in band with remaining points.
         basems = scan['band1']
         delta = (now_secs - basems - scan['midpoint']) % 3600
         band = int(round(delta / 12 / 60.0) % 5) + 1
 
-        # Check if that band already filled
+        # Check if that band is already filled.
         if scan['band' + str(band)] > -1:
             return scan
 
-        # Check if this result falls within the band 2 min window
+        # Check if this result falls within the band's 2 minute window.
         offset = (delta + 1080) % 720 - 360
         if abs(offset) > 120 - scan['width'] / 2:
             return scan
 
-        # find band midpoint/width
+        # Find band midpoint/width.
         scan = cls.db_format(scan, band, now_secs)
         bts = [scan['band' + str(i)] for i in range(1, 6)]
         bts = filter(lambda ms: ms > -1, bts)
@@ -917,13 +950,14 @@ class ScannedLocation(BaseModel):
 
     @classmethod
     def select_in_hex(cls, center, steps):
-        # should be a way to delegate this to SpawnPoint.select_in_hex, but w/e
+        # There should be a way to delegate this to SpawnPoint.select_in_hex,
+        # but w/e.
 
-        R = 6378.1  # km radius of the earth
+        R = 6378.1  # KM radius of the earth
         hdist = ((steps * 120.0) - 50.0) / 1000.0
         n, e, s, w = hex_bounds(center, steps)
 
-        # get all spawns in that box
+        # Get all spawns in that box.
         sp = list(cls
                   .select()
                   .where((cls.latitude <= n) &
@@ -932,22 +966,23 @@ class ScannedLocation(BaseModel):
                          (cls.longitude <= e))
                   .dicts())
 
-        # for each spawn work out if it is in the hex (clipping the diagonals)
+        # For each spawn work out if it is in the hex (clipping the diagonals).
         in_hex = []
         for spawn in sp:
-            # get the offset from the center of each spawn in km
+            # Get the offset from the center of each spawn in km.
             offset = [math.radians(spawn['latitude'] - center[0]) * R,
-                      math.radians(spawn['longitude'] - center[1]) * (R * math.cos(math.radians(center[0])))]
-            # check agains the 4 lines that make up the diagonals
-            if (offset[1] + (offset[0] * 0.5)) > hdist:  # too far ne
+                      math.radians(spawn['longitude'] - center[1]) *
+                      (R * math.cos(math.radians(center[0])))]
+            # Check against the 4 lines that make up the diagonals.
+            if (offset[1] + (offset[0] * 0.5)) > hdist:  # Too far NE.
                 continue
-            if (offset[1] - (offset[0] * 0.5)) > hdist:  # too far se
+            if (offset[1] - (offset[0] * 0.5)) > hdist:  # Too far SE
                 continue
-            if ((offset[0] * 0.5) - offset[1]) > hdist:  # too far nw
+            if ((offset[0] * 0.5) - offset[1]) > hdist:  # Too far NW
                 continue
-            if ((0 - offset[1]) - (offset[0] * 0.5)) > hdist:  # too far sw
+            if ((0 - offset[1]) - (offset[0] * 0.5)) > hdist:  # Too far SW
                 continue
-            # if it gets to here its  a good spawn
+            # If it gets to here it's a good spawn.
             in_hex.append(spawn)
         return in_hex
 
@@ -983,7 +1018,8 @@ class WorkerStatus(BaseModel):
                 'skip': status['skip'],
                 'last_modified': datetime.utcnow(),
                 'message': status['message'],
-                'last_scan_date': status.get('last_scan_date', datetime.utcnow()),
+                'last_scan_date': status.get('last_scan_date',
+                                             datetime.utcnow()),
                 'latitude': status.get('latitude', None),
                 'longitude': status.get('longitude', None)}
 
@@ -1009,8 +1045,8 @@ class WorkerStatus(BaseModel):
                  .where((WorkerStatus.username == username))
                  .dicts())
 
-        # Sometimes is appears peewee is slow to load, and and this produces an Exception
-        # Retry after a second to give peewee time to load
+        # Sometimes is appears peewee is slow to load, and this produces
+        # an exception.  Retry after a second to give peewee time to load.
         while True:
             try:
                 result = query[0] if len(query) else {
@@ -1027,8 +1063,8 @@ class WorkerStatus(BaseModel):
                 }
                 break
             except Exception as e:
-                log.error('Exception in get_worker under account {} Exception message: {}'.format(
-                    username, e))
+                log.error('Exception in get_worker under account {}.  '
+                          'Exception message: {}'.format(username, e))
                 traceback.print_exc(file=sys.stdout)
                 time.sleep(1)
 
@@ -1040,38 +1076,41 @@ class SpawnPoint(BaseModel):
     latitude = DoubleField()
     longitude = DoubleField()
     last_scanned = DateTimeField(index=True)
-    # kind gives the four quartiles of the spawn, as 's' for seen or 'h' for hidden
-    # for example, a 30 minute spawn is 'hhss'
+    # kind gives the four quartiles of the spawn, as 's' for seen
+    # or 'h' for hidden.  For example, a 30 minute spawn is 'hhss'.
     kind = CharField(max_length=4, default='hhhs')
 
-    # links shows whether a Pokemon encounter id changes between quartiles or stays the same
-    # both 1x45 and 1x60h3 have the kind of 'sssh', but the different links shows when the
-    # encounter id changes
-    # same encounter id is shared between two quartiles, links shows a '+',
-    # a different encounter id between two quartiles is a '-'
-    # For the hidden times, an 'h' is used. Until determined, '?' is used.
-    # Note index is shifted by a half. links[0] is the link between kind[0] and kind[1],
-    # and so on. links[3] is the link between kind[3] and kind[0]
+    # links shows whether a Pokemon encounter id changes between quartiles or
+    # stays the same.  Both 1x45 and 1x60h3 have the kind of 'sssh', but the
+    # different links shows when the encounter id changes.  Same encounter id
+    # is shared between two quartiles, links shows a '+'.  A different
+    # encounter id between two quartiles is a '-'.
+    #
+    # For the hidden times, an 'h' is used.  Until determined, '?' is used.
+    # Note index is shifted by a half. links[0] is the link between
+    # kind[0] and kind[1] and so on. links[3] is the link between
+    # kind[3] and kind[0]
     links = CharField(max_length=4, default='????')
 
-    # count consecutive times spawn should have been seen, but wasn't
-    # if too high, will not be scheduled for review, and treated as inactive
+    # Count consecutive times spawn should have been seen, but wasn't.
+    # If too high, will not be scheduled for review, and treated as inactive.
     missed_count = IntegerField(default=0)
 
-    # next 2 fields are to narrow down on the valid TTH window
-    # seconds after the hour of the latest Pokemon seen time within the hour
+    # Next 2 fields are to narrow down on the valid TTH window.
+    # Seconds after the hour of the latest Pokemon seen time within the hour.
     latest_seen = IntegerField()
 
-    # seconds after the hour of the earliest time wasn't seen after an
-    # appearance
+    # Seconds after the hour of the earliest time Pokemon wasn't seen after an
+    # appearance.
     earliest_unseen = IntegerField()
 
     class Meta:
         indexes = ((('latitude', 'longitude'), False),)
-        constraints = [Check('earliest_unseen >= 0'), Check('earliest_unseen < 3600'),
+        constraints = [Check('earliest_unseen >= 0'),
+                       Check('earliest_unseen < 3600'),
                        Check('latest_seen >= 0'), Check('latest_seen < 3600')]
 
-    # Returns the spawn point dict from ID, or a new dict if not found
+    # Returns the spawnpoint dict from ID, or a new dict if not found.
     @classmethod
     def get_by_id(cls, id, latitude=0, longitude=0):
         query = (cls
@@ -1083,7 +1122,7 @@ class SpawnPoint(BaseModel):
             'id': id,
             'latitude': latitude,
             'longitude': longitude,
-            'last_scanned': None,  # Null value used as new flag
+            'last_scanned': None,  # Null value used as new flag.
             'kind': 'hhhs',
             'links': '????',
             'missed_count': 0,
@@ -1092,23 +1131,24 @@ class SpawnPoint(BaseModel):
 
         }
 
-    # Confirm if tth has been found
+    # Confirm if tth has been found.
     @staticmethod
     def tth_found(sp):
-        # fully indentified if no '?' in links and latest seen == earliest seen
+        # Fully indentified if no '?' in links and
+        # latest_seen == earliest_unseen.
         return sp['latest_seen'] == sp['earliest_unseen']
 
-    # return [start, end] in seconds after the hour for the spawn, despawn
-    # time of a spawnpoint
+    # Return [start, end] in seconds after the hour for the spawn, despawn
+    # time of a spawnpoint.
     @classmethod
     def start_end(cls, sp, spawn_delay=0, links=False):
         links_arg = links
         links = links if links else str(sp['links'])
 
-        if links == '????':  # clean up for old data
+        if links == '????':  # Clean up for old data.
             links = str(sp['kind'].replace('s', '?'))
 
-        # make some assumptions if link not fully identified
+        # Make some assumptions if link not fully identified.
         if links.count('-') == 0:
             links = links[:-1] + '-'
 
@@ -1122,7 +1162,7 @@ class SpawnPoint(BaseModel):
         end = sp['latest_seen'] - (3 - links.index('-')) * 900 + no_tth_adjust
         return [start % 3600, end % 3600]
 
-    # Return a list of dicts with the next spawn times
+    # Return a list of dicts with the next spawn times.
     @classmethod
     def get_times(cls, cell, scan, now_date, scan_delay):
         l = []
@@ -1136,11 +1176,11 @@ class SpawnPoint(BaseModel):
             cls.add_if_not_scanned('spawn', l, sp, scan, endpoints[
                                    0], endpoints[1], now_date, now_secs)
 
-            # check to see if still searching for valid TTH
+            # Check to see if still searching for valid TTH.
             if cls.tth_found(sp):
                 continue
 
-            # add a spawnpoint check between latest seen and earliest seen
+            # Add a spawnpoint check between latest_seen and earliest_unseen.
             start = sp['latest_seen'] + scan_delay
             end = sp['earliest_unseen']
 
@@ -1150,31 +1190,34 @@ class SpawnPoint(BaseModel):
         return l
 
     @classmethod
-    def add_if_not_scanned(cls, kind, l, sp, scan, start, end, now_date, now_secs):
-        # make sure later than now_secs
+    def add_if_not_scanned(cls, kind, l, sp, scan, start, end, now_date,
+                           now_secs):
+        # Make sure later than now_secs.
         while end < now_secs:
             start, end = start + 3600, end + 3600
 
-        # ensure start before end
+        # Ensure start before end.
         while start > end:
             start -= 3600
 
-        if (now_date - cls.get_by_id(sp['id'])['last_scanned']).total_seconds() > now_secs - start:
+        if ((now_date - cls.get_by_id(sp['id'])[
+                'last_scanned']).total_seconds() > (now_secs - start)):
             l.append(ScannedLocation._q_init(scan, start, end, kind, sp['id']))
 
-    # given seconds after the hour and a spawnpoint dict, return which quartile of the
-    # spawnpoint the secs falls in
+    # Given seconds after the hour and a spawnpoint dict, return which quartile
+    # of the spawnpoint the secs falls in.
     @staticmethod
     def get_quartile(secs, sp):
-        return int(((secs - sp['earliest_unseen'] + 15 * 60 + 3600 - 1) % 3600) / 15 / 60)
+        return int(((secs - sp['earliest_unseen'] + 15 * 60 + 3600 - 1) %
+                    3600) / 15 / 60)
 
     @classmethod
     def select_in_hex(cls, center, steps):
-        R = 6378.1  # km radius of the earth
+        R = 6378.1  # KM radius of the earth
         hdist = ((steps * 120.0) - 50.0) / 1000.0
         n, e, s, w = hex_bounds(center, steps)
 
-        # get all spawns in that box
+        # Get all spawns in that box.
         sp = list(cls
                   .select()
                   .where((cls.latitude <= n) &
@@ -1183,31 +1226,28 @@ class SpawnPoint(BaseModel):
                          (cls.longitude <= e))
                   .dicts())
 
-        # for each spawn work out if it is in the hex (clipping the diagonals)
+        # For each spawn work out if it is in the hex (clipping the diagonals).
         in_hex = []
         for spawn in sp:
-            # get the offset from the center of each spawn in km
+            # Get the offset from the center of each spawn in km.
             offset = [math.radians(spawn['latitude'] - center[0]) * R,
-                      math.radians(spawn['longitude'] - center[1]) * (R * math.cos(math.radians(center[0])))]
-            # check agains the 4 lines that make up the diagonals
-            if (offset[1] + (offset[0] * 0.5)) > hdist:  # too far ne
+                      math.radians(spawn['longitude'] - center[1]) *
+                      (R * math.cos(math.radians(center[0])))]
+            # Check against the 4 lines that make up the diagonals.
+            if (offset[1] + (offset[0] * 0.5)) > hdist:  # Too far NE
                 continue
-            if (offset[1] - (offset[0] * 0.5)) > hdist:  # too far se
+            if (offset[1] - (offset[0] * 0.5)) > hdist:  # Too far SE
                 continue
-            if ((offset[0] * 0.5) - offset[1]) > hdist:  # too far nw
+            if ((offset[0] * 0.5) - offset[1]) > hdist:  # Too far NW
                 continue
-            if ((0 - offset[1]) - (offset[0] * 0.5)) > hdist:  # too far sw
+            if ((0 - offset[1]) - (offset[0] * 0.5)) > hdist:  # Too far SW
                 continue
-            # if it gets to here its  a good spawn
+            # If it gets to here it's a good spawn.
             in_hex.append(spawn)
         return in_hex
 
 
 class ScanSpawnPoint(BaseModel):
-    # removing ForeignKeyField due to MSQL issues with upserting rows that are foreignkeys for other tables
-    # scannedlocation = ForeignKeyField(ScannedLocation)
-    # spawnpoint = ForeignKeyField(SpawnPoint)
-
     scannedlocation = ForeignKeyField(ScannedLocation, null=True)
     spawnpoint = ForeignKeyField(SpawnPoint, null=True)
 
@@ -1217,9 +1257,9 @@ class ScanSpawnPoint(BaseModel):
 
 class SpawnpointDetectionData(BaseModel):
     id = CharField(primary_key=True, max_length=54)
-    # removed ForeignKeyField since it caused MySQL issues
+    # Removed ForeignKeyField since it caused MySQL issues.
     encounter_id = CharField(max_length=54)
-    # removed ForeignKeyField since it caused MySQL issues
+    # Removed ForeignKeyField since it caused MySQL issues.
     spawnpoint_id = CharField(max_length=54)
     scan_time = DateTimeField()
     tth_secs = IntegerField(null=True)
@@ -1231,20 +1271,21 @@ class SpawnpointDetectionData(BaseModel):
     @classmethod
     def classify(cls, sp, scan_loc, now_secs, sighting=None):
 
-        # to reduce CPU usage, give an intial reading of 15 min spawns if not
-        # done with initial scan of location
+        # To reduce CPU usage, give an intial reading of 15 minunte spawns if
+        # not done with initial scan of location.
         if not scan_loc['done']:
             sp['kind'] = 'hhhs'
             if not sp['earliest_unseen']:
                 sp['latest_seen'] = now_secs
                 cls.set_default_earliest_unseen(sp)
 
-            elif clock_between(sp['latest_seen'], now_secs, sp['earliest_unseen']):
+            elif clock_between(sp['latest_seen'], now_secs,
+                               sp['earliest_unseen']):
                 sp['latest_seen'] = now_secs
 
             return
 
-        # get past sightings
+        # Get past sightings.
         query = list(cls.select()
                         .where(cls.spawnpoint_id == sp['id'])
                         .dicts())
@@ -1252,104 +1293,112 @@ class SpawnpointDetectionData(BaseModel):
         if sighting:
             query.append(sighting)
 
-        # make a record of links, so we can reset earliest_unseen if it changes
+        # Make a record of links, so we can reset earliest_unseen
+        # if it changes.
         old_kind = str(sp['kind'])
 
-        # make a sorted list of the seconds after the hour
+        # Make a sorted list of the seconds after the hour.
         seen_secs = sorted(map(lambda x: date_secs(x['scan_time']), query))
 
-        # add the first seen_secs to the end as a clock wrap around
+        # Add the first seen_secs to the end as a clock wrap around.
         if seen_secs:
             seen_secs.append(seen_secs[0] + 3600)
 
-        # make a list of gaps between sightings
+        # Make a list of gaps between sightings.
         gap_list = [seen_secs[i + 1] - seen_secs[i]
                     for i in range(len(seen_secs) - 1)]
 
         max_gap = max(gap_list)
 
-        # an hour (60 min) minus the largest gap in minutes gives us the duration the spawn was there
-        # round up to the nearest 15 min interval for our current best duration
-        # guess
+        # An hour minus the largest gap in minutes gives us the duration the
+        # spawn was there.  Round up to the nearest 15 minute interval for our
+        # current best guess duration.
         duration = (int((59 - max_gap / 60.0) / 15) + 1) * 15
 
-        # if the second largest gap is larger than 15 minutes, then there are two gaps that are
-        # greater than 15 min, so it must be a double-spawn
+        # If the second largest gap is larger than 15 minutes, then there are
+        # two gaps greater than 15 minutes.  It must be a double spawn.
         if len(gap_list) > 4 and sorted(gap_list)[-2] > 900:
             sp['kind'] = 'hshs'
             sp['links'] = 'h?h?'
 
         else:
-            # convert the duration into a 'hhhs', 'hhss', 'hsss', 'ssss' string accordingly
-            # 's' is for seen, 'h' is for hidden
+            # Convert the duration into a 'hhhs', 'hhss', 'hsss', 'ssss' string
+            # accordingly.  's' is for seen, 'h' is for hidden.
             sp['kind'] = ''.join(
                 ['s' if i > (3 - duration / 15) else 'h' for i in range(0, 4)])
 
-        # assume no hidden times
+        # Assume no hidden times.
         sp['links'] = sp['kind'].replace('s', '?')
 
         if sp['kind'] != 'ssss':
 
-            if not sp['earliest_unseen'] or sp['earliest_unseen'] != sp['latest_seen']:
+            if (not sp['earliest_unseen'] or
+                    sp['earliest_unseen'] != sp['latest_seen']):
 
-                # new latest seen will be just before max_gap
+                # New latest_seen will be just before max_gap.
                 sp['latest_seen'] = seen_secs[gap_list.index(max_gap)]
 
-                # if we don't have a earliest_unseen yet or the kind of spawn has changed, reset
-                # set to latest_seen + 14 min
+                # if we don't have a earliest_unseen yet or if the kind of
+                # spawn has changed, reset to latest_seen + 14 minutes.
                 if not sp['earliest_unseen'] or sp['kind'] != old_kind:
                     cls.set_default_earliest_unseen(sp)
 
             return
 
-        # only ssss spawns from here below
+        # Only ssss spawns from here below.
 
         sp['links'] = '+++-'
         if sp['earliest_unseen'] == sp['latest_seen']:
             return
 
-        # make a sight_list of dicts like
+        # Make a sight_list of dicts:
         # {date: first seen time,
         # delta: duration of sighting,
         # same: whether encounter ID was same or different over that time}
-
-        # for 60 min spawns ('ssss'), the largest gap doesn't give the earliest spawn point,
-        # because a Pokemon is always there
-        # use the union of all intervals where the same encounter ID was seen to find the latest_seen
-        # If a different encounter ID was seen, then the complement of that interval was the same
-        # ID, so union that complement as well
+        #
+        # For 60 minute spawns ('ssss'), the largest gap doesn't give the
+        # earliest spawnpoint because a Pokemon is always there.  Use the union
+        # of all intervals where the same encounter ID was seen to find the
+        # latest_seen.  If a different encounter ID was seen, then the
+        # complement of that interval was the same ID, so union that
+        # complement as well.
 
         sight_list = [{'date': query[i]['scan_time'],
-                       'delta': query[i + 1]['scan_time'] - query[i]['scan_time'],
-                       'same': query[i + 1]['encounter_id'] == query[i]['encounter_id']}
+                       'delta': query[i + 1]['scan_time'] -
+                       query[i]['scan_time'],
+                       'same': query[i + 1]['encounter_id'] ==
+                       query[i]['encounter_id']
+                       }
                       for i in range(len(query) - 1)
-                      if query[i + 1]['scan_time'] - query[i]['scan_time'] < timedelta(hours=1)]
+                      if query[i + 1]['scan_time'] - query[i]['scan_time'] <
+                      timedelta(hours=1)
+                      ]
 
         start_end_list = []
         for s in sight_list:
             if s['same']:
-                # get the seconds past the hour for start and end times
+                # Get the seconds past the hour for start and end times.
                 start = date_secs(s['date'])
                 end = (start + int(s['delta'].total_seconds())) % 3600
 
             else:
-                # convert diff range to same range by taking the clock
-                # complement
+                # Convert diff range to same range by taking the clock
+                # complement.
                 start = date_secs(s['date'] + s['delta']) % 3600
                 end = date_secs(s['date'])
 
             start_end_list.append([start, end])
 
-        # Take the union of all the ranges
+        # Take the union of all the ranges.
         while True:
-            # union is list of unions of ranges with the same encounter id
+            # union is list of unions of ranges with the same encounter id.
             union = []
             for start, end in start_end_list:
                 if not union:
                     union.append([start, end])
                     continue
-                # cycle through all ranges in union, since it might overlap
-                # with any of them
+                # Cycle through all ranges in union, since it might overlap
+                # with any of them.
                 for u in union:
                     if clock_between(u[0], start, u[1]):
                         u[1] = end if not(clock_between(
@@ -1363,46 +1412,48 @@ class SpawnpointDetectionData(BaseModel):
             # Are no more unions possible?
             if union == start_end_list:
                 break
-            else:
-                start_end_list = union  # Make another pass looking for unions
 
-        # if more than one disparate union, take the largest as our starting
-        # point
-        union = reduce(lambda x, y: x if (x[1] - x[0]) % 3600 > (y[1] - y[0]) % 3600 else y,
-                       union, [0, 3600])
+            start_end_list = union  # Make another pass looking for unions.
+
+        # If more than one disparate union, take the largest as our starting
+        # point.
+        union = reduce(lambda x, y: x if (x[1] - x[0]) % 3600 >
+                       (y[1] - y[0]) % 3600 else y, union, [0, 3600])
         sp['latest_seen'] = union[1]
         sp['earliest_unseen'] = union[0]
-        log.info('1x60: appear %d, despawn %d, duration: %d min', union[
-                 0], union[1], ((union[1] - union[0]) % 3600) / 60)
+        log.info('1x60: appear %d, despawn %d, duration: %d min.',
+                 union[0], union[1], ((union[1] - union[0]) % 3600) / 60)
 
-    # expand the seen times for 30 minute spawnpoints based on scans when spawn wasn't there
-    # return true if spawnpoint dict changed
+    # Expand the seen times for 30 minute spawnpoints based on scans when spawn
+    # wasn't there.  Return true if spawnpoint dict changed.
     @classmethod
     def unseen(cls, sp, now_secs):
 
-        # return if we already have a tth
+        # Return if we already have a tth.
         if sp['latest_seen'] == sp['earliest_unseen']:
             return False
 
-        # if now_secs is later than the latest seen return
-        if not clock_between(sp['latest_seen'], now_secs, sp['earliest_unseen']):
+        # If now_secs is later than the latest seen return.
+        if not clock_between(sp['latest_seen'], now_secs,
+                             sp['earliest_unseen']):
             return False
 
         sp['earliest_unseen'] = now_secs
 
         return True
 
-    # expand a 30 minute spawn with a new seen point based on which endpoint it is closer to
-    # return true if sp changed
+    # Expand a 30 minute spawn with a new seen point based on which endpoint it
+    #  is closer to.  Return true if sp changed.
     @classmethod
     def clock_extend(cls, sp, new_secs):
-        # check if this is a new earliest time
+        # Check if this is a new earliest time.
         if clock_between(sp['earliest_seen'], new_secs, sp['latest_seen']):
             return False
 
-        # extend earliest or latest seen depending on which is closer to the
-        # new point
-        if secs_between(new_secs, sp['earliest_seen']) < secs_between(new_secs, sp['latest_seen']):
+        # Extend earliest or latest seen depending on which is closer to the
+        # new point.
+        if (secs_between(new_secs, sp['earliest_seen']) <
+                secs_between(new_secs, sp['latest_seen'])):
             sp['earliest_seen'] = new_secs
         else:
             sp['latest_seen'] = new_secs
@@ -1463,8 +1514,8 @@ class GymDetails(BaseModel):
 
 
 def hex_bounds(center, steps=None, radius=None):
-    # Make a box that is (70m * step_limit * 2) + 70m away from the center point
-    # Rationale is that you need to travel
+    # Make a box that is (70m * step_limit * 2) + 70m away from the
+    # center point.  Rationale is that you need to travel.
     sp_dist = 0.07 * (2 * steps + 1) if steps else radius
     n = get_new_coords(center, sp_dist, 0)[0]
     e = get_new_coords(center, sp_dist, 90)[1]
@@ -1473,16 +1524,17 @@ def hex_bounds(center, steps=None, radius=None):
     return (n, e, s, w)
 
 
-# todo: this probably shouldn't _really_ be in "models" anymore, but w/e
-def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, api, now_date):
-    pokemons = {}
+# todo: this probably shouldn't _really_ be in "models" anymore, but w/e.
+def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
+              api, now_date):
+    pokemon = {}
     pokestops = {}
     gyms = {}
     skipped = 0
     stopsskipped = 0
     forts = []
     wild_pokemon = []
-    nearby_pokemons = []
+    nearby_pokemon = []
     spawn_points = {}
     scan_spawn_points = {}
     sightings = {}
@@ -1490,50 +1542,64 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
     sp_id_list = []
     now_secs = date_secs(now_date)
 
-    # consolidate the individual lists in each cell into one list of Pokemon
-    # and a list of forts
+    # Consolidate the individual lists in each cell into two lists of Pokemon
+    # and a list of forts.
     cells = map_dict['responses']['GET_MAP_OBJECTS']['map_cells']
     for cell in cells:
-        nearby_pokemons += cell.get('nearby_pokemons', [])
-        if config['parse_pokemon']:
-            wild_pokemon += cell.get('wild_pokemons', [])
+        nearby_pokemon += cell.get('nearby_pokemons', [])
+        # Parse everything for stats (counts).  Future enhancement -- we don't
+        # necessarily need to know *how many* forts/wild/nearby were found but
+        # we'd like to know whether or not *any* were found to help determine
+        # if a scan was actually bad.
+        wild_pokemon += cell.get('wild_pokemons', [])
 
-        if config['parse_pokestops'] or config['parse_gyms']:
-            forts += cell.get('forts', [])
+        forts += cell.get('forts', [])
 
-    # Check for a 0/0/0 bad scan
-    # If we saw nothing and there should be visible forts, it's bad
-    if not len(wild_pokemon) and not len(forts) and ScannedLocation.visible_forts(step_location):
-        log.warning('Bad scan. Parsing found 0/0/0 Pokemon/pokestops/gyms')
-        log.info('Common causes: captchas, IP bans, or using -ng and -nk arguments')
-        return {
-            'count': 0,
-            'gyms': gyms,
-            'spawn_points': spawn_points,
-            'bad_scan': True
-        }
-
-    if not len(nearby_pokemons) and not len(wild_pokemon):
-        log.warning('No nearby or wild Pokemon. Speed violation?')
-        log.info("Common causes: not using -speed, deleting or dropping the WorkerStatus table without waiting before restarting, or there really aren't any Pokemon in 200m")
+    # If there are no wild or nearby Pokemon . . .
+    if not wild_pokemon and not nearby_pokemon:
+        # . . . and there are no gyms/pokestops then it's unusable/bad.
+        if not forts:
+            log.warning('Bad scan. Parsing found absolutely nothing.')
+            log.info('Common causes: captchas or IP bans.')
+            return {
+                'count': 0,
+                'gyms': gyms,
+                'spawn_points': spawn_points,
+                'bad_scan': True
+            }
+        else:
+            # No wild or nearby Pokemon but there are forts.  It's probably
+            # a speed violation.
+            log.warning('No nearby or wild Pokemon but there are visible gyms '
+                        'or pokestops. Possible speed violation.')
+            if not (config['parse_pokestops'] or config['parse_gyms']):
+                # If we're not going to parse the forts, then we'll just
+                # exit here.
+                return {
+                    'count': 0,
+                    'gyms': gyms,
+                    'spawn_points': spawn_points,
+                    'bad_scan': True
+                }
 
     scan_loc = ScannedLocation.get_by_loc(step_location)
     done_already = scan_loc['done']
     ScannedLocation.update_band(scan_loc)
     just_completed = not done_already and scan_loc['done']
 
-    if len(wild_pokemon):
+    if wild_pokemon and config['parse_pokemon']:
         encounter_ids = [b64encode(str(p['encounter_id']))
                          for p in wild_pokemon]
         # For all the wild Pokemon we found check if an active Pokemon is in
         # the database.
         query = (Pokemon
                  .select(Pokemon.encounter_id, Pokemon.spawnpoint_id)
-                 .where((Pokemon.disappear_time > datetime.utcnow()) & (Pokemon.encounter_id << encounter_ids))
+                 .where((Pokemon.disappear_time > datetime.utcnow()) &
+                        (Pokemon.encounter_id << encounter_ids))
                  .dicts())
 
-        # Store all encounter_ids and spawnpoint_id for the Pokemon in query
-        # (all thats needed to make sure its unique).
+        # Store all encounter_ids and spawnpoint_ids for the Pokemon in query.
+        # All of that is needed to make sure it's unique.
         encountered_pokemon = [
             (p['encounter_id'], p['spawnpoint_id']) for p in query]
 
@@ -1552,49 +1618,55 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
                 'tth_secs': None
             }
 
-            # keep a list of sp_ids to return
+            # Keep a list of sp_ids to return.
             sp_id_list.append(p['spawn_point_id'])
 
             # time_till_hidden_ms was overflowing causing a negative integer.
             # It was also returning a value above 3.6M ms.
             if 0 < p['time_till_hidden_ms'] < 3600000:
                 d_t_secs = date_secs(datetime.utcfromtimestamp(
-                    (p['last_modified_timestamp_ms'] + p['time_till_hidden_ms']) / 1000.0))
+                    (p['last_modified_timestamp_ms'] +
+                     p['time_till_hidden_ms']) / 1000.0))
                 if sp['latest_seen'] != sp['earliest_unseen']:
-                    log.info('TTH found for spawnpoint %s', sp['id'])
+                    log.info('TTH found for spawnpoint %s.', sp['id'])
                     sighting['tth_secs'] = d_t_secs
 
-                    # only update when TTH is seen for the first time
-                    # just before Pokemon migrations, Niantic sets all TTH to the exact time of the migration
-                    # not the normal despawn time
+                    # Only update when TTH is seen for the first time.
+                    # Just before Pokemon migrations, Niantic sets all TTH
+                    # to the exact time of the migration, not the normal
+                    # despawn time.
                     sp['latest_seen'] = d_t_secs
                     sp['earliest_unseen'] = d_t_secs
 
-            scan_spawn_points[scan_loc['cellid'] + sp['id']] = {'spawnpoint': sp['id'],
-                                                                'scannedlocation': scan_loc['cellid']}
+            scan_spawn_points[scan_loc['cellid'] +
+                              sp['id']] = {'spawnpoint': sp['id'],
+                                           'scannedlocation': scan_loc[
+                                                'cellid']}
             if not sp['last_scanned']:
-                log.info('New Spawn Point found!')
+                log.info('New Spawn Point found.')
                 new_spawn_points.append(sp)
 
-                # if we found a new spawnpoint after the location was already fully scanned
-                # either it's new, or we had a bad scan. Either way, rescan the
-                # loc
+                # If we found a new spawnpoint after the location was already
+                # fully scanned then either it's new, or we had a bad scan.
+                # Either way, rescan the location.
                 if scan_loc['done'] and not just_completed:
-                    log.warning(
-                        'Location was fully scanned, and yet a brand new spawnpoint found.')
-                    log.warning(
-                        'Redoing scan of this location to identify new spawnpoint.')
+                    log.warning('Location was fully scanned, and yet a brand '
+                                'new spawnpoint found.')
+                    log.warning('Redoing scan of this location to identify '
+                                'new spawnpoint.')
                     ScannedLocation.reset_bands(scan_loc)
 
-            if (not SpawnPoint.tth_found(sp) or sighting['tth_secs'] or not scan_loc['done'] or just_completed):
-                SpawnpointDetectionData.classify(
-                    sp, scan_loc, now_secs, sighting)
+            if (not SpawnPoint.tth_found(sp) or sighting['tth_secs'] or
+                    not scan_loc['done'] or just_completed):
+                SpawnpointDetectionData.classify(sp, scan_loc, now_secs,
+                                                 sighting)
                 sightings[p['encounter_id']] = sighting
 
             sp['last_scanned'] = datetime.utcfromtimestamp(
                 p['last_modified_timestamp_ms'] / 1000.0)
 
-            if (b64encode(str(p['encounter_id'])), p['spawn_point_id']) in encountered_pokemon:
+            if ((b64encode(str(p['encounter_id'])), p['spawn_point_id'])
+                    in encountered_pokemon):
                 # If Pokemon has been encountered before don't process it.
                 skipped += 1
                 continue
@@ -1609,17 +1681,18 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
 
             # Scan for IVs and moves.
             encounter_result = None
-            if (args.encounter and (p['pokemon_data']['pokemon_id'] in args.encounter_whitelist or
-                                    p['pokemon_data']['pokemon_id'] not in args.encounter_blacklist and not args.encounter_whitelist)):
+            if (args.encounter and (p['pokemon_data']['pokemon_id']
+                                    in args.encounter_whitelist or
+                                    p['pokemon_data']['pokemon_id']
+                                    not in args.encounter_blacklist and
+                                    not args.encounter_whitelist)):
                 time.sleep(args.encounter_delay)
-                # Set up encounter request envelope
+                # Setup encounter request envelope.
                 req = api.create_request()
-                encounter_result = req.encounter(encounter_id=p['encounter_id'],
-                                                 spawn_point_id=p[
-                                                     'spawn_point_id'],
-                                                 player_latitude=step_location[
-                                                     0],
-                                                 player_longitude=step_location[1])
+                encounter_result = req.encounter(encounter_id=p[
+                    'encounter_id'], spawn_point_id=p['spawn_point_id'],
+                    player_latitude=step_location[0],
+                    player_longitude=step_location[1])
                 encounter_result = req.check_challenge()
                 encounter_result = req.get_hatched_eggs()
                 encounter_result = req.get_inventory()
@@ -1628,7 +1701,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
                 encounter_result = req.get_buddy_walked()
                 encounter_result = req.call()
 
-            pokemons[p['encounter_id']] = {
+            pokemon[p['encounter_id']] = {
                 'encounter_id': b64encode(str(p['encounter_id'])),
                 'spawnpoint_id': p['spawn_point_id'],
                 'pokemon_id': p['pokemon_data']['pokemon_id'],
@@ -1642,28 +1715,33 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
                 'move_2': None
             }
 
-            if encounter_result is not None and 'wild_pokemon' in encounter_result['responses']['ENCOUNTER']:
+            if (encounter_result is not None and 'wild_pokemon'
+                    in encounter_result['responses']['ENCOUNTER']):
                 pokemon_info = encounter_result['responses'][
                     'ENCOUNTER']['wild_pokemon']['pokemon_data']
-                pokemons[p['encounter_id']].update({
-                    'individual_attack': pokemon_info.get('individual_attack', 0),
-                    'individual_defense': pokemon_info.get('individual_defense', 0),
-                    'individual_stamina': pokemon_info.get('individual_stamina', 0),
+                pokemon[p['encounter_id']].update({
+                    'individual_attack': pokemon_info.get(
+                        'individual_attack', 0),
+                    'individual_defense': pokemon_info.get(
+                        'individual_defense', 0),
+                    'individual_stamina': pokemon_info.get(
+                        'individual_stamina', 0),
                     'move_1': pokemon_info['move_1'],
                     'move_2': pokemon_info['move_2'],
                 })
 
             if args.webhooks:
 
-                wh_poke = pokemons[p['encounter_id']].copy()
+                wh_poke = pokemon[p['encounter_id']].copy()
                 wh_poke.update({
-                    'disappear_time': calendar.timegm(disappear_time.timetuple()),
+                    'disappear_time': calendar.timegm(
+                        disappear_time.timetuple()),
                     'last_modified_time': p['last_modified_timestamp_ms'],
                     'time_until_hidden_ms': p['time_till_hidden_ms']
                 })
                 wh_update_queue.put(('pokemon', wh_poke))
 
-    if len(forts):
+    if forts and (config['parse_pokestops'] or config['parse_gyms']):
         if config['parse_pokestops']:
             stop_ids = [f['id'] for f in forts if f.get('type') == 1]
             if len(stop_ids) > 0:
@@ -1672,13 +1750,15 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
                          .where((Pokestop.pokestop_id << stop_ids))
                          .dicts())
                 encountered_pokestops = [(f['pokestop_id'], int(
-                    (f['last_modified'] - datetime(1970, 1, 1)).total_seconds())) for f in query]
+                    (f['last_modified'] -
+                     datetime(1970, 1, 1)).total_seconds())) for f in query]
 
         for f in forts:
             if config['parse_pokestops'] and f.get('type') == 1:  # Pokestops.
                 if 'active_fort_modifier' in f:
-                    lure_expiration = datetime.utcfromtimestamp(
-                        f['last_modified_timestamp_ms'] / 1000.0) + timedelta(minutes=30)
+                    lure_expiration = (datetime.utcfromtimestamp(
+                        f['last_modified_timestamp_ms'] / 1000.0) +
+                        timedelta(minutes=30))
                     active_fort_modifier = f['active_fort_modifier']
                     if args.webhooks and args.webhook_updates_only:
                         wh_update_queue.put(('pokestop', {
@@ -1686,8 +1766,10 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
                             'enabled': f['enabled'],
                             'latitude': f['latitude'],
                             'longitude': f['longitude'],
-                            'last_modified_time': f['last_modified_timestamp_ms'],
-                            'lure_expiration': calendar.timegm(lure_expiration.timetuple()),
+                            'last_modified_time': f[
+                                'last_modified_timestamp_ms'],
+                            'lure_expiration': calendar.timegm(
+                                lure_expiration.timetuple()),
                             'active_fort_modifier': active_fort_modifier
                         }))
                 else:
@@ -1695,8 +1777,9 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
 
                 # Send all pokestops to webhooks.
                 if args.webhooks and not args.webhook_updates_only:
-                    # Explicitly set 'webhook_data', in case we want to change the information pushed to webhooks,
-                    # similar to above and previous commits.
+                    # Explicitly set 'webhook_data', in case we want to change
+                    # the information pushed to webhooks.  Similar to above and
+                    # previous commits.
                     l_e = None
 
                     if lure_expiration is not None:
@@ -1712,9 +1795,10 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
                         'active_fort_modifier': active_fort_modifier
                     }))
 
-                if (f['id'], int(f['last_modified_timestamp_ms'] / 1000.0)) in encountered_pokestops:
+                if ((f['id'], int(f['last_modified_timestamp_ms'] / 1000.0))
+                        in encountered_pokestops):
                     # If pokestop has been encountered before and hasn't
-                    # changed dont process it.
+                    # changed don't process it.
                     stopsskipped += 1
                     continue
 
@@ -1729,12 +1813,13 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
                     'active_fort_modifier': active_fort_modifier
                 }
 
-            # Currently, there are only stops and gyms
+            # Currently, there are only stops and gyms.
             elif config['parse_gyms'] and f.get('type') is None:
                 # Send gyms to webhooks.
                 if args.webhooks and not args.webhook_updates_only:
-                    # Explicitly set 'webhook_data', in case we want to change the information pushed to webhooks,
-                    # similar to above and previous commits.
+                    # Explicitly set 'webhook_data', in case we want to change
+                    # the information pushed to webhooks.  Similar to above
+                    # and previous commits.
                     wh_update_queue.put(('gym', {
                         'gym_id': b64encode(str(f['id'])),
                         'team_id': f.get('owned_by_team', 0),
@@ -1758,19 +1843,19 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
                         f['last_modified_timestamp_ms'] / 1000.0),
                 }
 
-    log.info('Parsing found %d Pokemon, %d nearby, %d pokestops, and %d gyms.',
-             len(pokemons) + skipped,
-             len(nearby_pokemons),
+    log.info('Parsing found Pokemon: %d, nearby: %d, pokestops: %d, gyms: %d.',
+             len(pokemon) + skipped,
+             len(nearby_pokemon),
              len(pokestops) + stopsskipped,
              len(gyms))
 
-    log.debug('Skipped %d Pokemon and %d pokestops.', skipped, stopsskipped)
+    log.debug('Skipped Pokemon: %d, pokestops: %d.', skipped, stopsskipped)
 
-    # look for spawnpoints within scan_loc that are not here to see if can
-    # narrow down tth window
+    # Look for spawnpoints within scan_loc that are not here to see if we
+    # can narrow down tth window.
     for sp in ScannedLocation.linked_spawn_points(scan_loc['cellid']):
         if sp['id'] in sp_id_list:
-            # Don't overwrite changes from this parse with DB version
+            # Don't overwrite changes from this parse with DB version.
             sp = spawn_points[sp['id']]
         else:
             if SpawnpointDetectionData.unseen(sp, now_secs):
@@ -1779,16 +1864,20 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
             if clock_between(endpoints[0], now_secs, endpoints[1]):
                 sp['missed_count'] += 1
                 spawn_points[sp['id']] = sp
-                log.warning('%s kind spawnpoint %s has no Pokemon %d times in a row',
-                            sp['kind'], sp['id'], sp['missed_count'])
-                log.info(
-                    'Possible causes: Still doing initial scan, or super rare double spawnpoint during hidden period, or Niantic has removed spawnpoint')
+                log.warning('%s kind spawnpoint %s has no Pokemon %d times '
+                            'in a row.', sp['kind'], sp['id'],
+                            sp['missed_count'])
+                log.info('Possible causes: Still doing initial scan, super '
+                         'rare double spawnpoint during')
+                log.info('hidden period, or Niantic has removed spawnpoint.')
 
         if (not SpawnPoint.tth_found(sp) and scan_loc['done'] and
-                (sp['earliest_unseen'] - sp['latest_seen'] - args.spawn_delay) % 3600 < 60):
-            log.warning('Spawnpoint %s was unable to locate a TTH, with only %ss after Pokemon last seen',
-                        sp['id'], (sp['earliest_unseen'] - sp['latest_seen']) % 3600)
-            log.info('Embiggening search for TTH by 15 minutes to try again')
+                (sp['earliest_unseen'] - sp['latest_seen'] -
+                 args.spawn_delay) % 3600 < 60):
+            log.warning('Spawnpoint %s was unable to locate a TTH, with only '
+                        '%ss after Pokemon last seen.', sp['id'],
+                        (sp['earliest_unseen'] - sp['latest_seen']) % 3600)
+            log.info('Restarting current 15 minute search for TTH.')
             if sp['id'] not in sp_id_list:
                 SpawnpointDetectionData.classify(sp, scan_loc, now_secs)
             sp['latest_seen'] = (sp['latest_seen'] - 60) % 3600
@@ -1797,17 +1886,27 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
 
     db_update_queue.put((ScannedLocation, {0: scan_loc}))
 
-    if len(pokemons):
-        db_update_queue.put((Pokemon, pokemons))
-    if len(pokestops):
+    if pokemon:
+        db_update_queue.put((Pokemon, pokemon))
+    if pokestops:
         db_update_queue.put((Pokestop, pokestops))
-    if len(gyms):
+    if gyms:
         db_update_queue.put((Gym, gyms))
-    if len(spawn_points):
+    if spawn_points:
         db_update_queue.put((SpawnPoint, spawn_points))
         db_update_queue.put((ScanSpawnPoint, scan_spawn_points))
-        if len(sightings):
+        if sightings:
             db_update_queue.put((SpawnpointDetectionData, sightings))
+
+    if not nearby_pokemon and not wild_pokemon:
+        # After parsing the forts, we'll mark this scan as bad due to
+        # a possible speed violation.
+        return {
+            'count': len(wild_pokemon) + len(forts),
+            'gyms': gyms,
+            'sp_id_list': sp_id_list,
+            'bad_scan': True
+        }
 
     return {
         'count': len(wild_pokemon) + len(forts),
@@ -1866,10 +1965,14 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
                 'stamina': member['pokemon_data'].get('stamina'),
                 'stamina_max': member['pokemon_data'].get('stamina_max'),
                 'cp_multiplier': member['pokemon_data'].get('cp_multiplier'),
-                'additional_cp_multiplier': member['pokemon_data'].get('additional_cp_multiplier', 0),
-                'iv_defense': member['pokemon_data'].get('individual_defense', 0),
-                'iv_stamina': member['pokemon_data'].get('individual_stamina', 0),
-                'iv_attack': member['pokemon_data'].get('individual_attack', 0),
+                'additional_cp_multiplier': member['pokemon_data'].get(
+                    'additional_cp_multiplier', 0),
+                'iv_defense': member['pokemon_data'].get(
+                    'individual_defense', 0),
+                'iv_stamina': member['pokemon_data'].get(
+                    'individual_stamina', 0),
+                'iv_attack': member['pokemon_data'].get(
+                    'individual_attack', 0),
                 'last_seen': datetime.utcnow(),
             }
 
@@ -1885,18 +1988,24 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
                     'pokemon_uid': member['pokemon_data']['id'],
                     'pokemon_id': member['pokemon_data']['pokemon_id'],
                     'cp': member['pokemon_data']['cp'],
-                    'num_upgrades': member['pokemon_data'].get('num_upgrades', 0),
+                    'num_upgrades': member['pokemon_data'].get(
+                        'num_upgrades', 0),
                     'move_1': member['pokemon_data'].get('move_1'),
                     'move_2': member['pokemon_data'].get('move_2'),
                     'height': member['pokemon_data'].get('height_m'),
                     'weight': member['pokemon_data'].get('weight_kg'),
                     'stamina': member['pokemon_data'].get('stamina'),
                     'stamina_max': member['pokemon_data'].get('stamina_max'),
-                    'cp_multiplier': member['pokemon_data'].get('cp_multiplier'),
-                    'additional_cp_multiplier': member['pokemon_data'].get('additional_cp_multiplier', 0),
-                    'iv_defense': member['pokemon_data'].get('individual_defense', 0),
-                    'iv_stamina': member['pokemon_data'].get('individual_stamina', 0),
-                    'iv_attack': member['pokemon_data'].get('individual_attack', 0),
+                    'cp_multiplier': member['pokemon_data'].get(
+                        'cp_multiplier'),
+                    'additional_cp_multiplier': member['pokemon_data'].get(
+                        'additional_cp_multiplier', 0),
+                    'iv_defense': member['pokemon_data'].get(
+                        'individual_defense', 0),
+                    'iv_stamina': member['pokemon_data'].get(
+                        'individual_stamina', 0),
+                    'iv_attack': member['pokemon_data'].get(
+                        'individual_attack', 0),
                     'trainer_name': member['trainer_public_profile']['name'],
                     'trainer_level': member['trainer_public_profile']['level'],
                 })
@@ -1905,12 +2014,13 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
         if args.webhooks:
             wh_update_queue.put(('gym_details', webhook_data))
 
-    # All this database stuff is synchronous (not using the upsert queue) on purpose.
-    # Since the search workers load the GymDetails model from the database to determine if a gym
-    # needs rescanned, we need to be sure the GymDetails get fully committed to the database before moving on.
+    # All this database stuff is synchronous (not using the upsert queue) on
+    # purpose.  Since the search workers load the GymDetails model from the
+    # database to determine if a gym needs to be rescanned, we need to be sure
+    # the GymDetails get fully committed to the database before moving on.
     #
-    # We _could_ synchronously upsert GymDetails, then queue the other tables for
-    # upsert, but that would put that Gym's overall information in a weird
+    # We _could_ synchronously upsert GymDetails, then queue the other tables
+    # for upsert, but that would put that Gym's overall information in a weird
     # non-atomic state.
 
     # Upsert all the models.
@@ -1921,9 +2031,9 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
     if len(trainers):
         db_update_queue.put((Trainer, trainers))
 
-    # This needs to be completed in a transaction, because we don't wany any other thread or process
-    # to mess with the GymMembers for the gyms we're updating while we're
-    # updating the bridge table.
+    # This needs to be completed in a transaction, because we don't wany any
+    # other thread or process to mess with the GymMembers for the gyms we're
+    # updating while we're updating the bridge table.
     with flaskDb.database.transaction():
         # Get rid of all the gym members, we're going to insert new records.
         if len(gym_details):
@@ -1934,7 +2044,7 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
         if len(gym_members):
             db_update_queue.put((GymMember, gym_members))
 
-    log.info('Upserted %d gyms and %d gym members',
+    log.info('Upserted gyms: %d, gym members: %d.',
              len(gym_details),
              len(gym_members))
 
@@ -1949,20 +2059,22 @@ def db_updater(args, q, db):
                     flaskDb.connect_db()
                     break
                 except Exception as e:
-                    log.warning('%s... Retrying', e)
+                    log.warning('%s... Retrying...', e)
 
             # Loop the queue.
             while True:
                 model, data = q.get()
                 bulk_upsert(model, data, db)
                 q.task_done()
-                log.debug('Upserted to %s, %d records (upsert queue remaining: %d)',
+                log.debug('Upserted to %s, %d records (upsert queue '
+                          'remaining: %d.)',
                           model.__name__,
                           len(data),
                           q.qsize())
                 if q.qsize() > 50:
                     log.warning(
-                        "DB queue is > 50 (@%d); try increasing --db-threads", q.qsize())
+                        "DB queue is > 50 (@%d); try increasing --db-threads.",
+                        q.qsize())
 
         except Exception as e:
             log.exception('Exception in db_updater: %s', e)
@@ -1994,10 +2106,11 @@ def clean_db_loop(args):
                 query = (Pokemon
                          .delete()
                          .where((Pokemon.disappear_time <
-                                 (datetime.utcnow() - timedelta(hours=args.purge_data)))))
+                                 (datetime.utcnow() -
+                                  timedelta(hours=args.purge_data)))))
                 query.execute()
 
-            log.info('Regular database cleaning complete')
+            log.info('Regular database cleaning complete.')
             time.sleep(60)
         except Exception as e:
             log.exception('Exception in clean_db_loop: %s', e)
@@ -2015,11 +2128,12 @@ def bulk_upsert(cls, data, db):
         step = 50
 
     while i < num_rows:
-        log.debug('Inserting items %d to %d', i, min(i + step, num_rows))
+        log.debug('Inserting items %d to %d.', i, min(i + step, num_rows))
         try:
-            # Turn off FOREIGN_KEY_CHECKS on MySQL, because it apparently is unable
-            # to recognize strings to update unicode keys for foriegn key fields,
-            # thus giving lots of foreign key constraint errors
+            # Turn off FOREIGN_KEY_CHECKS on MySQL, because it apparently is
+            # unable to recognize strings to update unicode keys for
+            # foriegn key fields, thus giving lots of foreign key constraint
+            # errors.
             if args.db_type == 'mysql':
                 db.execute_sql('SET FOREIGN_KEY_CHECKS=0;')
 
@@ -2030,8 +2144,10 @@ def bulk_upsert(cls, data, db):
                 db.execute_sql('SET FOREIGN_KEY_CHECKS=1;')
 
         except Exception as e:
-            # if there is a DB table constraint error, dump the data and don't retry
-            # unrecoverable error strings:
+            # If there is a DB table constraint error, dump the data and don't
+            # retry.
+            #
+            # Unrecoverable error strings:
             unrecoverable = ['constraint', 'has no attribute',
                              'peewee.IntegerField object at']
             has_unrecoverable = filter(lambda x: x in str(e), unrecoverable)
@@ -2039,7 +2155,7 @@ def bulk_upsert(cls, data, db):
                 log.warning('%s. Data is:', e)
                 log.warning(data.items())
             else:
-                log.warning('%s... Retrying', e)
+                log.warning('%s... Retrying...', e)
                 time.sleep(1)
                 continue
 
@@ -2049,15 +2165,19 @@ def bulk_upsert(cls, data, db):
 def create_tables(db):
     db.connect()
     verify_database_schema(db)
-    db.create_tables([Pokemon, Pokestop, Gym, ScannedLocation, GymDetails, GymMember, GymPokemon,
-                      Trainer, MainWorker, WorkerStatus, SpawnPoint, ScanSpawnPoint, SpawnpointDetectionData], safe=True)
+    db.create_tables([Pokemon, Pokestop, Gym, ScannedLocation, GymDetails,
+                      GymMember, GymPokemon, Trainer, MainWorker, WorkerStatus,
+                      SpawnPoint, ScanSpawnPoint, SpawnpointDetectionData],
+                     safe=True)
     db.close()
 
 
 def drop_tables(db):
     db.connect()
-    db.drop_tables([Pokemon, Pokestop, Gym, ScannedLocation, Versions, GymDetails, GymMember, GymPokemon,
-                    Trainer, MainWorker, WorkerStatus, SpawnPoint, ScanSpawnPoint, SpawnpointDetectionData, Versions], safe=True)
+    db.drop_tables([Pokemon, Pokestop, Gym, ScannedLocation, Versions,
+                    GymDetails, GymMember, GymPokemon, Trainer, MainWorker,
+                    WorkerStatus, SpawnPoint, ScanSpawnPoint,
+                    SpawnpointDetectionData, Versions], safe=True)
     db.close()
 
 
@@ -2066,11 +2186,11 @@ def verify_database_schema(db):
         db.create_tables([Versions])
 
         if ScannedLocation.table_exists():
-            # Versions table didn't exist, but there were tables. This must mean the user
-            # is coming from a database that existed before we started tracking the schema
-            # version. Perform a full upgrade.
-            InsertQuery(
-                Versions, {Versions.key: 'schema_version', Versions.val: 0}).execute()
+            # Versions table doesn't exist, but there are tables. This must
+            # mean the user is coming from a database that existed before we
+            # started tracking the schema version. Perform a full upgrade.
+            InsertQuery(Versions, {Versions.key: 'schema_version',
+                                   Versions.val: 0}).execute()
             database_migrate(db, 0)
         else:
             InsertQuery(Versions, {Versions.key: 'schema_version',
@@ -2083,10 +2203,10 @@ def verify_database_schema(db):
             database_migrate(db, db_ver)
 
         elif db_ver > db_schema_version:
-            log.error("Your database version (%i) appears to be newer than the code supports (%i).",
-                      db_ver, db_schema_version)
-            log.error(
-                "Please upgrade your code base or drop all tables in your database.")
+            log.error('Your database version (%i) appears to be newer than '
+                      'the code supports (%i).', db_ver, db_schema_version)
+            log.error('Please upgrade your code base or drop all tables in '
+                      'your database.')
             sys.exit(1)
 
 
@@ -2095,7 +2215,7 @@ def database_migrate(db, old_ver):
     Versions.update(val=db_schema_version).where(
         Versions.key == 'schema_version').execute()
 
-    log.info("Detected database version %i, updating to %i",
+    log.info('Detected database version %i, updating to %i...',
              old_ver, db_schema_version)
 
     # Perform migrations here.
@@ -2104,10 +2224,6 @@ def database_migrate(db, old_ver):
         migrator = MySQLMigrator(db)
     else:
         migrator = SqliteMigrator(db)
-
-#   No longer necessary, we're doing this at schema 4 as well.
-#    if old_ver < 1:
-#        db.drop_tables([ScannedLocation])
 
     if old_ver < 2:
         migrate(migrator.add_column('pokestop', 'encounter_id',
@@ -2169,8 +2285,8 @@ def database_migrate(db, old_ver):
         )
 
     if old_ver < 10:
-        # Information in ScannedLocation and Member Status probably out of date,
-        # so drop and re-create with new schema
+        # Information in ScannedLocation and Member Status is probably
+        # out of date.  Drop and recreate with new schema.
 
         db.drop_tables([ScannedLocation])
         db.drop_tables([WorkerStatus])

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -227,8 +227,9 @@ class Pokemon(BaseModel):
                          Pokemon.latitude,
                          Pokemon.longitude,
                          pokemon_count_query.c.count)
-                 .join(pokemon_count_query, on=(
-                    Pokemon.pokemon_id == pokemon_count_query.c.pokemon_id))
+                 .join(pokemon_count_query,
+                       on=(Pokemon.pokemon_id ==
+                           pokemon_count_query.c.pokemon_id))
                  .distinct()
                  .where(Pokemon.disappear_time ==
                         pokemon_count_query.c.lastappeared)
@@ -1641,7 +1642,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
             scan_spawn_points[scan_loc['cellid'] +
                               sp['id']] = {'spawnpoint': sp['id'],
                                            'scannedlocation': scan_loc[
-                                                'cellid']}
+                                               'cellid']}
             if not sp['last_scanned']:
                 log.info('New Spawn Point found.')
                 new_spawn_points.append(sp)

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1271,7 +1271,7 @@ class SpawnpointDetectionData(BaseModel):
     @classmethod
     def classify(cls, sp, scan_loc, now_secs, sighting=None):
 
-        # To reduce CPU usage, give an intial reading of 15 minunte spawns if
+        # To reduce CPU usage, give an intial reading of 15 minute spawns if
         # not done with initial scan of location.
         if not scan_loc['done']:
             sp['kind'] = 'hhhs'

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1744,7 +1744,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
     if forts and (config['parse_pokestops'] or config['parse_gyms']):
         if config['parse_pokestops']:
             stop_ids = [f['id'] for f in forts if f.get('type') == 1]
-            if len(stop_ids) > 0:
+            if stop_ids:
                 query = (Pokestop
                          .select(Pokestop.pokestop_id, Pokestop.last_modified)
                          .where((Pokestop.pokestop_id << stop_ids))
@@ -2024,11 +2024,11 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
     # non-atomic state.
 
     # Upsert all the models.
-    if len(gym_details):
+    if gym_details:
         db_update_queue.put((GymDetails, gym_details))
-    if len(gym_pokemon):
+    if gym_pokemon:
         db_update_queue.put((GymPokemon, gym_pokemon))
-    if len(trainers):
+    if trainers:
         db_update_queue.put((Trainer, trainers))
 
     # This needs to be completed in a transaction, because we don't wany any
@@ -2036,12 +2036,12 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
     # updating while we're updating the bridge table.
     with flaskDb.database.transaction():
         # Get rid of all the gym members, we're going to insert new records.
-        if len(gym_details):
+        if gym_details:
             DeleteQuery(GymMember).where(
                 GymMember.gym_id << gym_details.keys()).execute()
 
         # Insert new gym members.
-        if len(gym_members):
+        if gym_members:
             db_update_queue.put((GymMember, gym_members))
 
     log.info('Upserted gyms: %d, gym members: %d.',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added sightings/nearby Pokémon to the logic for identifying a bad scan.
Changed the way a speed violation is logged and processed.
## Motivation and Context
We can tell more about 0/0/0 scans (bad scan, speed violation, nearby Pokémon). Let's report on them properly. Works nicely with the new nearby Pokémon count added to the logging.
## How Has This Been Tested?
Running on my small Windows deployment.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
