### PR TITLE
Updated pgoapi for 0.53.

### DIFF
--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -629,7 +629,7 @@ def complete_tutorial(api, account, tutorial_state):
             'shirt': random.randint(1, 3),
             'pants': random.randint(1, 2),
             'shoes': random.randint(1, 6),
-            'gender': random.randint(0, 1),
+            'avatar': random.randint(0, 1),
             'eyes': random.randint(1, 4),
             'backpack': random.randint(1, 5)
         })

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ PyMySQL==0.7.5
 flask-cors==2.1.2
 flask-compress==1.3.0
 LatLon==1.0.1
-git+https://github.com/pogodevorg/pgoapi.git@8f741a89e084de0c11b2458f43964e6e63d04451#egg=pgoapi
+git+https://github.com/pogodevorg/pgoapi.git@eceb6e9f361fbf71889dae20452727da1a48c503#egg=pgoapi
 xxhash
 sphinx==1.4.5
 sphinx-autobuild==0.6.0


### PR DESCRIPTION
## Description
Updates requirements and `-tut` field for API 0.53 and new protos. pgoapi still doesn't include the Platform Request object, but it might still take a while to include it, so we can update and warn users for account flagging.

To use:
```
pip install -r requirements.txt --upgrade
```

## Motivation and Context
pgoapi updated to API 0.53.

## Types of changes
- [x] Enhancement

## Checklist:
- [x] My code follows the code style of this project.
