### PR TITLE
Display dialog on map when requests to /raw_data error or timeout

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1029,6 +1029,19 @@ function loadRawData() {
                 rawDataIsLoading = true
             }
         },
+        error: function() {
+            if (!$timeoutDialog) {
+                var opts = {
+                    title: 'Reduce marker settings'
+                };
+
+                $timeoutDialog = $('<div>Hmm... we\'re having problems getting data for your criteria. Try reducing what you\'re showing and zooming in to limit what\'s returned.</div>').dialog(opts);
+                $timeoutDialog.dialog('open');
+            }
+            else if (!$timeoutDialog.dialog('isOpen')) {
+                $timeoutDialog.dialog('open');
+            }
+        },
         complete: function () {
             rawDataIsLoading = false
         }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -14,6 +14,7 @@ var $selectSearchIconMarker
 var $selectGymMarkerStyle
 var $selectLocationIconMarker
 var $switchGymSidebar
+var $timeoutDialog
 
 var language = document.documentElement.lang === '' ? 'en' : document.documentElement.lang
 var idToPokemon = {}

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1030,17 +1030,16 @@ function loadRawData() {
                 rawDataIsLoading = true
             }
         },
-        error: function() {
+        error: function () {
             if (!$timeoutDialog) {
                 var opts = {
                     title: 'Reduce marker settings'
-                };
+                }
 
-                $timeoutDialog = $('<div>Hmm... we\'re having problems getting data for your criteria. Try reducing what you\'re showing and zooming in to limit what\'s returned.</div>').dialog(opts);
-                $timeoutDialog.dialog('open');
-            }
-            else if (!$timeoutDialog.dialog('isOpen')) {
-                $timeoutDialog.dialog('open');
+                $timeoutDialog = $('<div>Hmm... we\'re having problems getting data for your criteria. Try reducing what you\'re showing and zooming in to limit what\'s returned.</div>').dialog(opts)
+                $timeoutDialog.dialog('open')
+            } else if (!$timeoutDialog.dialog('isOpen')) {
+                $timeoutDialog.dialog('open')
             }
         },
         complete: function () {


### PR DESCRIPTION
## Description
For larger map implementations, there are cases where a user's marker settings (criteria) is wide open by selecting pokemon, gyms, scanned locations, spawnpoints, etc. Also, they may have zoomed out to include many hive locations for their large viewport.  Doing so can potentially time out a request.  In addition to wide open criteria, their connection could also be a factor in timing out (WiFi or mobile).

While an error is returned for the timeout, it is not being handled on the client side and the user sees nothing.  This will now display a dialog with the following text:

Title: Reduce marker settings
Body: Hmm... we're having problems getting data for your criteria. Try reducing what you're showing and zooming in to limit what's returned.

## Motivation and Context
I've had frequent questions from a bunch of my users saying "no pokemon" appear on the map when it was due to the wide open criteria or slow connections.

## How Has This Been Tested?
My local maps.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
