### PR TITLE
Sleep between DB operation retry

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -2124,6 +2124,7 @@ def db_updater(args, q, db):
                     break
                 except Exception as e:
                     log.warning('%s... Retrying...', e)
+                    time.sleep(5)
 
             # Loop the queue.
             while True:
@@ -2142,6 +2143,7 @@ def db_updater(args, q, db):
 
         except Exception as e:
             log.exception('Exception in db_updater: %s', e)
+            time.sleep(5)
 
 
 def clean_db_loop(args):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Sleep between retry on db_updater thread. This is just an update with requested fixes of #1056

## Motivation and Context
In #1055, we saw lots of database error. The db_updater keep reconnecting mysql, make the system unresponsive.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
