### PR TITLE
Prevent "Speed violation?" message when using --no-pokemon

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1466,7 +1466,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue, a
             'bad_scan': True
         }
 
-    if not len(nearby_pokemons) and not len(wild_pokemon):
+    if not len(nearby_pokemons) and not len(wild_pokemon) and not args.no_pokemon:
         log.warning('No nearby or wild Pokemon. Speed violation?')
         log.info("Common causes: not using -speed, deleting or dropping the WorkerStatus table without waiting before restarting, or there really aren't any Pokemon in 200m")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Using the --no-pokemon flag will always result in no nearby_pokemons or wild_pokemon.

## Motivation and Context
Prevents log spam.

## How Has This Been Tested?
Run in a remote area without --no-pokemon to see the message, run in a busy area with --no-pokemon to suppress the message.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
