### PR TITLE
Refactored webhooks.

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1548,6 +1548,9 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
     scheduler_name = scheduler.__class__.__name__
     tth_found = getattr(scheduler, 'tth_found', -1)
 
+    if tth_found > -1:
+        tth_found = tth_found * 100 / getattr(scheduler, 'active_sp', 100)
+
     # Consolidate the individual lists in each cell into two lists of Pokemon
     # and a list of forts.
     cells = map_dict['responses']['GET_MAP_OBJECTS']['map_cells']
@@ -1931,6 +1934,9 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue, scheduler)
 
     scheduler_name = scheduler.__class__.__name__
     tth_found = getattr(scheduler, 'tth_found', -1)
+
+    if tth_found > -1:
+        tth_found = tth_found * 100 / getattr(scheduler, 'active_sp', 100)
 
     i = 0
     for g in gym_responses.values():

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1549,7 +1549,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
     tth_found = getattr(scheduler, 'tth_found', -1)
 
     if tth_found > -1:
-        tth_found = tth_found * 100 / getattr(scheduler, 'active_sp', 100)
+        tth_found = tth_found * 100.0 / getattr(scheduler, 'active_sp', 100.0)
 
     # Consolidate the individual lists in each cell into two lists of Pokemon
     # and a list of forts.
@@ -1936,7 +1936,7 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue, scheduler)
     tth_found = getattr(scheduler, 'tth_found', -1)
 
     if tth_found > -1:
-        tth_found = tth_found * 100 / getattr(scheduler, 'active_sp', 100)
+        tth_found = tth_found * 100.0 / getattr(scheduler, 'active_sp', 100.0)
 
     i = 0
     for g in gym_responses.values():

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -402,7 +402,7 @@ class Pokemon(BaseModel):
 
         for idx, sp in enumerate(s):
             if geopy.distance.distance(center, (sp['lat'],
-                                       sp['lng'])).meters <= step_distance:
+                                                sp['lng'])).meters <= step_distance:
                 filtered.append(s[idx])
 
         # At this point, 'time' is DISAPPEARANCE time, we're going to morph it
@@ -2301,5 +2301,6 @@ def database_migrate(db, old_ver):
     if old_ver < 12:
         db.drop_tables([MainWorker])
         migrate(
-            migrator.add_column('workerstatus', 'captcha', IntegerField(default=0))
+            migrator.add_column('workerstatus', 'captcha',
+                                IntegerField(default=0))
         )

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -462,6 +462,7 @@ class SpeedScan(HexSearch):
         self.scan_percent = []
         self.spawn_percent = []
         self.status_message = []
+        self.tth_found = 0
         self._stat_init()
 
     def _stat_init(self):
@@ -649,7 +650,7 @@ class SpeedScan(HexSearch):
         self.queues[0] = queue
         self.ready = True
         log.info('New queue created with %d entries', len(queue))
-        if len(old_q):
+        if old_q:
             try:  # Enclosing in try: to avoid divide by zero exceptions from killing overseer
 
                 # Possible 'done' values are 'Missed', 'Scanned', None, or
@@ -674,7 +675,7 @@ class SpeedScan(HexSearch):
                 band_percent = self.band_status()
                 kinds = {}
                 tth_ranges = {}
-                tth_found = 0
+                self.tth_found = 0
                 active_sp = 0
                 found_percent = 100.0
                 good_percent = 100.0
@@ -685,14 +686,14 @@ class SpeedScan(HexSearch):
                     if sp['missed_count'] > 5:
                         continue
                     active_sp += 1
-                    tth_found += sp['earliest_unseen'] == sp['latest_seen']
+                    self.tth_found += sp['earliest_unseen'] == sp['latest_seen']
                     kind = sp['kind']
                     kinds[kind] = kinds.get(kind, 0) + 1
                     tth_range = str(
                         int(round(((sp['earliest_unseen'] - sp['latest_seen']) % 3600) / 60.0)))
                     tth_ranges[tth_range] = tth_ranges.get(tth_range, 0) + 1
 
-                tth_ranges['0'] = tth_ranges.get('0', 0) - tth_found
+                tth_ranges['0'] = tth_ranges.get('0', 0) - self.tth_found
                 len_spawnpoints = len(spawnpoints) + (not len(spawnpoints))
                 log.info('Total Spawn Points found in hex: %d',
                          len(spawnpoints))
@@ -705,7 +706,7 @@ class SpeedScan(HexSearch):
                     log.info('%s kind spawns: %d or %.1f%%', k,
                              kinds[k], kinds[k] * 100.0 / active_sp)
                 log.info('Spawns with found TTH: %d or %.1f%%',
-                         tth_found, tth_found * 100.0 / active_sp)
+                         self.tth_found, self.tth_found * 100.0 / active_sp)
                 for k in sorted(tth_ranges.keys(), key=int):
                     log.info(
                         'Spawnpoints with a %sm range to find TTH: %d', k, tth_ranges[k])
@@ -756,7 +757,7 @@ class SpeedScan(HexSearch):
                         self.scans_missed_list).most_common(3))
                     log.info('History: %s', str(self.scan_percent).strip('[]'))
                 self.status_message = 'Initial scan: {:.2f}%, TTH found: {:.2f}%, '.format(
-                    band_percent, tth_found * 100.0 / active_sp)
+                    band_percent, self.tth_found * 100.0 / active_sp)
                 self.status_message += 'Spawns reached: {:.2f}%, Spawns found: {:.2f}%, Good scans {:.2f}%'\
                     .format(spawns_reached, found_percent, good_percent)
                 self._stat_init()

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -676,7 +676,7 @@ class SpeedScan(HexSearch):
                 kinds = {}
                 tth_ranges = {}
                 self.tth_found = 0
