### PR TITLE
Thread safe webhooks & minor enhancements.

### DIFF
--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -3,11 +3,13 @@
 
 import logging
 import requests
+import threading
 from .utils import get_args
 from requests.packages.urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
 
 log = logging.getLogger(__name__)
+wh_lock = threading.Lock()
 
 
 def send_to_webhook(message_type, message):
@@ -68,30 +70,33 @@ def wh_updater(args, queue, key_cache):
             }
             ident = message.get(ident_fields.get(whtype), None)
 
-            # Only send if identifier isn't already in cache.
-            if ident is None:
-                # We don't know what it is, so let's just log and send as-is.
-                log.warning(
-                    'Sending webhook item of unknown type: %s.', whtype)
-                send_to_webhook(whtype, message)
-            elif ident not in key_cache:
-                key_cache[ident] = message
-                log.debug('Sending %s to webhook: %s.', whtype, ident)
-                send_to_webhook(whtype, message)
-            else:
-                # Make sure to call key_cache[ident] in all branches so it
-                # updates the LFU usage count.
-
-                # If the object has changed in an important way, send new data
-                # to webhooks.
-                if __wh_object_changed(whtype, key_cache[ident], message):
-                    key_cache[ident] = message
+            # cachetools in Python2.7 isn't thread safe, so we add a lock.
+            with wh_lock:
+                # Only send if identifier isn't already in cache.
+                if ident is None:
+                    # We don't know what it is, so let's just log and send
+                    # as-is.
+                    log.warning(
+                        'Sending webhook item of unknown type: %s.', whtype)
                     send_to_webhook(whtype, message)
-                    log.debug('Sending updated %s to webhook: %s.',
-                              whtype, ident)
+                elif ident not in key_cache:
+                    key_cache[ident] = message
+                    log.debug('Sending %s to webhook: %s.', whtype, ident)
+                    send_to_webhook(whtype, message)
                 else:
-                    log.debug('Not resending %s to webhook: %s.',
-                              whtype, ident)
+                    # Make sure to call key_cache[ident] in all branches so it
+                    # updates the LFU usage count.
+
+                    # If the object has changed in an important way, send new
+                    # data to webhooks.
+                    if __wh_object_changed(whtype, key_cache[ident], message):
+                        key_cache[ident] = message
+                        send_to_webhook(whtype, message)
+                        log.debug('Sending updated %s to webhook: %s.',
+                                  whtype, ident)
+                    else:
+                        log.debug('Not resending %s to webhook: %s.',
+                                  whtype, ident)
 
             # Webhook queue moving too slow.
             if queue.qsize() > 50:


### PR DESCRIPTION
## Motivation and Context
cachetools in Python2.7 isn't thread safe and can cause a KeyError when several threads are working on the LFUCache simultaneously.

I've also separated some of the code for clarity, and changed the logging of unknown webhook types to debug.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.