### PR TITLE
Modify 'Bad scan' logic so that initial scans complete

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1607,7 +1607,7 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
     if not wild_pokemon and not nearby_pokemon:
         # . . . and there are no gyms/pokestops then it's unusable/bad.
         abandon_loc = False
-        
+
         if not forts:
             log.warning('Bad scan. Parsing found absolutely nothing.')
             log.info('Common causes: captchas or IP bans.')
@@ -1621,12 +1621,12 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
                 # If we're not going to parse the forts, then we'll just
                 # exit here.
                 abandon_loc = True
-        
+
         if abandon_loc:
             scan_loc = ScannedLocation.get_by_loc(step_location)
             ScannedLocation.update_band(scan_loc)
             db_update_queue.put((ScannedLocation, {0: scan_loc}))
-            
+
             return {
                 'count': 0,
                 'gyms': gyms,

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1609,6 +1609,9 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
         if not forts:
             log.warning('Bad scan. Parsing found absolutely nothing.')
             log.info('Common causes: captchas or IP bans.')
+            scan_loc = ScannedLocation.get_by_loc(step_location)
+            ScannedLocation.update_band(scan_loc)
+            db_update_queue.put((ScannedLocation, {0: scan_loc}))
             return {
                 'count': 0,
                 'gyms': gyms,
@@ -1621,6 +1624,9 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
             log.warning('No nearby or wild Pokemon but there are visible gyms '
                         'or pokestops. Possible speed violation.')
             if not (config['parse_pokestops'] or config['parse_gyms']):
+                scan_loc = ScannedLocation.get_by_loc(step_location)
+                ScannedLocation.update_band(scan_loc)
+                db_update_queue.put((ScannedLocation, {0: scan_loc}))
                 # If we're not going to parse the forts, then we'll just
                 # exit here.
                 return {

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1606,35 +1606,33 @@ def parse_map(args, map_dict, step_location, db_update_queue, wh_update_queue,
     # If there are no wild or nearby Pokemon . . .
     if not wild_pokemon and not nearby_pokemon:
         # . . . and there are no gyms/pokestops then it's unusable/bad.
+        abandon_loc = False
+        
         if not forts:
             log.warning('Bad scan. Parsing found absolutely nothing.')
             log.info('Common causes: captchas or IP bans.')
-            scan_loc = ScannedLocation.get_by_loc(step_location)
-            ScannedLocation.update_band(scan_loc)
-            db_update_queue.put((ScannedLocation, {0: scan_loc}))
-            return {
-                'count': 0,
-                'gyms': gyms,
-                'spawn_points': spawn_points,
-                'bad_scan': True
-            }
+            abandon_loc = True
         else:
             # No wild or nearby Pokemon but there are forts.  It's probably
             # a speed violation.
             log.warning('No nearby or wild Pokemon but there are visible gyms '
                         'or pokestops. Possible speed violation.')
             if not (config['parse_pokestops'] or config['parse_gyms']):
-                scan_loc = ScannedLocation.get_by_loc(step_location)
-                ScannedLocation.update_band(scan_loc)
-                db_update_queue.put((ScannedLocation, {0: scan_loc}))
                 # If we're not going to parse the forts, then we'll just
                 # exit here.
-                return {
-                    'count': 0,
-                    'gyms': gyms,
-                    'spawn_points': spawn_points,
-                    'bad_scan': True
-                }
+                abandon_loc = True
+        
+        if abandon_loc:
+            scan_loc = ScannedLocation.get_by_loc(step_location)
+            ScannedLocation.update_band(scan_loc)
+            db_update_queue.put((ScannedLocation, {0: scan_loc}))
+            
+            return {
+                'count': 0,
+                'gyms': gyms,
+                'spawn_points': spawn_points,
+                'bad_scan': True
+            }
 
     scan_loc = ScannedLocation.get_by_loc(step_location)
     done_already = scan_loc['done']


### PR DESCRIPTION
## Description
Change the code to treat 'bad scans' in a similar fashion to 'Empty scans'

## Motivation and Context
Currently 'Bad scan' locations are retried until '--bad_scan_retries' is reached, then the step is put back onto the schedule. This means the schedule keeps attempting to scan these locations and never completes. It is assumed that 'Bad scans' only occur because they are in rural areas far from Gyms and Pokestops. In the past, bad scans could occur in dense populations, test have shown that this is no longer the case.

## How Has This Been Tested?
I have run a large map, the initial scan now completes, whereas previously it would not.

## Screenshots (if appropriate):
The following test was run, just to be sure that 'Bad scans' only occur in rural areas. 'Bad scan' locations were recorded and shown on the map next to spawn points. this provides a sense check. If any of these locations are near a spawn point then there is something wrong.

![image](https://cloud.githubusercontent.com/assets/24545326/22244544/ea5bb98a-e223-11e6-91ed-d7ee98f2c021.png)


To me, this clearly shows the 'bad scan' locations (green circles) are not near any spawns, gyms or Pokestops, so should be treated as 'empty'.

## Types of changes

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
