### PR TITLE
Revert pgoapi for Ubuntu users.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ PyMySQL==0.7.5
 flask-cors==2.1.2
 flask-compress==1.3.0
 LatLon==1.0.1
-git+https://github.com/pogodevorg/pgoapi.git@8f741a89e084de0c11b2458f43964e6e63d04451#egg=pgoapi
+git+https://github.com/pogodevorg/pgoapi.git@0b13191a8043d8572647a17326b0f7b384774c63#egg=pgoapi
 xxhash
 sphinx==1.4.5
 sphinx-autobuild==0.6.0
@@ -25,4 +25,3 @@ PySocks==1.5.6
 git+https://github.com/maddhatter/Flask-CacheBust.git@38d940cc4f18b5fcb5687746294e0360640a107e#egg=flask_cachebust
 protobuf_to_dict==0.1.0
 cachetools==2.0.0
-


### PR DESCRIPTION
## Description
Revert to a commit of pgoapi before PR 176 (on pgoapi's side) got merged. These changes cause issues for some of our users that have Ubuntu (confirmed on 16.04) or CentOS (7).

## How Has This Been Tested?
All affected users say the problem is solved after applying this fix and re-installing pgoapi via pip.

**Important:** the commit we link to includes a pre-release version of protobuf. All affected users manually need to reinstall protobuf to a working version (e.g. 3.1.0 instead of 3.2.0rc1).

In summary:
```
pip uninstall pgoapi
pip install -r requirements.txt --upgrade
pip install protobuf==3.1.0 --force-reinstall
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
