### PR TITLE
Improve refresh queue performance

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -744,7 +744,6 @@ class ScannedLocation(BaseModel):
     def _q_init(scan, start, end, kind, sp_id=None):
         return {'loc': scan['loc'], 'kind': kind, 'start': start, 'end': end, 'step': scan['step'], 'sp': sp_id}
 
-
     @classmethod
     def get_by_locs(cls, locs):
         lats = [loc[0] for loc in locs]

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -800,8 +800,7 @@ class ScannedLocation(BaseModel):
 
     @classmethod
     def get_by_locs(cls, locs):
-        lats = [loc[0] for loc in locs]
-        lons = [loc[1] for loc in locs]
+        lats, lons = zip(*locs)
         query = (cls
                  .select()
                  .where((ScannedLocation.latitude << lats) &

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -800,7 +800,11 @@ class ScannedLocation(BaseModel):
 
     @classmethod
     def get_by_locs(cls, locs):
-        lats, lons = zip(*locs)
+        lats, lons = [], []
+        for loc in locs:
+            lats.append(loc[0])
+            lons.append(loc[1])
+
         query = (cls
                  .select()
                  .where((ScannedLocation.latitude << lats) &

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -594,14 +594,29 @@ class SpeedScan(HexSearch):
         old_q = deepcopy(self.queues[0])
         queue = []
 
+        # Measure the time it takes to refresh the queue
+        start = time.time()
+
+        # prefetch all scanned locations
+        locs = [scan['loc'] for scan in self.scans.values()]
+        scanned_locations = ScannedLocation.get_by_locs(locs)
+
+        # extract all spawnpoints into a dict with spawnpoint id -> spawnpoint for easy access later
+        cell_to_linked_spawn_points = ScannedLocation.get_cell_to_linked_spawn_points(self.scans.keys())
+        sp_by_id = {}
+        for sps in cell_to_linked_spawn_points.itervalues():
+            for sp in sps:
+                sp_by_id[sp['id']] = sp
+
         for cell, scan in self.scans.iteritems():
-            queue += ScannedLocation.get_times(scan, now_date)
-            queue += SpawnPoint.get_times(cell, scan, now_date, self.args.spawn_delay)
+            queue += ScannedLocation.get_times(scan, now_date, scanned_locations)
+            queue += SpawnPoint.get_times(cell, scan, now_date, self.args.spawn_delay, cell_to_linked_spawn_points, sp_by_id)
+        end = time.time()
 
         queue.sort(key=itemgetter('start'))
         self.queues[0] = queue
         self.ready = True
-        log.info('New queue created with %d entries', len(queue))
+        log.info('New queue created with %d entries in %f seconds', len(queue), (end - start))
         if len(old_q):
             try:  # Enclosing in try: to avoid divide by zero exceptions from killing overseer
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Decrease the amount of sql queries when refreshing the queue.

## Motivation and Context
There is an insane amount of sql queries going on when refreshing the queue. Depending on the setup, there could be thousands of different queries to the database when in fact only a few is needed.

## How Has This Been Tested?
Tested on a windows machine with -st 16. ( around 1700 spawnpoints)
Time taken to perform queue refresh was reduced from 5-10 second to about half a second.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
