### PR TITLE
b64encode gym ID for consistency.

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1984,7 +1984,7 @@ def parse_gyms(args, gym_responses, wh_update_queue, db_update_queue):
 
         if args.webhooks:
             webhook_data = {
-                'id': gym_id,
+                'id': b64encode(str(gym_id)),
                 'latitude': gym_state['fort_data']['latitude'],
                 'longitude': gym_state['fort_data']['longitude'],
                 'team': gym_state['fort_data'].get('owned_by_team', 0),


### PR DESCRIPTION
## Description
All other webhook objects b64encode their IDs (including `gym`), so I've added it to `gym_details` for consistency.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
