### PR TITLE
Added cell id radius to fix most bad scans

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -775,7 +775,7 @@ def map_request(api, position, jitter=False):
         scan_location = position
 
     try:
-        cell_ids = util.get_cell_ids(scan_location[0], scan_location[1])
+        cell_ids = util.get_cell_ids(scan_location[0], scan_location[1], radius=1000)
         timestamps = [0, ] * len(cell_ids)
         req = api.create_request()
         response = req.get_map_objects(latitude=f2i(scan_location[0]),


### PR DESCRIPTION
## Description
Speed uses pokestops and gyms to determine bad scans from good scans.
The master branch of pogodev api changed this to 500, so I changed it back to 1000.

This fix wont work for everyone if there was no gyms or pokestops around to begin with.
I was getting too many empty results and this fixed my map and allowed it to go from less than 10% on the initial scan to over 90% in the first hour of running it.

## Motivation and Context
wasted $30 on captchas from pure bad scans in 3 days, it had to be fixed.

## How Has This Been Tested?
My map

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
