### PR TITLE
Improve webhooks

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1785,8 +1785,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     'last_modified_time': p['last_modified_timestamp_ms'],
                     'time_until_hidden_ms': p['time_till_hidden_ms']
                 })
-                wh_update_queue.put(
-                    ('pokemon', wh_poke))
+                wh_update_queue.put(('pokemon', wh_poke))
 
     if forts and (config['parse_pokestops'] or config['parse_gyms']):
         if config['parse_pokestops']:
@@ -2059,8 +2058,7 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
 
             i += 1
         if args.webhooks:
-            wh_update_queue.put(
-                ('gym_details', webhook_data))
+            wh_update_queue.put(('gym_details', webhook_data))
 
     # All this database stuff is synchronous (not using the upsert queue) on
     # purpose.  Since the search workers load the GymDetails model from the
@@ -2115,7 +2113,7 @@ def db_updater(args, q, db):
                 bulk_upsert(model, data, db)
                 q.task_done()
                 log.debug('Upserted to %s, %d records (upsert queue '
-                          'remaining: %d.)',
+                          'remaining: %d).',
                           model.__name__,
                           len(data),
                           q.qsize())

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1529,7 +1529,7 @@ def hex_bounds(center, steps=None, radius=None):
 
 # todo: this probably shouldn't _really_ be in "models" anymore, but w/e.
 def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
-              api, now_date, scheduler):
+              api, now_date):
     pokemon = {}
     pokestops = {}
     gyms = {}
@@ -1544,14 +1544,6 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
     new_spawn_points = []
     sp_id_list = []
     now_secs = date_secs(now_date)
-
-    scheduler_name = scheduler.__class__.__name__
-    tth_found = getattr(scheduler, 'tth_found', -1)
-
-    if tth_found > -1:
-        # Avoid division by zero. Keep 0.0 default for consistency.
-        active_sp = max(getattr(scheduler, 'active_sp', 0.0), 1.0)
-        tth_found = tth_found * 100.0 / active_sp
 
     # Consolidate the individual lists in each cell into two lists of Pokemon
     # and a list of forts.
@@ -1751,7 +1743,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                     'time_until_hidden_ms': p['time_till_hidden_ms']
                 })
                 wh_update_queue.put(
-                    ('pokemon', wh_poke, scheduler_name, tth_found))
+                    ('pokemon', wh_poke))
 
     if forts and (config['parse_pokestops'] or config['parse_gyms']):
         if config['parse_pokestops']:
@@ -1783,7 +1775,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                             'lure_expiration': calendar.timegm(
                                 lure_expiration.timetuple()),
                             'active_fort_modifier': active_fort_modifier
-                        }, scheduler_name, tth_found))
+                        }))
                 else:
                     lure_expiration, active_fort_modifier = None, None
 
@@ -1805,7 +1797,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                         'last_modified_time': f['last_modified_timestamp_ms'],
                         'lure_expiration': l_e,
                         'active_fort_modifier': active_fort_modifier
-                    }, scheduler_name, tth_found))
+                    }))
 
                 if ((f['id'], int(f['last_modified_timestamp_ms'] / 1000.0))
                         in encountered_pokestops):
@@ -1841,7 +1833,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                         'latitude': f['latitude'],
                         'longitude': f['longitude'],
                         'last_modified': f['last_modified_timestamp_ms']
-                    }, scheduler_name, tth_found))
+                    }))
 
                 gyms[f['id']] = {
                     'gym_id': f['id'],
@@ -1928,19 +1920,11 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
     }
 
 
-def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue, scheduler):
+def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
     gym_details = {}
     gym_members = {}
     gym_pokemon = {}
     trainers = {}
-
-    scheduler_name = scheduler.__class__.__name__
-    tth_found = getattr(scheduler, 'tth_found', -1)
-
-    if tth_found > -1:
-        # Avoid division by zero. Keep 0.0 default for consistency.
-        active_sp = max(getattr(scheduler, 'active_sp', 0.0), 1.0)
-        tth_found = tth_found * 100.0 / active_sp
 
     i = 0
     for g in gym_responses.values():
@@ -2033,7 +2017,7 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue, scheduler)
             i += 1
         if args.webhooks:
             wh_update_queue.put(
-                ('gym_details', webhook_data, scheduler_name, tth_found))
+                ('gym_details', webhook_data))
 
     # All this database stuff is synchronous (not using the upsert queue) on
     # purpose.  Since the search workers load the GymDetails model from the

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -114,11 +114,11 @@ class BaseScheduler(object):
         step, step_location, appears, leaves = self.queues[0].get()
         remain = appears - now() + 10
         messages = {
-            'wait': 'Waiting for item from queue',
+            'wait': 'Waiting for item from queue.',
             'early': 'Early for {:6f},{:6f}; waiting {}s...'.format(step_location[0], step_location[1], remain),
-            'late': 'Too late for location {:6f},{:6f}; skipping'.format(step_location[0], step_location[1]),
-            'search': 'Searching at {:6f},{:6f}'.format(step_location[0], step_location[1]),
-            'invalid': 'Invalid response at {:6f},{:6f}, abandoning location'.format(step_location[0], step_location[1])
+            'late': 'Too late for location {:6f},{:6f}; skipping.'.format(step_location[0], step_location[1]),
+            'search': 'Searching at {:6f},{:6f}.'.format(step_location[0], step_location[1]),
+            'invalid': 'Invalid response at {:6f},{:6f}, abandoning location.'.format(step_location[0], step_location[1])
         }
         return step, step_location, appears, leaves, messages
 
