### PR TITLE
(1) Enable hash server usage (2) Introduce key scheduler

### DIFF
--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -35,6 +35,7 @@ Where:
 If implementing a new scheduler, place it before SchedulerFactory, and add it to __scheduler_classes
 '''
 
+import itertools
 import logging
 import math
 import geopy
@@ -864,3 +865,12 @@ class SchedulerFactory():
             return scheduler_class(*args, **kwargs)
 
         raise NotImplementedError("The requested scheduler has not been implemented")
+
+# The KeyScheduler returns a scheduler that cycles through the given hash server keys
+class KeyScheduler(object):
+    def __init__(self, keys):
+        self.keys = keys
+        
+    def scheduler(self):
+        cycle = itertools.cycle(self.keys)
+        return cycle

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -867,7 +867,7 @@ class SchedulerFactory():
         raise NotImplementedError("The requested scheduler has not been implemented")
 
 
-# The KeyScheduler returns a scheduler that cycles through the given hash server keys
+# The KeyScheduler returns a scheduler that cycles through the given hash server keys.
 class KeyScheduler(object):
     def __init__(self, keys):
         self.keys = keys

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -866,11 +866,12 @@ class SchedulerFactory():
 
         raise NotImplementedError("The requested scheduler has not been implemented")
 
+
 # The KeyScheduler returns a scheduler that cycles through the given hash server keys
 class KeyScheduler(object):
     def __init__(self, keys):
         self.keys = keys
-        
+
     def scheduler(self):
         cycle = itertools.cycle(self.keys)
         return cycle

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -263,6 +263,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb, db_updat
     scheduler_array = []
     account_queue = Queue()
     threadStatus = {}
+    key_scheduler = None
 
     '''
     Create a queue of accounts for workers to pull from. When a worker has failed too many times,
@@ -303,6 +304,10 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb, db_updat
                    args=(threadStatus, args.status_name, db_updates_queue))
         t.daemon = True
         t.start()
+    
+    # Create the hash server key scheduler (only if the keys are passed as a list)
+    if args.hash_key:
+        key_scheduler = schedulers.KeyScheduler(args.hash_key).scheduler()
 
     # Create specified number of search_worker_thread.
     log.info('Starting search worker threads...')
@@ -338,7 +343,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb, db_updat
                    name='search-worker-{}'.format(i),
                    args=(args, account_queue, account_failures, search_items_queue, pause_bit,
                          threadStatus[workerId],
-                         db_updates_queue, wh_queue, scheduler))
+                         db_updates_queue, wh_queue, scheduler, key_scheduler))
         t.daemon = True
         t.start()
 
@@ -455,7 +460,7 @@ def generate_hive_locations(current_location, step_distance, step_limit, hive_co
     return results
 
 
-def search_worker_thread(args, account_queue, account_failures, search_items_queue, pause_bit, status, dbq, whq, scheduler):
+def search_worker_thread(args, account_queue, account_failures, search_items_queue, pause_bit, status, dbq, whq, scheduler, key_scheduler):
 
     log.debug('Search worker thread starting...')
 
@@ -592,7 +597,12 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                 # when the auth token is refreshed.
                 api.set_position(*step_location)
 
-                # Ok, let's get started -- check our login status.
+                if args.hash_key:
+                    key = key_scheduler.next()
+                    api.activate_hash_server(key)
+                    log.info('Using key {} for this scan.'.format(key))
+
+                # Ok, let's get started -- check our login status
                 status['message'] = 'Logging in...'
                 check_login(args, account, api, step_location, status['proxy_url'])
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -304,8 +304,8 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb, db_updat
                    args=(threadStatus, args.status_name, db_updates_queue))
         t.daemon = True
         t.start()
-    
-    # Create the hash server key scheduler (only if the keys are passed as a list)
+
+    # Create the key scheduler
     if args.hash_key:
         key_scheduler = schedulers.KeyScheduler(args.hash_key).scheduler()
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -305,7 +305,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb, db_updat
         t.daemon = True
         t.start()
 
-    # Create the key scheduler
+    # Create the key scheduler.
     if args.hash_key:
         key_scheduler = schedulers.KeyScheduler(args.hash_key).scheduler()
 
@@ -602,7 +602,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                     api.activate_hash_server(key)
                     log.info('Using key {} for this scan.'.format(key))
 
-                # Ok, let's get started -- check our login status
+                # Ok, let's get started -- check our login status.
                 status['message'] = 'Logging in...'
                 check_login(args, account, api, step_location, status['proxy_url'])
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -307,6 +307,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb, db_updat
 
     # Create the key scheduler.
     if args.hash_key:
+        log.info('Enabling hashing key scheduler...')
         key_scheduler = schedulers.KeyScheduler(args.hash_key).scheduler()
 
     # Create specified number of search_worker_thread.
@@ -599,8 +600,8 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
 
                 if args.hash_key:
                     key = key_scheduler.next()
+                    log.debug('Using key {} for this scan.'.format(key))
                     api.activate_hash_server(key)
-                    log.info('Using key {} for this scan.'.format(key))
 
                 # Ok, let's get started -- check our login status.
                 status['message'] = 'Logging in...'

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -233,6 +233,8 @@ def get_args():
                         help='Enable status page database update using STATUS_NAME as main worker name.')
     parser.add_argument('-spp', '--status-page-password', default=None,
                         help='Set the status page password.')
+    parser.add_argument('-hk', '--hash-key', default=None, action='append',
+                        help='Key for hash server')
     parser.add_argument('-el', '--encrypt-lib',
                         help='Path to encrypt lib to be used instead of the shipped ones.')
     parser.add_argument('-odt', '--on-demand_timeout',

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ PyMySQL==0.7.5
 flask-cors==2.1.2
 flask-compress==1.3.0
 LatLon==1.0.1
-git+https://github.com/pogodevorg/pgoapi.git#egg=pgoapi
+git+https://github.com/pogodevorg/pgoapi.git@develop#egg=pgoapi
 xxhash
 sphinx==1.4.5
 sphinx-autobuild==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ PyMySQL==0.7.5
 flask-cors==2.1.2
 flask-compress==1.3.0
 LatLon==1.0.1
-git+https://github.com/pogodevorg/pgoapi.git@develop#egg=pgoapi
+git+https://github.com/pogodevorg/pgoapi.git@0b13191a8043d8572647a17326b0f7b384774c63#egg=pgoapi
 xxhash
 sphinx==1.4.5
 sphinx-autobuild==0.6.0


### PR DESCRIPTION
## Description
The KeyScheduler class in scheduler.py serves as the basic building
block for more complex scheduling in the future (throttling by ms, query
remaining hashes, etc). Similar to how BaseScheduler is used for more complex scan methods. 

Usage is similar to any args that are usually parsed as a list:
ex: `-hk KEY_1 -hk KEY_2 -hk KEY_3`

## Motivation and Context
Enables 0.51 API usage. 

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
