### PR TITLE
Detect captchas also when catcha solving is not enabled to avoid bad scans and not needed retries.

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -694,10 +694,9 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                 # todo's to db/wh queues.
                 try:
                     # Captcha check.
-                    if args.captcha_solving:
-                        captcha_url = response_dict['responses'][
-                            'CHECK_CHALLENGE']['challenge_url']
-                        if len(captcha_url) > 1:
+                    captcha_url = response_dict['responses']['CHECK_CHALLENGE']['challenge_url']
+                    if len(captcha_url) > 1:
+                        if args.captcha_solving:
                             status['message'] = 'Account {} is encountering a captcha, starting 2captcha sequence.'.format(account[
                                                                                                                            'username'])
                             log.warning(status['message'])
@@ -733,6 +732,11 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                                     account_failures.append({'account': account, 'last_fail_time': now(
                                     ), 'reason': 'captcha failed to verify'})
                                     break
+                        else:
+                            status['message'] = "Account {} has encountered a captcha, putting away account for now.".format(account['username'])
+                            log.info(status['message'])
+                            account_failures.append({'account': account, 'last_fail_time': now(), 'reason': 'captcha found'})
+                            break
 
                     parsed = parse_map(args, response_dict,
                                        step_location, dbq, whq, api, scan_date)


### PR DESCRIPTION
## Description
Avoid register a captcha as a bad scan when we get a captcha inside the api response with the _captcha-solving (-cs)_ option not enabled.

Avoid trying to rescan again with that account until we reach the max-empty attempts which by default is disabled (it can be an infinte loop). So, put the account to cool down with a message related to captcha encountered as son as we detect it.

## Motivation and Context
Some of us we don't use any external service to solve captchas. So, when a captcha is encountered we receive bad scan 0/0/0 messages in our logs which can be confusing and the account tries to rescan again and again unless you specify a max-empty number of attempts (waste of time). 

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