@@ -851,11 +851,11 @@ class SpeedScan(HexSearch):
         step = best.get('step', 0)
         i = best.get('i', 0)
         messages = {
-            'wait': 'Nothing to scan',
+            'wait': 'Nothing to scan.',
             'early': 'Early for step {}; waiting a few seconds...'.format(step),
-            'late': 'API response on step {} delayed by {} seconds. Possible causes: slow proxies, internet, or Niantic servers'.format(step, int((now_date - last_action).total_seconds())),
-            'search': 'Searching at step {}'.format(step),
-            'invalid': 'Invalid response at step {}, abandoning location'.format(step)
+            'late': 'API response on step {} delayed by {} seconds. Possible causes: slow proxies, internet, or Niantic servers.'.format(step, int((now_date - last_action).total_seconds())),
+            'search': 'Searching at step {}.'.format(step),
+            'invalid': 'Invalid response at step {}, abandoning location.'.format(step)
         }
 
         try:
@@ -867,12 +867,12 @@ class SpeedScan(HexSearch):
         if best['score'] == 0:
             if cant_reach:
                 messages[
-                    'wait'] = 'Not able to reach any scan under the speed limit'
+                    'wait'] = 'Not able to reach any scan under the speed limit.'
             return -1, 0, 0, 0, messages
 
         if equi_rect_distance(loc, worker_loc) > (now_date - last_action).total_seconds() * self.args.kph / 3600:
 
-            messages['wait'] = 'Moving {}m to step {} for a {}'.format(
+            messages['wait'] = 'Moving {}m to step {} for a {}.'.format(
                 int(equi_rect_distance(loc, worker_loc) * 1000), step, best['kind'])
             return -1, 0, 0, 0, messages
 
@@ -895,7 +895,7 @@ class SpeedScan(HexSearch):
         item['done'] = 'Scanned'
         status['index_of_queue_item'] = i
 
-        messages['search'] = 'Scanning step {} for a {}'.format(
+        messages['search'] = 'Scanning step {} for a {}.'.format(
             best['step'], best['kind'])
         return best['step'], best['loc'], 0, 0, messages
 

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -471,11 +471,11 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb, db_updat
             if tth_found > -1:
                 # Avoid division by zero. Keep 0.0 default for consistency.
                 active_sp = max(getattr(scheduler_array[0], 'active_sp',
-                    0.0), 1.0)
+                                        0.0), 1.0)
                 tth_found = tth_found * 100.0 / float(active_sp)
 
             if scheduler_tth_found < tth_found:
-                wh_queue.put(('speed-scan', { 'tth_found': tth_found }))
+                wh_queue.put(('speed-scan', {'tth_found': tth_found}))
                 scheduler_tth_found = tth_found
 
         # Now we just give a little pause here.

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -401,6 +401,16 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb, db_updat
 
     # The real work starts here but will halt on pause_bit.set().
     while True:
+        # TODO: send regular updates when tth_found changes
+        '''
+        scheduler_name = scheduler.__class__.__name__
+        tth_found = getattr(scheduler, 'tth_found', -1)
+
+        if tth_found > -1:
+        # Avoid division by zero. Keep 0.0 default for consistency.
+        active_sp = max(getattr(scheduler, 'active_sp', 0.0), 1.0)
+        tth_found = tth_found * 100.0 / active_sp
+        '''
 
         if args.on_demand_timeout > 0 and (now() - args.on_demand_timeout) > heartb[0]:
             pause_bit.set()
@@ -861,7 +871,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
                             break
 
                     parsed = parse_map(
-                        args, response_dict, step_location, dbq, whq, api, scan_date, scheduler)
+                        args, response_dict, step_location, dbq, whq, api, scan_date)
                     scheduler.task_done(status, parsed)
                     if parsed['count'] > 0:
                         status['success'] += 1
@@ -946,7 +956,7 @@ def search_worker_thread(args, account_queue, account_failures, search_items_que
 
                         if gym_responses:
                             parse_gyms(args, gym_responses,
-                                       whq, dbq, scheduler)
+                                       whq, dbq)
 
                 # Delay the desired amount after "scan" completion.
                 delay = scheduler.delay(status['last_scan_date'])

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -228,6 +228,9 @@ def get_args():
                         help='Factor (in seconds) by which the delay until next retry will increase.', type=float, default=0.25)
     parser.add_argument('-whlfu', '--wh-lfu-size',
                         help='Webhook LFU cache max size.', type=int, default=1000)
