### PR TITLE
Detect captchas also when catcha solving is not enabled to avoid bad scans and not needed retries.

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -200,8 +200,10 @@ def status_printer(threadStatus, search_items_queue_array, db_updates_queue, wh_
 
                     status_text.append(
                         status.format(item, time.strftime('%H:%M', time.localtime(threadStatus[item]['starttime'])),
-                                      threadStatus[item]['username'], threadStatus[item]['proxy_display'],
-                                      threadStatus[item]['success'], threadStatus[item]['fail'], threadStatus[item]['noitems'],
+                                      threadStatus[item]['username'], threadStatus[
+                                          item]['proxy_display'],
+                                      threadStatus[item]['success'], threadStatus[
+                                          item]['fail'], threadStatus[item]['noitems'],
                                       threadStatus[item]['skip'], threadStatus[item]['captcha'], threadStatus[item]['message']))
 
         elif display_type[0] == 'failedaccounts':
@@ -507,10 +509,13 @@ def update_total_stats(threadStatus, last_account_status):
             current_accounts.add(username)
             last_status = last_account_status.get(username, {})
             overseer['skip_total'] += stat_delta(tstatus, last_status, 'skip')
-            overseer['captcha_total'] += stat_delta(tstatus, last_status, 'captcha')
-            overseer['empty_total'] += stat_delta(tstatus, last_status, 'noitems')
+            overseer[
+                'captcha_total'] += stat_delta(tstatus, last_status, 'captcha')
+            overseer[
+                'empty_total'] += stat_delta(tstatus, last_status, 'noitems')
             overseer['fail_total'] += stat_delta(tstatus, last_status, 'fail')
-            overseer['success_total'] += stat_delta(tstatus, last_status, 'success')
+            overseer[
+                'success_total'] += stat_delta(tstatus, last_status, 'success')
             last_account_status[username] = copy.deepcopy(tstatus)
 
     overseer['active_accounts'] = usercount

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -807,11 +807,11 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                 # todo's to db/wh queues.
                 try:
                     # Captcha check.
-                    if args.captcha_solving:
-                        captcha_url = response_dict['responses'][
-                            'CHECK_CHALLENGE']['challenge_url']
-                        if len(captcha_url) > 1:
-                            status['captcha'] += 1
+                    captcha_url = response_dict['responses'][
+                        'CHECK_CHALLENGE']['challenge_url']
+                    if captcha_url:
+                        status['captcha'] += 1
+                        if args.captcha_solving:
                             status['message'] = 'Account {} is encountering a captcha, starting 2captcha sequence.'.format(account[
                                                                                                                            'username'])
                             log.warning(status['message'])
@@ -847,6 +847,13 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                                     account_failures.append({'account': account, 'last_fail_time': now(
                                     ), 'reason': 'captcha failed to verify'})
                                     break
+                        else:
+                            status['message'] = "Account {} has encountered a captcha, putting away account for now.".format(account[
+                                                                                                                             'username'])
+                            log.info(status['message'])
+                            account_failures.append(
+                                {'account': account, 'last_fail_time': now(), 'reason': 'captcha found'})
+                            break
 
                     parsed = parse_map(args, response_dict,
                                        step_location, dbq, whq, api, scan_date)


### PR DESCRIPTION
## Description
Avoid register a captcha as a bad scan when we get a captcha inside the api response with the captcha-solving (-cs) option not enabled.

Avoid trying to rescan again with that account until we reach the max-empty attempts which by default is disabled (it can be an infinte loop). So, put the account to cool down with a message related to captcha encountered as son as we detect it.

## Motivation and Context
Some of us we don't use any external service to solve captchas. So, when a captcha is encountered we receive bad scan 0/0/0 messages in our logs which can be confusing and the account tries to rescan again and again unless you specify a max-empty number of attempts (waste of time).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
