### PR TITLE
Option to enable -PS status feature but start in logging mode

### DIFF
--- a/docs/extras/commandline.md
+++ b/docs/extras/commandline.md
@@ -23,7 +23,7 @@
                         [--db-threads DB_THREADS] [-wh [WEBHOOKS [WEBHOOKS ...]]]
                         [-gi] [--webhook-updates-only] [--wh-threads WH_THREADS]
                         [--ssl-certificate SSL_CERTIFICATE]
-                        [--ssl-privatekey SSL_PRIVATEKEY] [-ps] [-sn STATUS_NAME]
+                        [--ssl-privatekey SSL_PRIVATEKEY] [-ps [logs]] [-sn STATUS_NAME]
                         [-spp STATUS_PAGE_PASSWORD] [-el ENCRYPT_LIB]
                         [-v [filename.log] | -vv [filename.log]]
     
@@ -212,9 +212,11 @@
       --ssl-privatekey SSL_PRIVATEKEY
                             Path to SSL private key file [env var:
                             POGOMAP_SSL_PRIVATEKEY]
-      -ps, --print-status   Show a status screen instead of log messages. Can
-                            switch between status and logs by pressing enter. [env
-                            var: POGOMAP_PRINT_STATUS]
+      -ps [logs], --print-status [logs]  
+                            Show a status screen instead of log messages. Can
+                            switch between status and logs by pressing enter. 
+                            Optionally specify 'logs' to enable feature yet
+                            start in log view [env var: POGOMAP_PRINT_STATUS]
       -sn STATUS_NAME, --status-name STATUS_NAME
                             Enable status page database update using STATUS_NAME
                             as main worker name [env var: POGOMAP_STATUS_NAME]

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -62,9 +62,11 @@ def jitterLocation(location=None, maxMeters=10):
 
 
 # Thread to handle user input.
-def switch_status_printer(display_type, current_page, mainlog, loglevel):
+def switch_status_printer(display_type, current_page, mainlog, loglevel, logmode):
     # Disable logging of the first handler - the stream handler, and disable it's output.
-    mainlog.handlers[0].setLevel(logging.CRITICAL)
+
+    if (logmode != 'logs'):
+        mainlog.handlers[0].setLevel(logging.CRITICAL)
 
     while True:
         # Wait for the user to press a key.
@@ -92,8 +94,13 @@ def switch_status_printer(display_type, current_page, mainlog, loglevel):
 
 
 # Thread to print out the status of each worker.
-def status_printer(threadStatus, search_items_queue_array, db_updates_queue, wh_queue, account_queue, account_failures):
-    display_type = ["workers"]
+def status_printer(threadStatus, search_items_queue_array, db_updates_queue, wh_queue, account_queue, account_failures, logmode):
+
+    if (logmode == 'logs'):
+        display_type = ["logs"]
+    else:
+        display_type = ["workers"]
+
     current_page = [1]
     # Grab current log / level.
     mainlog = logging.getLogger()
@@ -102,7 +109,7 @@ def status_printer(threadStatus, search_items_queue_array, db_updates_queue, wh_
     # Start another thread to get user input.
     t = Thread(target=switch_status_printer,
                name='switch_status_printer',
-               args=(display_type, current_page, mainlog, loglevel))
+               args=(display_type, current_page, mainlog, loglevel, logmode))
     t.daemon = True
     t.start()
 
@@ -287,7 +294,7 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb, db_updat
         log.info('Starting status printer thread...')
         t = Thread(target=status_printer,
                    name='status_printer',
-                   args=(threadStatus, search_items_queue_array, db_updates_queue, wh_queue, account_queue, account_failures))
+                   args=(threadStatus, search_items_queue_array, db_updates_queue, wh_queue, account_queue, account_failures, args.print_status))
         t.daemon = True
         t.start()
 

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -229,8 +229,8 @@ def get_args():
                         help='Path to SSL certificate file.')
     parser.add_argument('--ssl-privatekey',
                         help='Path to SSL private key file.')
-    parser.add_argument('-ps', '--print-status', action='store_true',
-                        help='Show a status screen instead of log messages. Can switch between status and logs by pressing enter.', default=False)
+    parser.add_argument('-ps', '--print-status',
+                        help='Show a status screen instead of log messages. Can switch between status and logs by pressing enter.  Optionally specify "logs" to startup in logging mode.', nargs='?', const='status', default=False, metavar='logs')
     parser.add_argument('-sn', '--status-name', default=None,
                         help='Enable status page database update using STATUS_NAME as main worker name.')
     parser.add_argument('-spp', '--status-page-password', default=None,

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -233,7 +233,7 @@ def get_args():
     parser.add_argument('--ssl-privatekey',
                         help='Path to SSL private key file.')
     parser.add_argument('-ps', '--print-status',
-                        help='Show a status screen instead of log messages. Can switch between status and logs by pressing enter.  Optionally specify "logs" to startup in logging mode.',nargs='?', const='status', default=False, metavar='logs')
+                        help='Show a status screen instead of log messages. Can switch between status and logs by pressing enter.  Optionally specify "logs" to startup in logging mode.', nargs='?', const='status', default=False, metavar='logs')
     parser.add_argument('-slt', '--stats-log-timer',
                         help='In log view, list per hr stats every X seconds', type=int, default=0)
     parser.add_argument('-sn', '--status-name', default=None,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently if you don't use the -ps or --print-status command line option, there is no way to get into the status screen later if desired.  The is because the thread to enable keyboard monitoring is only initiated if the -ps option is used.  This change adds a 'logs' options to the -ps and --prints-status command line option to enable the -PS feature yet start in logging mode.  It launches the keyboard monitoring thread but defaults to logging mode.  

Although possibly cleaner, I chose not to launch the keyboard monitoring thread by default because that would change existing functionality.  If designing from scratch, I'd have the keyboard monitoring always enabled and just that -PS changes the default starting mode from log view to status view.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I wanted to be able to run in logging mode but switch to -PS if needed for a nice summary view instead of waiting for key information to show up in the log periodically (captcha info, TTH info, etc)

This is my first PR so please provide feedback

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test on my Windows server with 7 instances of 5-25 workers each

## Screenshots (if appropriate):
Not applicable

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
