### PR TITLE
Fix logging.

### DIFF
--- a/pogom/models.py
+++ b/pogom/models.py
@@ -1108,7 +1108,7 @@ class WorkerStatus(BaseModel):
                 break
             except Exception as e:
                 log.error('Exception in get_worker under account {}.  '
-                          'Exception message: {}'.format(username, e))
+                          'Exception message: {}'.format(username, repr(e)))
                 traceback.print_exc(file=sys.stdout)
                 time.sleep(1)
 
@@ -2111,7 +2111,7 @@ def db_updater(args, q, db):
                     flaskDb.connect_db()
                     break
                 except Exception as e:
-                    log.warning('%s... Retrying...', e)
+                    log.warning('%s... Retrying...', repr(e))
                     time.sleep(5)
 
             # Loop the queue.
@@ -2130,7 +2130,7 @@ def db_updater(args, q, db):
                         q.qsize())
 
         except Exception as e:
-            log.exception('Exception in db_updater: %s', e)
+            log.exception('Exception in db_updater: %s', repr(e))
             time.sleep(5)
 
 
@@ -2167,7 +2167,7 @@ def clean_db_loop(args):
             log.info('Regular database cleaning complete.')
             time.sleep(60)
         except Exception as e:
-            log.exception('Exception in clean_db_loop: %s', e)
+            log.exception('Exception in clean_db_loop: %s', repr(e))
 
 
 def bulk_upsert(cls, data, db):
@@ -2206,10 +2206,10 @@ def bulk_upsert(cls, data, db):
                              'peewee.IntegerField object at']
             has_unrecoverable = filter(lambda x: x in str(e), unrecoverable)
             if has_unrecoverable:
-                log.warning('%s. Data is:', e)
+                log.warning('%s. Data is:', repr(e))
                 log.warning(data.items())
             else:
-                log.warning('%s... Retrying...', e)
+                log.warning('%s... Retrying...', repr(e))
                 time.sleep(1)
                 continue
 

--- a/pogom/proxy.py
+++ b/pogom/proxy.py
@@ -83,9 +83,9 @@ def check_proxy(proxy_queue, timeout, proxies, show_warnings, check_results):
 
     # Decrease output amount if there are lot of proxies.
     if show_warnings:
-        log.warning('%s', proxy_error)
+        log.warning('%s', repr(proxy_error))
     else:
-        log.debug('%s', proxy_error)
+        log.debug('%s', repr(proxy_error))
     proxy_queue.task_done()
 
     check_results[check_result] += 1
@@ -188,7 +188,7 @@ def proxies_refresher(args):
             args.proxy = proxies
             log.info('Regular proxy refresh complete.')
         except Exception as e:
-            log.exception('Exception while refresh proxies: %s', e)
+            log.exception('Exception while refresh proxies: %s', repr(e))
 
 
 # Provide new proxy for a search thread.

--- a/pogom/schedulers.py
+++ b/pogom/schedulers.py
@@ -360,12 +360,11 @@ class SpawnScan(BaseScheduler):
                 with open(self.args.spawnpoint_scanning) as file:
                     self.locations = json.load(file)
             except ValueError as e:
-                log.exception(e)
-                log.error('JSON error: %s; will fallback to database', e)
+                log.error('JSON error: %s; will fallback to database', repr(e))
             except IOError as e:
                 log.error(
                     'Error opening json file: %s; will fallback to database',
-                    e)
+                    repr(e))
 
         # No locations yet? Try the database!
         if not self.locations:
@@ -667,7 +666,8 @@ class SpeedScan(HexSearch):
 
         except Exception as e:
             log.error(
-                'Exception in band_status: Exception message: {}'.format(e))
+                'Exception in band_status: Exception message: {}'.format(
+                    repr(e)))
 
     # Update the queue, and provide a report on performance of last minutes
     def schedule(self):
@@ -847,7 +847,8 @@ class SpeedScan(HexSearch):
 
             except Exception as e:
                 log.error(
-                    'Performance statistics had an Exception: {}'.format(e))
+                    'Performance statistics had an Exception: {}'.format(
+                        repr(e)))
                 traceback.print_exc(file=sys.stdout)
 
     # Find the best item to scan next

--- a/pogom/search.py
+++ b/pogom/search.py
@@ -483,7 +483,8 @@ def search_overseer_thread(args, new_location_queue, pause_bit, heartb,
                     scheduler_array[i].schedule()
                 except Exception as e:
                     log.error(
-                        'Schedule creation had an Exception: {}.'.format(e))
+                        'Schedule creation had an Exception: {}.'.format(
+                            repr(e)))
                     traceback.print_exc(file=sys.stdout)
                     time.sleep(10)
             else:
@@ -983,8 +984,8 @@ def search_worker_thread(args, account_queue, account_failures,
                     consecutive_fails = 0
                     status['message'] = ('Search at {:6f},{:6f} completed ' +
                                          'with {} finds.').format(
-                                            step_location[0], step_location[1],
-                                            parsed['count'])
+                        step_location[0], step_location[1],
+                        parsed['count'])
                     log.debug(status['message'])
                 except Exception as e:
                     parsed = False
@@ -998,7 +999,7 @@ def search_worker_thread(args, account_queue, account_failures,
                                                            step_location[1],
                                                            account['username'])
                     log.exception('{}. Exception message: {}'.format(
-                        status['message'], e))
+                        status['message'], repr(e)))
 
                 # Get detailed information about gyms.
                 if args.gym_info and parsed:
@@ -1095,7 +1096,7 @@ def search_worker_thread(args, account_queue, account_failures,
         except Exception as e:
             log.error(
                 'Exception in search_worker under account {} Exception ' +
-                'message: {}.'.format(account['username'], e))
+                'message: {}.'.format(account['username'], repr(e)))
             status['message'] = (
                 'Exception in search_worker using account {}. Restarting ' +
                 'with fresh account. See logs for details.').format(
@@ -1179,7 +1180,7 @@ def map_request(api, position, no_jitter=False):
         return response
 
     except Exception as e:
-        log.warning('Exception while downloading map: %s', e)
+        log.warning('Exception while downloading map: %s', repr(e))
         return False
 
 
@@ -1205,7 +1206,7 @@ def gym_request(api, position, gym):
         return x
 
     except Exception as e:
-        log.warning('Exception while downloading gym details: %s', e)
+        log.warning('Exception while downloading gym details: %s', repr(e))
         return False
 
 

--- a/pogom/webhook.py
+++ b/pogom/webhook.py
@@ -50,7 +50,7 @@ def send_to_webhook(message_type, message):
         except requests.exceptions.ReadTimeout:
             log.exception('Response timeout on webhook endpoint %s.', w)
         except requests.exceptions.RequestException as e:
-            log.exception(e)
+            log.exception(repr(e))
 
 
 def wh_updater(args, queue, key_cache):
@@ -111,7 +111,7 @@ def wh_updater(args, queue, key_cache):
 
             queue.task_done()
         except Exception as e:
-            log.exception('Exception in wh_updater: %s.', e)
+            log.exception('Exception in wh_updater: %s.', repr(e))
 
 
 # Helpers


### PR DESCRIPTION
## Description
People with bad habits have added logging that doesn't convert an object to a string representation. To fix this, I've made all logging explicit.

I'm aware the logger doesn't need this (it does it by itself), but making it more explicit everywhere will force others to get used to better habits instead of breaking things.

## Motivation and Context
Improperly handled exceptions are logged with empty messages, because the object isn't properly converted to a string in uses of `''.format()`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