-                active_sp = 0
+                self.active_sp = 0
                 found_percent = 100.0
                 good_percent = 100.0
                 spawns_reached = 100.0
@@ -685,7 +685,7 @@ class SpeedScan(HexSearch):
                 for sp in spawnpoints:
                     if sp['missed_count'] > 5:
                         continue
-                    active_sp += 1
+                    self.active_sp += 1
                     self.tth_found += sp['earliest_unseen'] == sp['latest_seen']
                     kind = sp['kind']
                     kinds[kind] = kinds.get(kind, 0) + 1
@@ -698,15 +698,15 @@ class SpeedScan(HexSearch):
                 log.info('Total Spawn Points found in hex: %d',
                          len(spawnpoints))
                 log.info('Inactive Spawn Points found in hex: %d or %.1f%%',
-                         len(spawnpoints) - active_sp, (len(spawnpoints) - active_sp) * 100.0 / len_spawnpoints)
+                         len(spawnpoints) - self.active_sp, (len(spawnpoints) - self.active_sp) * 100.0 / len_spawnpoints)
                 log.info('Active Spawn Points found in hex: %d or %.1f%%',
-                         active_sp, active_sp * 100.0 / len_spawnpoints)
-                active_sp += active_sp == 0
+                         self.active_sp, self.active_sp * 100.0 / len_spawnpoints)
+                self.active_sp += self.active_sp == 0
                 for k in sorted(kinds.keys()):
                     log.info('%s kind spawns: %d or %.1f%%', k,
-                             kinds[k], kinds[k] * 100.0 / active_sp)
+                             kinds[k], kinds[k] * 100.0 / self.active_sp)
                 log.info('Spawns with found TTH: %d or %.1f%%',
-                         self.tth_found, self.tth_found * 100.0 / active_sp)
+                         self.tth_found, self.tth_found * 100.0 / self.active_sp)
                 for k in sorted(tth_ranges.keys(), key=int):
                     log.info(
                         'Spawnpoints with a %sm range to find TTH: %d', k, tth_ranges[k])
@@ -757,7 +757,7 @@ class SpeedScan(HexSearch):
                         self.scans_missed_list).most_common(3))
                     log.info('History: %s', str(self.scan_percent).strip('[]'))
                 self.status_message = 'Initial scan: {:.2f}%, TTH found: {:.2f}%, '.format(
-                    band_percent, self.tth_found * 100.0 / active_sp)
+                    band_percent, self.tth_found * 100.0 / self.active_sp)
                 self.status_message += 'Spawns reached: {:.2f}%, Spawns found: {:.2f}%, Good scans {:.2f}%'\
                     .format(spawns_reached, found_percent, good_percent)
                 self._stat_init()

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -841,7 +841,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                                         api, step_location, args.no_jitter)
                                     status['last_scan_date'] = datetime.utcnow()
                                 else:
-                                    status['message'] = "Account {} failed verifyChallenge, putting away account for now.".format(account[
+                                    status['message'] = 'Account {} failed verifyChallenge, putting away account for now.'.format(account[
                                                                                                                                   'username'])
                                     log.info(status['message'])
                                     account_failures.append({'account': account, 'last_fail_time': now(
@@ -855,8 +855,8 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                                 {'account': account, 'last_fail_time': now(), 'reason': 'captcha found'})
                             break
 
-                    parsed = parse_map(args, response_dict,
-                                       step_location, dbq, whq, api, scan_date)
+                    parsed = parse_map(
+                        args, response_dict, step_location, dbq, whq, api, scan_date, scheduler)
                     scheduler.task_done(status, parsed)
                     if parsed['count'] > 0:
                         status['success'] += 1
@@ -940,7 +940,8 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                         log.debug(status['message'])
 
                         if gym_responses:
-                            parse_gyms(args, gym_responses, whq, dbq)
+                            parse_gyms(args, gym_responses,
+                                       whq, dbq, scheduler)
 
                 # Delay the desired amount after "scan" completion.
                 delay = scheduler.delay(status['last_scan_date'])

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -100,7 +100,7 @@ def wh_updater(args, queue, key_cache):
                     else:
                         log.debug('Not resending %s to webhook: %s.',
                                   whtype, ident)
-            except Exception as ex:
+            except KeyError as ex:
                 log.debug(
                     'LFUCache thread unsafe exception: %s. Requeuing.', repr(ex))
                 queue.put((whtype, message, scheduler_name, tth_found))


### PR DESCRIPTION
## Description
Two major changes to webhooks:

1. Removed thread locking in favor of capturing the exception when several threads get into a race condition. This immensely improves webhook throughput, and all webhooks still get sent: on exception, we requeue the failed webhook.
2. Included the type of search scheduler that's being used (e.g. SpeedScan, HexSearch) and the TTH percentage found (in case of SpeedScan, `-1` when not applicable). This is required for our public webhook server.

## Motivation and Context
- Severe reduction in webhook thread requirements, while maintaining delivery rate.
- TTH found is useful for data verification and spawn timer verification.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.