### PR TITLE
Added LFU cache to avoid sending duplicate data to webhooks.

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -45,6 +45,7 @@
 #wh-retries:            # Number of times to retry sending webhook data on failure (default: 5).
 #wh-timeout:            # Timeout (in seconds) for webhook requests (default: 2).
 #wh-backoff-factor:     # Factor (in seconds) by which the delay until next retry will increase (default: 0.25).
+#wh-lfu-size:           # Webhook LFU cache max size (default: 1000).
 
 # Webserver settings
 #host:                  # address to listen on (default 127.0.0.1)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -223,6 +223,8 @@ def get_args():
                         help='Timeout (in seconds) for webhook requests.', type=int, default=2)
     parser.add_argument('-whbf', '--wh-backoff-factor',
                         help='Factor (in seconds) by which the delay until next retry will increase.', type=float, default=0.25)
+    parser.add_argument('-whlfu', '--wh-lfu-size',
+                        help='Webhook LFU cache max size.', type=int, default=1000)
     parser.add_argument('--ssl-certificate',
                         help='Path to SSL certificate file.')
     parser.add_argument('--ssl-privatekey',

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -74,7 +74,7 @@ def wh_updater(args, queue, key_cache):
                     'Trying to send webhook item of invalid type: %s.', whtype)
             elif ident not in key_cache:
                 key_cache[ident] = 1
-                log.debug('Sending %s to webhook: %s', whtype, ident)
+                log.debug('Sending %s to webhook: %s.', whtype, ident)
                 send_to_webhook(whtype, message)
             else:
                 # Make sure to call key_cache[ident] so it updates the LFU

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -53,19 +53,41 @@ def send_to_webhook(message_type, message):
             log.exception(e)
 
 
-def wh_updater(args, q):
+def wh_updater(args, queue, key_cache):
     # The forever loop.
     while True:
         try:
             # Loop the queue.
-            while True:
-                whtype, message = q.get()
+            whtype, message = queue.get()
+
+            # Extract the proper identifier.
+            ident_fields = {
+                'pokestop': 'pokestop_id',
+                'pokemon': 'encounter_id',
+                'gym': 'gym_id'
+            }
+            ident = message.get(ident_fields.get(whtype))
+
+            # Only send if identifier isn't already in cache.
+            if ident is None:
+                log.warning(
+                    'Trying to send webhook item of invalid type: %s.', whtype)
+            elif ident not in key_cache:
+                key_cache[ident] = 1
+                log.debug('Sending %s to webhook: %s', whtype, ident)
                 send_to_webhook(whtype, message)
+            else:
+                # Make sure to call key_cache[ident] so it updates the LFU
+                # usage count. We just use it as a count for now, can come in
+                # useful for stats/debugging later.
+                key_cache[ident] = key_cache[ident] + 1
+                log.debug('Not resending %s to webhook: %s.', whtype, ident)
 
-                if q.qsize() > 50:
-                    log.warning(
-                        'Webhook queue is > 50 (@%d); try increasing --wh-threads.', q.qsize())
+            # Webhook queue moving too slow.
+            if queue.qsize() > 50:
+                log.warning(
+                    'Webhook queue is > 50 (@%d); try increasing --wh-threads.', queue.qsize())
 
-                q.task_done()
+            queue.task_done()
         except Exception as e:
             log.exception('Exception in wh_updater: %s.', e)


### PR DESCRIPTION
## Description
Webhooks are unaware of what data has already been sent. Over a 5-minute test, this result in **25 times** the data being sent (on average) for both pokéstops and gyms.

Duplicate data being resent until infinity (**per webhook**) is absolutely not good.

While a more _"perfect"_ fix would mean a complete rewrite of the webhooks, implementing a LFU cache is the next best thing and allows for a massive improvement without major changes.

## Motivation and Context
Massive decrease in data requirements for webhooks.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