+    parser.add_argument('-whsu', '--webhook-scheduler-updates',
+                        help='Send webhook updates with scheduler status.',
+                        action='store_true', default=False)
     parser.add_argument('--ssl-certificate',
                         help='Path to SSL certificate file.')
     parser.add_argument('--ssl-privatekey',

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -229,8 +229,8 @@ def get_args():
     parser.add_argument('-whlfu', '--wh-lfu-size',
                         help='Webhook LFU cache max size.', type=int, default=1000)
     parser.add_argument('-whsu', '--webhook-scheduler-updates',
-                        help='Send webhook updates with scheduler status.',
-                        action='store_true', default=False)
+                        help='Send webhook updates with scheduler status (use with -wh).',
+                        action='store_true', default=True)
     parser.add_argument('--ssl-certificate',
                         help='Path to SSL certificate file.')
     parser.add_argument('--ssl-privatekey',
@@ -453,6 +453,10 @@ def get_args():
             args.scheduler = 'SpeedScan'
         else:
             args.scheduler = 'HexSearch'
+
+        # Disable webhook scheduler updates if webhooks are disabled
+        if args.webhooks is None:
+            args.webhook_scheduler_updates = False
 
     return args
 

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -60,7 +60,7 @@ def wh_updater(args, queue, key_cache):
     while True:
         try:
             # Loop the queue.
-            whtype, message, scheduler_name, tth_found = queue.get()
+            whtype, message = queue.get()
 
             # Extract the proper identifier.
             ident_fields = {
@@ -80,11 +80,11 @@ def wh_updater(args, queue, key_cache):
                     # as-is.
                     log.debug(
                         'Sending webhook item of unknown type: %s.', whtype)
-                    send_to_webhook(whtype, message, scheduler_name, tth_found)
+                    send_to_webhook(whtype, message)
                 elif ident not in key_cache:
                     key_cache[ident] = message
                     log.debug('Sending %s to webhook: %s.', whtype, ident)
-                    send_to_webhook(whtype, message, scheduler_name, tth_found)
+                    send_to_webhook(whtype, message)
                 else:
                     # Make sure to call key_cache[ident] in all branches so it
                     # updates the LFU usage count.
@@ -93,8 +93,7 @@ def wh_updater(args, queue, key_cache):
                     # data to webhooks.
                     if __wh_object_changed(whtype, key_cache[ident], message):
                         key_cache[ident] = message
-                        send_to_webhook(whtype, message,
-                                        scheduler_name, tth_found)
+                        send_to_webhook(whtype, message)
                         log.debug('Sending updated %s to webhook: %s.',
                                   whtype, ident)
                     else:
@@ -103,7 +102,7 @@ def wh_updater(args, queue, key_cache):
             except KeyError as ex:
                 log.debug(
                     'LFUCache thread unsafe exception: %s. Requeuing.', repr(ex))
-                queue.put((whtype, message, scheduler_name, tth_found))
+                queue.put((whtype, message))
 
             # Webhook queue moving too slow.
             if queue.qsize() > 50:

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -10,7 +10,7 @@ from requests.adapters import HTTPAdapter
 log = logging.getLogger(__name__)
 
 
-def send_to_webhook(message_type, message, scheduler_name, tth_found):
+def send_to_webhook(message_type, message):
     args = get_args()
 
     if not args.webhooks:
@@ -41,9 +41,7 @@ def send_to_webhook(message_type, message, scheduler_name, tth_found):
 
     data = {
         'type': message_type,
-        'message': message,
-        'scheduler_name': scheduler_name,
-        'tth_found': tth_found
+        'message': message
     }
 
     for w in args.webhooks:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Remove `scheduler_name` and `tth_found` from the standard webhook message.
## Description
<!--- Describe your changes in detail -->
We don't need to send `scheduler_name` and `tth_found` bundled with *every* webhook message.
Since other schedulers don't even have a use for this, I changed back the structure of webhook message to its previous form:
```
data = {
        'type': message_type,
        'message': message
}
```
To send SpeedScanner scheduler updates, I added in search.py - search_overseer_thread() a webhook update message that is sent whenever the percentage of TTH found changes. This message will only be sent if SpeedScanner is enabled.

**UPDATED:** new SpeedScanner scheduler update message:
```
data = {
        'type': 'scheduler',
        'message': { 'name': <scheduler_name>,
                     'instance': <instance_status_name>,
                     'tth_found': 100.0,
                     'spawns_found': 54
        }
}
```

Also did some 'minor text fixes' adding and correcting some punctuation.

**UPDATED:** Added a config parameter `-whsu`, `--webhook-scheduler-updates` to enable/disable sending webhook updates with scheduler status.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Helps to reduce traffic sent from webhooks.
Improves compatibility with traditional/older webhook consumers.
Reduces "context leakage": keeps scheduler out of `parse_map()` and `parse_gym()` functions.
Can be refactored later to include more information relative to schedulers.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in my local machine, win7 x64, python 2.7.12, using PokeAlarm to check if webhooks were arriving.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
